### PR TITLE
Various improvements

### DIFF
--- a/src/CompileErrorProcessor.spec.ts
+++ b/src/CompileErrorProcessor.spec.ts
@@ -174,7 +174,7 @@ describe('BrightScriptDebugger', () => {
                 charEnd: 999,
                 charStart: 0,
                 errorText: 'ERR_COMPILE:',
-                lineNumber: 0,
+                lineNumber: 1,
                 message: 'Found 1 compile error in file tmp/plugin/IJBAAAfijvb8/pkg:/components/Scene/MainScene.GetConfigurationw.brs\n--- Error loading file. (compile error &hb9) in pkg:/components/Scene/MainScene.GetConfigurationw.brs',
                 path: 'pkg:/components/Scene/MainScene.GetConfigurationw.brs'
             }];
@@ -212,14 +212,14 @@ describe('BrightScriptDebugger', () => {
                     charEnd: 999,
                     charStart: 0,
                     errorText: 'ERR_COMPILE:',
-                    lineNumber: 2,
+                    lineNumber: 3,
                     message: 'XML syntax error found ---> not well-formed (invalid token)',
                     path: 'SampleScreen.xml'
                 }, {
                     charEnd: 999,
                     charStart: 0,
                     errorText: 'ERR_COMPILE:',
-                    lineNumber: 0,
+                    lineNumber: 1,
                     message: 'general compile error in xml file',
                     path: 'SampleScreen.xml'
                 }
@@ -251,35 +251,35 @@ describe('BrightScriptDebugger', () => {
                 {
                     charEnd: 999,
                     charStart: 0,
-                    lineNumber: 594,
+                    lineNumber: 595,
                     errorText: '--- Syntax Error. (compile error &h02) in pkg:/components/Services/Network/Parsers.brs(595)',
                     message: 'Syntax Error. (compile error &h02) in pkg:/components/Services/Network/Parsers.brs(595)',
                     path: 'pkg:/components/Services/Network/Parsers.brs'
                 }, {
                     charEnd: 999,
                     charStart: 0,
-                    lineNumber: 597,
+                    lineNumber: 598,
                     errorText: '--- Syntax Error. (compile error &h02) in pkg:/components/Services/Network/Parsers.brs(598)',
                     message: 'Syntax Error. (compile error &h02) in pkg:/components/Services/Network/Parsers.brs(598)',
                     path: 'pkg:/components/Services/Network/Parsers.brs'
                 }, {
                     charEnd: 999,
                     charStart: 0,
-                    lineNumber: 731,
+                    lineNumber: 732,
                     errorText: '--- Syntax Error. (compile error &h02) in pkg:/components/Services/Network/Parsers.brs(732)',
                     message: 'Syntax Error. (compile error &h02) in pkg:/components/Services/Network/Parsers.brs(732)',
                     path: 'pkg:/components/Services/Network/Parsers.brs'
                 }, {
                     charEnd: 999,
                     charStart: 0,
-                    lineNumber: 732,
+                    lineNumber: 733,
                     errorText: '--- Syntax Error. (compile error &h02) in pkg:/components/Services/Network/Parsers.brs(733)',
                     message: 'Syntax Error. (compile error &h02) in pkg:/components/Services/Network/Parsers.brs(733)',
                     path: 'pkg:/components/Services/Network/Parsers.brs'
                 }, {
                     charEnd: 999,
                     charStart: 0,
-                    lineNumber: 733,
+                    lineNumber: 734,
                     errorText: '--- Syntax Error. (compile error &h02) in pkg:/components/Services/Network/Parsers.brs(734)',
                     message: 'Syntax Error. (compile error &h02) in pkg:/components/Services/Network/Parsers.brs(734)',
                     path: 'pkg:/components/Services/Network/Parsers.brs'
@@ -302,6 +302,10 @@ describe('BrightScriptDebugger', () => {
                 `--- Line 3: XML syntax error found ---> not well-formed (invalid token)`,
                 ``,
                 `=================================================================`,
+                `Error in XML component Oops defined in file pkg:/components/Oops.xml`,
+                `-- Extends type does not exist: "BaseOops"`,
+                ``,
+                `=================================================================`,
                 `Found 1 parse error in XML file ChannelItemComponent.xml`,
                 `--- Line 9: XML syntax error found ---> not well-formed (invalid token)`,
                 `03-26 23:14:06.499 [scrpt.parse.mkup.time] Parsed markup dev 'sampleApp' in 108 milliseconds`,
@@ -310,10 +314,9 @@ describe('BrightScriptDebugger', () => {
                 `03-26 23:14:08.133 [scrpt.ctx.cmpl.time] Compiled 'sampleApp', id 'dev' in 1633 milliseconds`,
                 `03-26 23:14:08.152 [scrpt.unload.mkup] Unloading markup dev 'sampleApp'`,
                 ``,
-                ``,
                 `=================================================================`,
                 `An error occurred while attempting to compile the application's components:`,
-                `-------> Error parsing multiple XML components (SampleScreen.xml, ChannelItemComponent.xml)`
+                `-------> Error parsing multiple XML components (SampleScreen.xml, ChannelItemComponent.xml, Ooops)`
             ];
 
             let expectedErrors = [
@@ -321,23 +324,37 @@ describe('BrightScriptDebugger', () => {
                     charEnd: 999,
                     charStart: 0,
                     errorText: 'ERR_COMPILE:',
-                    lineNumber: 8,
+                    lineNumber: 3,
+                    message: 'XML syntax error found ---> not well-formed (invalid token)',
+                    path: 'SampleScreen.xml'
+                }, {
+                    charEnd: 999,
+                    charStart: 0,
+                    errorText: 'ERR_COMPILE:',
+                    lineNumber: 9,
                     message: 'XML syntax error found ---> not well-formed (invalid token)',
                     path: 'ChannelItemComponent.xml'
                 }, {
                     charEnd: 999,
                     charStart: 0,
                     errorText: 'ERR_COMPILE:',
-                    lineNumber: 0,
+                    lineNumber: 1,
                     message: 'general compile error in xml file',
                     path: 'SampleScreen.xml'
                 }, {
                     charEnd: 999,
                     charStart: 0,
                     errorText: 'ERR_COMPILE:',
-                    lineNumber: 0,
+                    lineNumber: 1,
                     message: 'general compile error in xml file',
                     path: 'ChannelItemComponent.xml'
+                }, {
+                    charEnd: 999,
+                    charStart: 0,
+                    errorText: 'ERR_COMPILE:',
+                    lineNumber: 1,
+                    message: 'Error in XML component Oops defined in file pkg:/components/Oops.xml\n-- Extends type does not exist: "BaseOops"',
+                    path: 'pkg:/components/Oops.xml'
                 }
             ];
 
@@ -365,7 +382,7 @@ describe('BrightScriptDebugger', () => {
                     charEnd: 999,
                     charStart: 0,
                     errorText: '--- Invalid #If/#ElseIf expression (<CONST-NAME> not defined) (compile error &h92) in Parsers.brs(19) \'BAD_BS_CONST\'',
-                    lineNumber: 18,
+                    lineNumber: 19,
                     message: 'compile error &h92) in Parsers.brs(19) \'BAD_BS_CONST\'',
                     path: 'Parsers.brs'
                 }
@@ -396,7 +413,7 @@ describe('BrightScriptDebugger', () => {
                     charEnd: 999,
                     charStart: 0,
                     errorText: 'ERR_COMPILE:',
-                    lineNumber: 0,
+                    lineNumber: 1,
                     message: 'No manifest. Invalid package.',
                     path: 'manifest'
                 }

--- a/src/CompileErrorProcessor.spec.ts
+++ b/src/CompileErrorProcessor.spec.ts
@@ -220,7 +220,7 @@ describe('BrightScriptDebugger', () => {
                     charStart: 0,
                     errorText: 'ERR_COMPILE:',
                     lineNumber: 1,
-                    message: 'general compile error in xml file',
+                    message: 'General XML compilation error',
                     path: 'SampleScreen.xml'
                 }
             ];
@@ -339,14 +339,14 @@ describe('BrightScriptDebugger', () => {
                     charStart: 0,
                     errorText: 'ERR_COMPILE:',
                     lineNumber: 1,
-                    message: 'general compile error in xml file',
+                    message: 'General XML compilation error',
                     path: 'SampleScreen.xml'
                 }, {
                     charEnd: 999,
                     charStart: 0,
                     errorText: 'ERR_COMPILE:',
                     lineNumber: 1,
-                    message: 'general compile error in xml file',
+                    message: 'General XML compilation error',
                     path: 'ChannelItemComponent.xml'
                 }, {
                     charEnd: 999,

--- a/src/CompileErrorProcessor.ts
+++ b/src/CompileErrorProcessor.ts
@@ -77,7 +77,7 @@ export class CompileErrorProcessor {
     }
 
     public sendErrors(): Promise<void> {
-        //session is shuttind down, process logs immediately
+        //session is shutting down, process logs immediately
         //HACK: leave time for events and errors resolvers to run,
         //otherwise the staging folder will have been deleted
         return new Promise(resolve => {
@@ -87,19 +87,13 @@ export class CompileErrorProcessor {
     }
 
     private getErrors() {
-        let syntaxErrors = this.getSyntaxErrors(this.compilingLines);
-        let compileErrors = this.getCompileErrors(this.compilingLines);
-        let xmlCompileErrors = this.getSingleFileXmlError(this.compilingLines);
-        let xmlComponentErrors = this.getSingleFileXmlComponentError(this.compilingLines);
-        let multipleXmlCompileErrors = this.getMultipleFileXmlError(this.compilingLines);
-        let missingManifestError = this.getMissingManifestError(this.compilingLines);
         return [
-            ...syntaxErrors,
-            ...compileErrors,
-            ...multipleXmlCompileErrors,
-            ...xmlCompileErrors,
-            ...xmlComponentErrors,
-            ...missingManifestError
+            ...this.getSyntaxErrors(this.compilingLines),
+            ...this.getCompileErrors(this.compilingLines),
+            ...this.getMultipleFileXmlError(this.compilingLines),
+            ...this.getSingleFileXmlError(this.compilingLines),
+            ...this.getSingleFileXmlComponentError(this.compilingLines),
+            ...this.getMissingManifestError(this.compilingLines)
         ];
     }
 
@@ -147,12 +141,12 @@ export class CompileErrorProcessor {
             return [];
         }
 
-        let getFileInfoRexEx = /Found(?:.*)file (.*)$/im;
+        let getFileInfoRegEx = /Found(?:.*)file (.*)$/im;
         for (let index = 1; index < filesWithErrors.length - 1; index++) {
             const fileErrorText = filesWithErrors[index];
             //TODO - for now just a simple parse - later on someone can improve with proper line checks + all parse/compile types
             //don't have time to do this now; just doing what keeps me productive.
-            let match = getFileInfoRexEx.exec(fileErrorText);
+            let match = getFileInfoRegEx.exec(fileErrorText);
             if (!match) {
                 continue;
             }
@@ -184,9 +178,9 @@ export class CompileErrorProcessor {
 
     public getLineErrors(path: string, fileErrorText: string): BrightScriptDebugCompileError[] {
         let errors: BrightScriptDebugCompileError[] = [];
-        let getFileInfoRexEx = /^--- Line (\d*): (.*)$/gim;
+        let getFileInfoRegEx = /^--- Line (\d*): (.*)$/gim;
         let match: RegExpExecArray;
-        while (match = getFileInfoRexEx.exec(fileErrorText)) {
+        while (match = getFileInfoRegEx.exec(fileErrorText)) {
             let lineNumber = parseInt(match[1]);
             let errorText = 'ERR_COMPILE:';
             let message = this.sanitizeCompilePath(match[2]);
@@ -206,9 +200,9 @@ export class CompileErrorProcessor {
 
     public getSingleFileXmlError(lines: string[]): BrightScriptDebugCompileError[] {
         let errors: BrightScriptDebugCompileError[] = [];
-        let getFileInfoRexEx = /^-------> Error parsing XML component (.*).*$/i;
+        let getFileInfoRegEx = /^-------> Error parsing XML component (.*).*$/i;
         lines.forEach((line) => {
-            let match = getFileInfoRexEx.exec(line);
+            let match = getFileInfoRegEx.exec(line);
             if (match) {
                 let errorText = 'ERR_COMPILE:';
                 let path = this.sanitizeCompilePath(match[1]);
@@ -229,9 +223,9 @@ export class CompileErrorProcessor {
 
     public getSingleFileXmlComponentError(lines: string[]): BrightScriptDebugCompileError[] {
         let errors: BrightScriptDebugCompileError[] = [];
-        let getFileInfoRexEx = /Error in XML component [a-z0-9_-]+ defined in file (.*)/i;
+        let getFileInfoRegEx = /Error in XML component [a-z0-9_-]+ defined in file (.*)/i;
         lines.forEach((line, index) => {
-            let match = getFileInfoRexEx.exec(line);
+            let match = getFileInfoRegEx.exec(line);
             if (match) {
                 let errorText = 'ERR_COMPILE:';
                 let path = match[1];
@@ -250,9 +244,9 @@ export class CompileErrorProcessor {
 
     public getMultipleFileXmlError(lines: string[]): BrightScriptDebugCompileError[] {
         let errors: BrightScriptDebugCompileError[] = [];
-        let getFileInfoRexEx = /^-------> Error parsing multiple XML components \((.*)\)/i;
+        let getFileInfoRegEx = /^-------> Error parsing multiple XML components \((.*)\)/i;
         lines.forEach((line) => {
-            let match = getFileInfoRexEx.exec(line);
+            let match = getFileInfoRegEx.exec(line);
             if (match) {
                 let errorText = 'ERR_COMPILE:';
                 let files = match[1].split(',');

--- a/src/CompileErrorProcessor.ts
+++ b/src/CompileErrorProcessor.ts
@@ -250,9 +250,9 @@ export class CompileErrorProcessor {
             if (match) {
                 let errorText = 'ERR_COMPILE:';
                 let files = match[1].split(',');
-                files.forEach((file) => {
+                files.forEach((path) => {
                     errors.push({
-                        path: this.sanitizeCompilePath(file.trim()),
+                        path: this.sanitizeCompilePath(path.trim()),
                         lineNumber: 1,
                         errorText: errorText,
                         message: GENERAL_XML_ERROR,

--- a/src/CompileErrorProcessor.ts
+++ b/src/CompileErrorProcessor.ts
@@ -219,7 +219,7 @@ export class CompileErrorProcessor {
                     path: path,
                     lineNumber: 1,
                     errorText: errorText,
-                    message: 'general compile error in xml file',
+                    message: 'General XML compilation error',
                     charStart: 0,
                     charEnd: 999 //TODO
                 });
@@ -263,7 +263,7 @@ export class CompileErrorProcessor {
                         path: this.sanitizeCompilePath(file.trim()),
                         lineNumber: 1,
                         errorText: errorText,
-                        message: 'general compile error in xml file',
+                        message: 'General XML compilation error',
                         charStart: 0,
                         charEnd: 999 //TODO
                     });
@@ -306,7 +306,6 @@ export class CompileErrorProcessor {
 
     public resetCompileErrorTimer(isRunning): any {
         // console.debug('resetCompileErrorTimer isRunning' + isRunning);
-        util.log('## ROKU DEBUG resetTimer: ' + isRunning);
 
         if (this.compileErrorTimer) {
             clearInterval(this.compileErrorTimer);
@@ -322,7 +321,6 @@ export class CompileErrorProcessor {
     }
 
     public onCompileErrorTimer() {
-        util.log('## ROKU DEBUG onTimer');
         console.debug('onCompileErrorTimer: timer complete. should\'ve caught all errors ');
 
         this.status = CompileStatus.compileError;
@@ -364,9 +362,6 @@ export class CompileErrorProcessor {
         //throw out any lines before the last found compiling line
 
         let errors = this.getErrors();
-
-        util.log('## ROKU DEBUG reportErrors: ' + errors.map(e => e.path).join(' '));
-
         errors = errors.filter((e) => {
             return e.path.toLowerCase().endsWith('.brs') || e.path.toLowerCase().endsWith('.xml') || e.path === 'manifest';
         });

--- a/src/CompileErrorProcessor.ts
+++ b/src/CompileErrorProcessor.ts
@@ -1,6 +1,7 @@
 import * as eol from 'eol';
 import { EventEmitter } from 'events';
-import { util } from './util';
+
+export const GENERAL_XML_ERROR = 'General XML compilation error';
 
 export class CompileErrorProcessor {
 
@@ -216,7 +217,7 @@ export class CompileErrorProcessor {
                     path: path,
                     lineNumber: 1,
                     errorText: errorText,
-                    message: 'General XML compilation error',
+                    message: GENERAL_XML_ERROR,
                     charStart: 0,
                     charEnd: 999 //TODO
                 });
@@ -260,7 +261,7 @@ export class CompileErrorProcessor {
                         path: this.sanitizeCompilePath(file.trim()),
                         lineNumber: 1,
                         errorText: errorText,
-                        message: 'General XML compilation error',
+                        message: GENERAL_XML_ERROR,
                         charStart: 0,
                         charEnd: 999 //TODO
                     });
@@ -356,14 +357,11 @@ export class CompileErrorProcessor {
      */
     private reportErrors() {
         console.debug('reportErrors');
-        //throw out any lines before the last found compiling line
 
-        let errors = this.getErrors();
-        errors = errors.filter((e) => {
-            return e.path.toLowerCase().endsWith('.brs') || e.path.toLowerCase().endsWith('.xml') || e.path === 'manifest';
+        const errors = this.getErrors().filter((e) => {
+            const path = e.path.toLowerCase();
+            return path.endsWith('.brs') || path.endsWith('.xml') || path === 'manifest';
         });
-
-        console.debug('errors.length ' + errors.length);
 
         if (errors.length > 0) {
             this.emit('compile-errors', errors);

--- a/src/CompileErrorProcessor.ts
+++ b/src/CompileErrorProcessor.ts
@@ -75,17 +75,14 @@ export class CompileErrorProcessor {
         }
     }
 
-    public shutdown(): Promise<void> {
+    public sendErrors(): Promise<void> {
         //session is shuttind down, process logs immediately
-        if (this.compileErrorTimer && this.status === CompileStatus.compileError) {
-            //HACK: leave time for events and errors resolvers to run,
-            //otherwise the staging folder will have been deleted
-            return new Promise(resolve => {
-                this.onCompileErrorTimer();
-                setTimeout(() => resolve(), 100);
-            });
-        }
-        return Promise.resolve();
+        //HACK: leave time for events and errors resolvers to run,
+        //otherwise the staging folder will have been deleted
+        return new Promise(resolve => {
+            this.onCompileErrorTimer();
+            setTimeout(() => resolve(), 500);
+        });
     }
 
     private getErrors() {
@@ -367,6 +364,7 @@ export class CompileErrorProcessor {
         });
 
         console.debug('errors.length ' + errors.length);
+
         if (errors.length > 0) {
             this.emit('compile-errors', errors);
         }

--- a/src/CompileErrorProcessor.ts
+++ b/src/CompileErrorProcessor.ts
@@ -181,7 +181,7 @@ export class CompileErrorProcessor {
         let getFileInfoRegEx = /^--- Line (\d*): (.*)$/gim;
         let match: RegExpExecArray;
         while (match = getFileInfoRegEx.exec(fileErrorText)) {
-            let lineNumber = parseInt(match[1]);
+            let lineNumber = parseInt(match[1]); // 1-based
             let errorText = 'ERR_COMPILE:';
             let message = this.sanitizeCompilePath(match[2]);
 

--- a/src/FileUtils.ts
+++ b/src/FileUtils.ts
@@ -3,10 +3,9 @@ import * as findInFiles from 'find-in-files';
 import * as fsExtra from 'fs-extra';
 import glob = require('glob');
 import * as path from 'path';
-import { SourceMapConsumer, SourceNode } from 'source-map';
 import { promisify } from 'util';
+import { util } from './util';
 import * as rokuDeploy from 'roku-deploy';
-import { SourceLocation } from './managers/LocationManager';
 const globp = promisify(glob);
 
 export class FileUtils {
@@ -82,7 +81,6 @@ export class FileUtils {
 
         //find any files from the outDir that end the same as this file
         let results: string[] = [];
-
         let relativePaths = await this.getAllRelativePaths(directoryPath);
         for (let relativePath of relativePaths) {
             //if the staging path looks like the debugger path, keep it for now

--- a/src/adapters/DebugProtocolAdapter.ts
+++ b/src/adapters/DebugProtocolAdapter.ts
@@ -512,7 +512,7 @@ export class DebugProtocolAdapter {
                     // isSelected: threadInfo.isPrimary,
                     filePath: threadInfo.fileName,
                     functionName: threadInfo.functionName,
-                    lineNumber: threadInfo.lineNumber + 1, //protocol is 0-based
+                    lineNumber: threadInfo.lineNumber + 1, //protocol is 0-based but 1-based is expected
                     lineContents: threadInfo.codeSnippet,
                     threadId: i
                 };

--- a/src/adapters/DebugProtocolAdapter.ts
+++ b/src/adapters/DebugProtocolAdapter.ts
@@ -110,8 +110,8 @@ export class DebugProtocolAdapter {
         this.handleStartupIfReady();
     }
 
-    public async shutdown() {
-        await this.compileErrorProcessor.shutdown();
+    public async sendErrors() {
+        await this.compileErrorProcessor.sendErrors();
     }
 
     private async handleStartupIfReady() {

--- a/src/adapters/DebugProtocolAdapter.ts
+++ b/src/adapters/DebugProtocolAdapter.ts
@@ -110,6 +110,10 @@ export class DebugProtocolAdapter {
         this.handleStartupIfReady();
     }
 
+    public async shutdown() {
+        await this.compileErrorProcessor.shutdown();
+    }
+
     private async handleStartupIfReady() {
         if (this.isActivated && this.isAppRunning) {
             this.emit('start');
@@ -233,10 +237,9 @@ export class DebugProtocolAdapter {
     }
 
     private beginAppExit() {
-        let that = this;
         this.compileErrorProcessor.compileErrorTimer = setTimeout(() => {
-            that.isAppRunning = false;
-            that.emit('app-exit');
+            this.isAppRunning = false;
+            this.emit('app-exit');
         }, 200);
     }
 
@@ -509,7 +512,7 @@ export class DebugProtocolAdapter {
                     // isSelected: threadInfo.isPrimary,
                     filePath: threadInfo.fileName,
                     functionName: threadInfo.functionName,
-                    lineNumber: threadInfo.lineNumber,
+                    lineNumber: threadInfo.lineNumber + 1, //protocol is 0-based
                     lineContents: threadInfo.codeSnippet,
                     threadId: i
                 };

--- a/src/adapters/TelnetAdapter.ts
+++ b/src/adapters/TelnetAdapter.ts
@@ -119,6 +119,10 @@ export class TelnetAdapter {
         this.handleStartupIfReady();
     }
 
+    public async shutdown() {
+        await this.compileErrorProcessor.shutdown();
+    }
+
     private async handleStartupIfReady() {
         if (this.isActivated && this.isAppRunning) {
             this.emit('start');
@@ -299,10 +303,9 @@ export class TelnetAdapter {
     }
 
     private beginAppExit() {
-        let that = this;
         this.compileErrorProcessor.compileErrorTimer = setTimeout(() => {
-            that.isAppRunning = false;
-            that.emit('app-exit');
+            this.isAppRunning = false;
+            this.emit('app-exit');
         }, 200);
     }
 

--- a/src/adapters/TelnetAdapter.ts
+++ b/src/adapters/TelnetAdapter.ts
@@ -119,8 +119,8 @@ export class TelnetAdapter {
         this.handleStartupIfReady();
     }
 
-    public async shutdown() {
-        await this.compileErrorProcessor.shutdown();
+    public async sendErrors() {
+        await this.compileErrorProcessor.sendErrors();
     }
 
     private async handleStartupIfReady() {

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -194,7 +194,8 @@ export class BrightScriptDebugSession extends BaseDebugSession {
             });
 
             // handle any compile errors
-            this.rokuAdapter.on('compile-errors', async (compileErrors: BrightScriptDebugCompileError[]) => {
+            this.rokuAdapter.on('compile-errors', async (errors: BrightScriptDebugCompileError[]) => {
+                const compileErrors = util.filterGenericErrors(errors);
                 for (let compileError of compileErrors) {
                     let sourceLocation = await this.projectManager.getSourceLocation(compileError.path, compileError.lineNumber);
                     if (sourceLocation) {

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -195,6 +195,9 @@ export class BrightScriptDebugSession extends BaseDebugSession {
 
             // handle any compile errors
             this.rokuAdapter.on('compile-errors', async (errors: BrightScriptDebugCompileError[]) => {
+                // collect errors and adjust the line number:
+                // - Roku device and sourcemap work with 1-based line numbers,
+                // - VS expects 0-based lines.
                 const compileErrors = util.filterGenericErrors(errors);
                 for (let compileError of compileErrors) {
                     let sourceLocation = await this.projectManager.getSourceLocation(compileError.path, compileError.lineNumber);
@@ -204,6 +207,7 @@ export class BrightScriptDebugSession extends BaseDebugSession {
                     } else {
                         // TODO: may need to add a custom event if the source location could not be found by the ProjectManager
                         compileError.path = fileUtils.removeLeadingSlash(util.removeFileScheme(compileError.path));
+                        compileError.lineNumber = (compileError.lineNumber || 1) - 1; //0-based
                     }
                 }
 

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -195,7 +195,7 @@ export class BrightScriptDebugSession extends BaseDebugSession {
 
             // handle any compile errors
             this.rokuAdapter.on('compile-errors', async (errors: BrightScriptDebugCompileError[]) => {
-                // collect errors and adjust the line number:
+                // remove redundant errors and adjust the line number:
                 // - Roku device and sourcemap work with 1-based line numbers,
                 // - VS expects 0-based lines.
                 const compileErrors = util.filterGenericErrors(errors);

--- a/src/managers/FileManager.ts
+++ b/src/managers/FileManager.ts
@@ -106,7 +106,7 @@ export class FileManager {
      */
     private getFunctionNameMap(fileContents: string) {
         let regexp = /^\s*(?:sub|function)\s+([a-z0-9_]+)/gim;
-        let match: RegExpMatchArray;
+        let match: RegExpExecArray;
 
         let result = {};
 

--- a/src/managers/LocationManager.spec.ts
+++ b/src/managers/LocationManager.spec.ts
@@ -104,7 +104,7 @@ describe('LocationManager', () => {
                 let sourceFilePath = s`${rootDir}/source/main.brs`;
                 let stagingFilePath = s`${stagingDir}/source/main.brs`;
                 let stagingMapPath = s`${stagingDir}/source/main.brs.map`;
-                function n(line, col, txt) {
+                function n(line: number, col: number, txt: string) {
                     return new SourceNode(line, col, sourceFilePath, txt);
                 }
 

--- a/src/managers/ProjectManager.ts
+++ b/src/managers/ProjectManager.ts
@@ -119,11 +119,11 @@ export class ProjectManager {
             sourceLocation.lineNumber = this.getLineNumberOffsetByBreakpoints(sourceLocation.filePath, sourceLocation.lineNumber);
         }
 
-        if (!sourceLocation.filePath || !sourceLocation.lineNumber) {
+        if (!sourceLocation.filePath) {
             //couldn't find a source location. At least send back the staging file information so the user can still debug
             return {
                 filePath: stagingFileInfo.absolutePath,
-                lineNumber: debuggerLineNumber,
+                lineNumber: sourceLocation.lineNumber || debuggerLineNumber,
                 columnIndex: 0
             } as SourceLocation;
         } else {

--- a/src/managers/SourceMapManager.ts
+++ b/src/managers/SourceMapManager.ts
@@ -99,15 +99,24 @@ export class SourceMapManager {
                         bias: SourceMapConsumer.LEAST_UPPER_BOUND
                     });
                 });
-                //if the sourcemap didn't find a valid mapped location, return undefined and fallback to whatever location the debugger produced
-                if (!position || !position.source) {
+                if (position?.source) {
+                    return {
+                        columnIndex: position.column,
+                        lineNumber: position.line,
+                        filePath: position.source
+                    };
+                }
+                //if the sourcemap didn't find a valid mapped location,
+                //try to fallback to the first source referenced in the map
+                if (parsedSourceMap.sources?.[0] ) {
+                    return {
+                        columnIndex: currentColumnIndex,
+                        lineNumber: currentLineNumber,
+                        filePath: parsedSourceMap.sources[0]
+                    };
+                } else {
                     return undefined;
                 }
-                return {
-                    columnIndex: position.column,
-                    lineNumber: position.line,
-                    filePath: position.source
-                };
             }
         }
     }

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -6,6 +6,7 @@ import * as getPort from 'get-port';
 import * as net from 'net';
 import * as path from 'path';
 import * as sinonActual from 'sinon';
+import { BrightScriptDebugCompileError, GENERAL_XML_ERROR } from './CompileErrorProcessor';
 
 import { util } from './util';
 let sinon = sinonActual.createSandbox();
@@ -275,6 +276,50 @@ describe('Util', () => {
                     y: 3
                 }
             });
+        });
+    });
+
+    describe('filterGenericErrors', () => {
+        it('should remove generic errors IF a more specific exists', () => {
+            const err1: BrightScriptDebugCompileError = {
+                path: 'file1.xml',
+                lineNumber: 0,
+                charStart: 0,
+                charEnd: 0,
+                message: 'Some other error',
+                errorText: 'err1'
+            };
+            const err2: BrightScriptDebugCompileError = {
+                path: 'file1.xml',
+                lineNumber: 0,
+                charStart: 0,
+                charEnd: 0,
+                message: GENERAL_XML_ERROR,
+                errorText: 'err2'
+            };
+            const err3: BrightScriptDebugCompileError = {
+                path: 'file2.xml',
+                lineNumber: 0,
+                charStart: 0,
+                charEnd: 0,
+                message: GENERAL_XML_ERROR,
+                errorText: 'err3'
+            };
+            const err4: BrightScriptDebugCompileError = {
+                path: 'file3.xml',
+                lineNumber: 0,
+                charStart: 0,
+                charEnd: 0,
+                message: 'Some other error',
+                errorText: 'err4'
+            };
+            const expected = [
+                err1,
+                err3,
+                err4
+            ];
+            const actual = util.filterGenericErrors([err1, err2, err3, err4]);
+            expect(actual).to.deep.equal(expected);
         });
     });
 });

--- a/src/util.ts
+++ b/src/util.ts
@@ -7,6 +7,7 @@ import { SmartBuffer } from 'smart-buffer';
 import { BrightScriptDebugSession } from './debugSession/BrightScriptDebugSession';
 import { DebugServerLogOutputEvent, LogOutputEvent } from './debugSession/Events';
 import { Position, Range } from 'vscode-languageserver';
+import { BrightScriptDebugCompileError, GENERAL_XML_ERROR } from './CompileErrorProcessor';
 
 class Util {
     /**
@@ -220,6 +221,23 @@ class Util {
             return false;
         }
         return true;
+    }
+
+    public filterGenericErrors(errors: BrightScriptDebugCompileError[]) {
+        const specificErrors: Record<string, BrightScriptDebugCompileError> = {};
+
+        //ignore generic errors when a specific error exists
+        return errors.filter(e => {
+            const path = e.path.toLowerCase();
+            if (e.message === GENERAL_XML_ERROR) {
+                if (specificErrors[path]) {
+                    return false;
+                }
+            } else {
+                specificErrors[path] = e;
+            }
+            return true;
+        });
     }
 }
 


### PR DESCRIPTION
- fix timing issue when shutting down debug session before the log processor has finish its job
- fix off-by-one location of "compile errors" when device validates XML components
- fix off-by-one code stepping with debug protocol
- fix errors being dropped when a "line" error is found
- added extra XML error matching
- filter out "generic XML error" on a file if a specific one was captured as well
- fix XML sourcemap resolution; follow mapped source even if we don't have a resolved mapping

Tested both with a "vanilla" Roku project and a brighterscript-processed one.