### PR TITLE
Fix debugger freeze on split telnet response

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -193,7 +193,8 @@ module.exports = {
             '@typescript-eslint/dot-notation': 'off',
             'github/array-foreach': 'off',
             'new-cap': 'off',
-            'no-shadow': 'off'
+            'no-shadow': 'off',
+            'func-names': 'off'
         }
     }, {
         files: ['benchmarks/**/*'],

--- a/src/adapters/TelnetAdapter.spec.ts
+++ b/src/adapters/TelnetAdapter.spec.ts
@@ -1,7 +1,6 @@
-import { assert, expect } from 'chai';
-import * as sinon from 'sinon';
+import { expect } from 'chai';
 import type { EvaluateContainer } from './TelnetAdapter';
-import { TelnetAdapter } from './TelnetAdapter';
+import { TelnetAdapter, RequestPipeline } from './TelnetAdapter';
 
 describe('TelnetAdapter ', () => {
     let adapter: TelnetAdapter;
@@ -202,6 +201,68 @@ vscode_key_start:mynewfield:vscode_key_stop vscode_is_string:false<Component: ro
                 type: 'roSGNode:ContentNode'
             });
         });
-
     });
 });
+
+describe('RequestPipeline', () => {
+    let pipeline: RequestPipeline;
+    let socket = {
+        listeners: [],
+        messageQueue: [] as Array<string[]>,
+        addListener: function(eventName: string, listener: (data: Buffer) => void) {
+            this.listeners.push(listener);
+        },
+        //custom function for tests used to emit data to listeners
+        emit: function(data: string) {
+            const buffer = Buffer.from(data);
+            for (const listener of this.listeners) {
+                listener(buffer);
+            }
+        },
+        write: async function(text: string) {
+            //flush messages after getting data written
+            for (const messages of this.messageQueue) {
+                for (const message of messages) {
+                    await sleep(1);
+                    this.emit(message);
+                }
+            }
+        }
+    };
+
+    beforeEach(() => {
+        socket.listeners = [];
+        pipeline = new RequestPipeline(socket as any);
+        pipeline['isAtDebuggerPrompt'] = true;
+    });
+
+    it('handles split debugger prompt messages', async () => {
+        socket.messageQueue.push([
+            'some text Brightsc',
+            'ript Debugger>'
+        ]);
+        expect(
+            await pipeline.executeCommand('doSomething', true)
+        ).to.eql(
+            'some text Brightscript Debugger>'
+        );
+    });
+
+    it('handles debugger prompt separate from data', async () => {
+        socket.messageQueue.push([
+            'some text',
+            ' Brightscript Debugger>'
+        ]);
+        expect(
+            await pipeline.executeCommand('doSomething', true)
+        ).to.eql(
+            'some text Brightscript Debugger>'
+        );
+    });
+});
+
+function sleep(ms: number) {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+}


### PR DESCRIPTION
Fix issue where telnet sends the `Brightscript Debugger>` prompt text split across two messages, such as:
```javascript
"1234 Brights"
"ript Debugger>"
```

This is probably also the reason the debugger stalls out sometimes for no apparent reason.

Note to reviewers: This PR looks much smaller if you ignore whitespace changes...I only modified like 3 lines, and removed an if statement wrapper.

TODO:

- [x] tests

