### PR TITLE
Various protocol fixes

### DIFF
--- a/src/adapters/DebugProtocolAdapter.ts
+++ b/src/adapters/DebugProtocolAdapter.ts
@@ -237,18 +237,6 @@ export class DebugProtocolAdapter {
                 this.beginAppExit();
             });
 
-            this.connected = await this.socketDebugger.connect();
-
-            this.logger.log(`Closing telnet connection used for compile errors`);
-            if (this.compileClient) {
-                this.compileClient.removeAllListeners();
-                this.compileClient.destroy();
-                this.compileClient = undefined;
-            }
-
-            this.logger.log(`Connected to device`, { host: this.host, connected: this.connected });
-            this.emit('connected', this.connected);
-
             // Listen for the app exit event
             this.socketDebugger.on('app-exit', () => {
                 this.emit('app-exit');
@@ -270,6 +258,18 @@ export class DebugProtocolAdapter {
             this.socketDebugger.on('cannot-continue', () => {
                 this.emit('cannot-continue');
             });
+
+            this.connected = await this.socketDebugger.connect();
+
+            this.logger.log(`Closing telnet connection used for compile errors`);
+            if (this.compileClient) {
+                this.compileClient.removeAllListeners();
+                this.compileClient.destroy();
+                this.compileClient = undefined;
+            }
+
+            this.logger.log(`Connected to device`, { host: this.host, connected: this.connected });
+            this.emit('connected', this.connected);
 
             //the adapter is connected and running smoothly. resolve the promise
             deferred.resolve();

--- a/src/adapters/DebugProtocolAdapter.ts
+++ b/src/adapters/DebugProtocolAdapter.ts
@@ -425,7 +425,7 @@ export class DebugProtocolAdapter {
         return this.resolve(`stack trace for thread ${threadId}`, async () => {
             let thread = await this.getThreadByThreadId(threadId);
             let frames: StackFrame[] = [];
-            let stackTraceData: any = await this.socketDebugger.stackTrace(threadId);
+            let stackTraceData = await this.socketDebugger.stackTrace(threadId);
             for (let i = 0; i < stackTraceData.stackSize; i++) {
                 let frameData = stackTraceData.entries[i];
                 let stackFrame: StackFrame = {
@@ -503,7 +503,8 @@ export class DebugProtocolAdapter {
                 }
 
                 if (variableType === 'Subtyped_Object') {
-                    let parts = variable.value.split('; ');
+                    //subtyped objects can only have string values
+                    let parts = (variable.value as string).split('; ');
                     variableType = `${parts[0]} (${parts[1]})`;
                 } else if (variableType === 'AA') {
                     variableType = 'AssociativeArray';
@@ -580,7 +581,7 @@ export class DebugProtocolAdapter {
         }
         return this.resolve('threads', async () => {
             let threads: Thread[] = [];
-            let threadsData: any = await this.socketDebugger.threads();
+            let threadsData = await this.socketDebugger.threads();
 
             for (let i = 0; i < threadsData.threadsCount; i++) {
                 let threadInfo = threadsData.threads[i];

--- a/src/debugProtocol/Debugger.ts
+++ b/src/debugProtocol/Debugger.ts
@@ -218,7 +218,7 @@ export class Debugger {
         if (this.stopped) {
             this.stopped = false;
             let stepResult: any = await this.makeRequest<ProtocolEvent>(buffer, COMMANDS.STEP);
-            if (stepResult.errorCode === 'OK') {
+            if (stepResult.errorCode === ERROR_CODES.OK) {
                 // this.stopped = true;
                 // this.emit('suspend');
             } else {

--- a/src/debugProtocol/Debugger.ts
+++ b/src/debugProtocol/Debugger.ts
@@ -1,5 +1,5 @@
 import * as Net from 'net';
-import * as EventEmitter from 'events';
+import * as EventEmitter from 'eventemitter3';
 import * as semver from 'semver';
 import type {
     ThreadAttached,
@@ -212,6 +212,7 @@ export class Debugger {
     }
 
     private async step(stepType: STEP_TYPE, threadId: number): Promise<ProtocolEvent> {
+        this.logger.log('[step]', { stepType: STEP_TYPE[stepType], threadId, stopped: this.stopped });
         let buffer = new SmartBuffer({ size: 17 });
         buffer.writeUInt32LE(threadId); // thread_index
         buffer.writeUInt8(stepType); // step_type
@@ -331,7 +332,7 @@ export class Debugger {
                 }
 
                 if (debuggerRequestResponse.updateType > 0) {
-                    this.logger.log('Update Type:',UPDATE_TYPES[debuggerRequestResponse.updateType])
+                    this.logger.log('Update Type:', UPDATE_TYPES[debuggerRequestResponse.updateType])
                     switch (debuggerRequestResponse.updateType) {
                         case UPDATE_TYPES.IO_PORT_OPENED:
                             return this.connectToIoPort(new ConnectIOPortResponse(slicedBuffer), buffer, packetLength);
@@ -392,10 +393,12 @@ export class Debugger {
         return false;
     }
 
-    private checkResponse(responseClass: { requestId: number, readOffset: number, success: boolean }, unhandledData: Buffer, packetLength = 0): boolean {
+    private checkResponse(responseClass: { requestId: number, readOffset: number, success: boolean }, unhandledData: Buffer, packetLength = 0) {
         if (responseClass.success) {
             this.removedProcessedBytes(responseClass, unhandledData, packetLength);
             return true;
+        } else if (packetLength > 0 && unhandledData.length >= packetLength) {
+            this.removedProcessedBytes(responseClass, unhandledData, packetLength);
         }
         return false;
     }

--- a/src/debugProtocol/Debugger.ts
+++ b/src/debugProtocol/Debugger.ts
@@ -218,7 +218,7 @@ export class Debugger {
         buffer.writeUInt8(stepType); // step_type
         if (this.stopped) {
             this.stopped = false;
-            let stepResult: any = await this.makeRequest<ProtocolEvent>(buffer, COMMANDS.STEP);
+            let stepResult = await this.makeRequest<ProtocolEvent>(buffer, COMMANDS.STEP);
             if (stepResult.errorCode === ERROR_CODES.OK) {
                 // this.stopped = true;
                 // this.emit('suspend');

--- a/src/debugProtocol/responses/VariableResponse.ts
+++ b/src/debugProtocol/responses/VariableResponse.ts
@@ -154,5 +154,5 @@ export class VariableInfo {
     public refCount = -1;
     public keyType: string;
     public elementCount = -1;
-    public value: any;
+    public value: number | string | boolean | bigint | null;
 }


### PR DESCRIPTION
- Fixes a bug that would cause the app to immediately exit any time the `step` command was sent. 
- Fixed bug that wasn't cleaning up the buffer when packetLength was known.
- remove `: any` type in a few places where the type is more specific.