### PR TITLE
Boxed primitive fixes for telnet

### DIFF
--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -786,6 +786,7 @@ export class BrightScriptDebugSession extends BaseDebugSession {
                         }
                         response.body = {
                             result: v.value,
+                            type: v.type,
                             variablesReference: v.variablesReference,
                             namedVariables: v.namedVariables || 0,
                             indexedVariables: v.indexedVariables || 0
@@ -933,6 +934,7 @@ export class BrightScriptDebugSession extends BaseDebugSession {
                 }
             }
 
+            v.type = result.type;
             v.evaluateName = result.evaluateName;
             v.frameId = frameId;
 


### PR DESCRIPTION
Evaluating boxed primitives in the telnet debugger was not properly showing the underlying primitive values. 

![image](https://user-images.githubusercontent.com/2544493/122989593-fd09ae00-d370-11eb-806b-b747a02d7853.png)

This PR evaluates those boxed objects so we can view the underlying primitive values instead:

![image](https://user-images.githubusercontent.com/2544493/122989714-21fe2100-d371-11eb-912a-6e6f40692741.png)

You can see the underlying data type by hovering over a variable:
![image](https://user-images.githubusercontent.com/2544493/122989771-33dfc400-d371-11eb-8143-3375a1dc1caf.png)
![image](https://user-images.githubusercontent.com/2544493/122989797-3d692c00-d371-11eb-8387-90d36e4bfa00.png)

The changes in #35 are included in this PR so that one should get merged first since.