### PR TITLE
Retain newlines after tracker processing

### DIFF
--- a/src/ChanperfTracker.spec.ts
+++ b/src/ChanperfTracker.spec.ts
@@ -163,6 +163,13 @@ describe('ChanperfTracker ', () => {
             expect(history).to.eql(expectedNoDataHistory);
             expect(chanperfTracker.getHistory).to.eql(expectedNoDataHistory);
         });
+
+        it('does not discard extra newlines', () => {
+            const text = `\n\r\nmessage\n\r\n\nmessage\n\r\n`;
+            expect(
+                chanperfTracker.processLog(text)
+            ).to.eql(text);
+        });
     });
 
     describe('clearHistory', () => {

--- a/src/ChanperfTracker.ts
+++ b/src/ChanperfTracker.ts
@@ -53,10 +53,10 @@ export class ChanperfTracker {
      */
     public processLog(log: string): string {
         let lines = log.split('\n');
-        let normalOutput = '';
         let chanperfEventData: ChanperfData;
 
-        for (let line of lines) {
+        for (let i = 0; i < lines.length; i++) {
+            const line = lines[i];
             let infoAvailableMatch = /channel:\smem=([0-9]+)kib{[a-z]+=([0-9]+),[a-z]+=([0-9]+),[a-z]+=([0-9]+)(,[a-z]+=([0-9]+))?},\%cpu=([0-9]+){[a-z]+=([0-9]+),[a-z]+=([0-9]+)}/gmi.exec(line);
             // see the following for an explanation for this regex: https://regex101.com/r/3HKIO0/2
             if (infoAvailableMatch) {
@@ -78,8 +78,8 @@ export class ChanperfTracker {
                     system: Math.min(parseInt(sysCpuUsage), 100)
                 };
 
-                if (!this.filterOutLogs) {
-                    normalOutput += line + '\n';
+                if (this.filterOutLogs) {
+                    lines.splice(i--, 1);
                 }
                 this.emit('chanperf', chanperfEventData);
                 this.history.push(chanperfEventData);
@@ -91,19 +91,16 @@ export class ChanperfTracker {
                     chanperfEventData = this.createNewChanperfEventData();
                     chanperfEventData.error = { message: noInfoAvailableMatch[1] };
 
-                    if (!this.filterOutLogs) {
-                        normalOutput += line + '\n';
+                    if (this.filterOutLogs) {
+                        lines.splice(i--, 1);
                     }
                     this.emit('chanperf', chanperfEventData);
                     this.history.push(chanperfEventData);
-                } else if (line) {
-                    normalOutput += line + '\n';
                 }
             }
-
         }
 
-        return normalOutput;
+        return lines.join('\n');
     }
 
     private toBytes(KiB): number {

--- a/src/RendezvousTracker.spec.ts
+++ b/src/RendezvousTracker.spec.ts
@@ -279,6 +279,13 @@ describe('BrightScriptFileUtils ', () => {
             assert.deepEqual(rendezvousTracker.getRendezvousHistory, expectedHistory);
             rendezvousTrackerMock.verify();
         });
+
+        it('does not discard extra newlines', async () => {
+            const text = `\n\r\nmessage\n\r\n\nmessage\n\r\n`;
+            expect(
+                await rendezvousTracker.processLog(text)
+            ).to.eql(text);
+        });
     });
 
     describe('clearHistory', () => {

--- a/src/RendezvousTracker.ts
+++ b/src/RendezvousTracker.ts
@@ -73,9 +73,9 @@ export class RendezvousTracker {
     public async processLog(log: string): Promise<string> {
         let dataChanged = false;
         let lines = log.split('\n');
-        let normalOutput = '';
 
-        for (let line of lines) {
+        for (let i = 0; i < lines.length; i++) {
+            const line = lines[i];
             let match = /\[sg\.node\.(BLOCK|UNBLOCK)\s{0,}\] Rendezvous\[(\d+)\](?:\s\w+\n|\s\w{2}\s(.*)\((\d+)\)|[\s\w]+(\d+\.\d+)+|\s\w+)/g.exec(line);
             // see the following for an explanation for this regex: https://regex101.com/r/In0t7d/6
             if (match) {
@@ -135,11 +135,9 @@ export class RendezvousTracker {
                     delete this.rendezvousBlocks[id];
                 }
 
-                if (!this.filterOutLogs) {
-                    normalOutput += line + '\n';
+                if (this.filterOutLogs) {
+                    lines.splice(i--, 1);
                 }
-            } else if (line) {
-                normalOutput += line + '\n';
             }
         }
 
@@ -147,7 +145,7 @@ export class RendezvousTracker {
             this.emit('rendezvous', this.rendezvousHistory);
         }
 
-        return normalOutput;
+        return lines.join('\n');
     }
 
     /**


### PR DESCRIPTION
Fixes a bug in `ChanperfTracker` and `RendezvousTracker` that would discard excess newlines. 