### PR TITLE
Complib manifest fix

### DIFF
--- a/src/managers/ProjectManager.ts
+++ b/src/managers/ProjectManager.ts
@@ -436,8 +436,7 @@ export class ComponentLibraryProject extends Project {
 
     /**
      * Takes a component Library and checks the outFile for replaceable values pulled from the libraries manifest
-     * @param componentLibrary The library to check
-     * @param stagingFolder staging folder of the component library to search for the manifest file
+     * @param manifestPath the path to the manifest file to check
      */
     private async computeOutFileName(manifestPath: string) {
         let regexp = /\$\{([\w\d_]*)\}/;
@@ -473,13 +472,11 @@ export class ComponentLibraryProject extends Project {
          */
         this.fileMappings = await this.getFileMappings();
 
-        /**
-         * NOTE: For the file mappings below, we're intentionally using `src` because the manifest must be read PRIOR to the staging process.
-         * This means that `dest` will not actually exist yet. 
-         */
-        let manifestPathRelative = fileUtils.standardizePath('/manifest');
-        var manifestFileEntry = this.fileMappings.find(x => x.src.endsWith(manifestPathRelative));
+        let expectedManifestDestPath = fileUtils.standardizePath(`${this.stagingFolderPath}/manifest`).toLowerCase();
+        //find the file entry with the `dest` value of `${stagingFolderPath}/manifest` (case insensitive)
+        var manifestFileEntry = this.fileMappings.find(x => x.dest.toLowerCase() === expectedManifestDestPath);
         if (manifestFileEntry) {
+            //read the manifest from `src` since nothing has been copied to staging yet
             await this.computeOutFileName(manifestFileEntry.src);
         } else {
             throw new Error(`Could not find manifest path for component library at '${this.rootDir}'`);

--- a/src/managers/ProjectManager.ts
+++ b/src/managers/ProjectManager.ts
@@ -473,10 +473,14 @@ export class ComponentLibraryProject extends Project {
          */
         this.fileMappings = await this.getFileMappings();
 
+        /**
+         * NOTE: For the file mappings below, we're intentionally using `src` because the manifest must be read PRIOR to the staging process.
+         * This means that `dest` will not actually exist yet. 
+         */
         let manifestPathRelative = fileUtils.standardizePath('/manifest');
-        var manifestFileEntry = this.fileMappings.find(x => x.dest.endsWith(manifestPathRelative));
+        var manifestFileEntry = this.fileMappings.find(x => x.src.endsWith(manifestPathRelative));
         if (manifestFileEntry) {
-            await this.computeOutFileName(manifestFileEntry.dest);
+            await this.computeOutFileName(manifestFileEntry.src);
         } else {
             throw new Error(`Could not find manifest path for component library at '${this.rootDir}'`);
         }


### PR DESCRIPTION
Prior to #15, every manifest file had to be named exactly "manifest", even though technically `roku-deploy` and the `files` array supported nonstandard manifest file names via the `{src;dest}` object. #15 attempted to fix that by looking at the `dest` path instead of `src`. However, #15 also introduced a regression where the debugger tried to read from `dest` before the files were copied. 

To solve both problems, we need to _find_ the file entry using its `dest` property, but then _read_ the `src` file since `dest` does not yet exist in staging. 

**Notable changes:**
 - fix regression introduced in #15 
 - more accurately handle manifest detection in the spirit of what #15 was trying to do
 - add unit test to prevent this regression from happening again