### PR TITLE
Remove channel delete during launch.

### DIFF
--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -161,14 +161,6 @@ export class BrightScriptDebugSession extends BaseDebugSession {
 
             await this.runAutomaticSceneGraphCommands(this.launchConfiguration.autoRunSgDebugCommands);
 
-            //delete any previously installed channel
-            try {
-                util.log(`Deleting existing sideloaded channel (if there is one)`);
-                await this.rokuDeploy.deleteInstalledChannel(this.launchConfiguration as RokuDeployOptions);
-            } catch (error) {
-                util.logDebug('Error deleting previously installed channel. Probably not a big deal...', error);
-            }
-
             //press the home button to ensure we're at the home screen
             await this.rokuDeploy.pressHomeButton(this.launchConfiguration.host);
 


### PR DESCRIPTION
Deleting a channel before launch can result in the registry data being purged. We shouldn't delete it. 