### PR TITLE
Send every stdio line as separate event

### DIFF
--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -173,15 +173,11 @@ export class BrightScriptDebugSession extends BaseDebugSession {
             //pass along the console output
             if (this.launchConfiguration.consoleOutput === 'full') {
                 this.rokuAdapter.on('console-output', (data) => {
-                    //forward the console output
-                    this.sendEvent(new OutputEvent(data, 'stdout'));
-                    this.sendEvent(new LogOutputEvent(data));
+                    this.sendLogOutput(data);
                 });
             } else {
                 this.rokuAdapter.on('unhandled-console-output', (data) => {
-                    //forward the console output
-                    this.sendEvent(new OutputEvent(data, 'stdout'));
-                    this.sendEvent(new LogOutputEvent(data));
+                    this.sendLogOutput(data);
                 });
             }
 
@@ -315,6 +311,19 @@ export class BrightScriptDebugSession extends BaseDebugSession {
                     return err ? reject(err) : resolve(response);
                 });
             });
+        }
+    }
+
+    /**
+     * Send log output to the "client" (i.e. vscode)
+     * @param logOutput
+     */
+    private sendLogOutput(logOutput: string) {
+        const lines = logOutput.split(/\r?\n/g);
+        for (let line of lines) {
+            line += '\n';
+            this.sendEvent(new OutputEvent(line, 'stdout'));
+            this.sendEvent(new LogOutputEvent(line));
         }
     }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -194,7 +194,7 @@ class Util {
      */
     public logDebug(...args) {
         args = Array.isArray(args) ? args : [];
-        let timestamp = dateFormat(new Date(), 'HH:mm:ss.l ');
+        let timestamp = `[${dateFormat(new Date(), 'HH:mm:ss.l')}]`;
         let messages = [];
 
         for (let arg of args) {
@@ -210,7 +210,7 @@ class Util {
         }
         let text = messages.join(', ');
         if (this._debugSession) {
-            this._debugSession.sendEvent(new DebugServerLogOutputEvent(`${timestamp}: ${text}`));
+            this._debugSession.sendEvent(new DebugServerLogOutputEvent(`${timestamp} ${text}`));
         }
 
         console.log(timestamp, ...args);


### PR DESCRIPTION
There's an issue in the Debug Console window of vscode that shows all the log output as giant chunks of text. instead, we should show each line as its own entry. This makes the output console much easier to navigate and less quirky. 