### PR TITLE
Fix bug with $anon function renaming

### DIFF
--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -507,7 +507,7 @@ export class BrightScriptDebugSession extends BaseDebugSession {
                             if (functionName.startsWith('$')) {
                                 functionName = this.fileManager.getFunctionNameAtPosition(
                                     sourceLocation.filePath,
-                                    debugFrame.lineNumber - 1,
+                                    sourceLocation.lineNumber - 1,
                                     functionName
                                 );
                             }


### PR DESCRIPTION
In certain situations, the debugger would show `$anon_#` function names when it should have been mapping those to actual function names. This bug was caused by using the wrong line number. 

## Notable Changes:
 - Use the source map translated location up `$anon` function names instead of the raw stack trace location