### PR TITLE
Explicitly set stagingFolderPath for deploy

### DIFF
--- a/src/LaunchConfiguration.ts
+++ b/src/LaunchConfiguration.ts
@@ -127,6 +127,12 @@ export interface LaunchConfiguration extends DebugProtocol.LaunchRequestArgument
      * or when sending commands through some type of port forwarding.
      */
     remotePort?: number;
+
+    /**
+     * The path used for the staging folder of roku-deploy
+     * This should explicitly be set to <outDir>/.roku-deploy-staging
+     */
+    stagingFolderPath?: string;
 }
 
 export interface ComponentLibraryConfiguration {

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -314,7 +314,8 @@ export class BrightScriptDebugSession extends BaseDebugSession {
             sourceDirs: this.launchConfiguration.sourceDirs,
             bsConst: this.launchConfiguration.bsConst,
             injectRaleTrackerTask: this.launchConfiguration.injectRaleTrackerTask,
-            raleTrackerTaskFileLocation: this.launchConfiguration.raleTrackerTaskFileLocation
+            raleTrackerTaskFileLocation: this.launchConfiguration.raleTrackerTaskFileLocation,
+            stagingFolderPath: this.launchConfiguration.stagingFolderPath
         });
 
         util.log('Moving selected files to staging area');


### PR DESCRIPTION
Be able to explicitly set the roku deploy staging path instead of relying on roku-deploy