### PR TITLE
Handle restartRequest to reset Roku adapter

### DIFF
--- a/src/adapters/DebugProtocolAdapter.ts
+++ b/src/adapters/DebugProtocolAdapter.ts
@@ -26,6 +26,7 @@ export class DebugProtocolAdapter {
         this.chanperfTracker = new ChanperfTracker();
         this.rendezvousTracker = new RendezvousTracker();
         this.compileErrorProcessor = new CompileErrorProcessor();
+        this.connected = false;
 
         // watch for chanperf events
         this.chanperfTracker.on('chanperf', (output) => {
@@ -616,6 +617,9 @@ export class DebugProtocolAdapter {
         }
     }
 
+    public removeAllListeners() {
+        this.emitter?.removeAllListeners();
+    }
     /**
      * Disconnect from the telnet session and unset all objects
      */

--- a/src/adapters/TelnetAdapter.ts
+++ b/src/adapters/TelnetAdapter.ts
@@ -23,6 +23,7 @@ export class TelnetAdapter {
         private host: string,
         private enableDebuggerAutoRecovery: boolean = false
     ) {
+        this.connected = false;
         this.emitter = new EventEmitter();
         this.debugStartRegex = /BrightScript Micro Debugger\./ig;
         this.debugEndRegex = /Brightscript Debugger>/ig;
@@ -1055,6 +1056,9 @@ export class TelnetAdapter {
         });
     }
 
+    public removeAllListeners() {
+        this.emitter?.removeAllListeners();
+    }
     /**
      * Disconnect from the telnet session and unset all objects
      */


### PR DESCRIPTION
When using the restart debugging session the session can fail to restart.
This PR enabled the restartRequest Debug Adapter Protocol so the Roku adaptor is appropriately cleaned up on restart commands.