### PR TITLE
Changed src to dest in stage

### DIFF
--- a/src/managers/ProjectManager.ts
+++ b/src/managers/ProjectManager.ts
@@ -474,9 +474,9 @@ export class ComponentLibraryProject extends Project {
         this.fileMappings = await this.getFileMappings();
 
         let manifestPathRelative = fileUtils.standardizePath('/manifest');
-        var manifestFileEntry = this.fileMappings.find(x => x.src.endsWith(manifestPathRelative));
+        var manifestFileEntry = this.fileMappings.find(x => x.dest.endsWith(manifestPathRelative));
         if (manifestFileEntry) {
-            await this.computeOutFileName(manifestFileEntry.src);
+            await this.computeOutFileName(manifestFileEntry.dest);
         } else {
             throw new Error(`Could not find manifest path for component library at '${this.rootDir}'`);
         }


### PR DESCRIPTION
Changed src to dest in stage manifest validation.
This fixes an issue where you could use src and dest for the manifest but it would fail a validation and cause it to fail at staging.