### PR TITLE
Add basic breakpoint logic to debug procool.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -188,6 +188,7 @@ module.exports = {
             '@typescript-eslint/no-unused-vars-experimental': 'off',
             '@typescript-eslint/dot-notation': 'off',
             'github/array-foreach': 'off',
+            'camelcase': 'off',
             'new-cap': 'off',
             'no-shadow': 'off',
             'func-names': 'off'

--- a/src/debugProtocol/responses/AddBreakpointsResponse.ts
+++ b/src/debugProtocol/responses/AddBreakpointsResponse.ts
@@ -1,0 +1,4 @@
+import { ListBreakpointsResponse } from './ListBreakpointsResponse';
+
+//There's currently no difference between this response and the ListBreakpoints response
+export class AddBreakpointsResponse extends ListBreakpointsResponse { }

--- a/src/debugProtocol/responses/ListBreakpointsResponse.spec.ts
+++ b/src/debugProtocol/responses/ListBreakpointsResponse.spec.ts
@@ -1,13 +1,7 @@
-import { HandshakeResponseV3 } from './HandshakeResponseV3';
-import { Debugger } from '../Debugger';
-import { createHandShakeResponseV3, createListBreakpointsResponse, getRandomBuffer } from './responseCreationHelpers.spec';
+import { createListBreakpointsResponse, getRandomBuffer } from './responseCreationHelpers.spec';
 import { expect } from 'chai';
-import { createSandbox } from 'sinon';
-import { SmartBuffer } from 'smart-buffer';
 import { ListBreakpointsResponse } from './ListBreakpointsResponse';
 import { ERROR_CODES } from '../Constants';
-import { ErrorCodes } from 'vscode-languageserver';
-const sinon = createSandbox();
 
 describe('ListBreakpointsResponse', () => {
     let response: ListBreakpointsResponse;

--- a/src/debugProtocol/responses/ListBreakpointsResponse.spec.ts
+++ b/src/debugProtocol/responses/ListBreakpointsResponse.spec.ts
@@ -1,0 +1,139 @@
+import { HandshakeResponseV3 } from './HandshakeResponseV3';
+import { Debugger } from '../Debugger';
+import { createHandShakeResponseV3, createListBreakpointsResponse, getRandomBuffer } from './responseCreationHelpers.spec';
+import { expect } from 'chai';
+import { createSandbox } from 'sinon';
+import { SmartBuffer } from 'smart-buffer';
+import { ListBreakpointsResponse } from './ListBreakpointsResponse';
+import { ERROR_CODES } from '../Constants';
+import { ErrorCodes } from 'vscode-languageserver';
+const sinon = createSandbox();
+
+describe('ListBreakpointsResponse', () => {
+    let response: ListBreakpointsResponse;
+    beforeEach(() => {
+        response = undefined;
+    });
+    it('handles empty buffer', () => {
+        response = new ListBreakpointsResponse(null);
+        //Great, it didn't explode!
+        expect(response.success).to.be.false;
+    });
+
+    it('handles undersized buffers', () => {
+        response = new ListBreakpointsResponse(
+            getRandomBuffer(0)
+        );
+        expect(response.success).to.be.false;
+
+        response = new ListBreakpointsResponse(
+            getRandomBuffer(1)
+        );
+        expect(response.success).to.be.false;
+
+        response = new ListBreakpointsResponse(
+            getRandomBuffer(11)
+        );
+        expect(response.success).to.be.false;
+    });
+
+    it('gracefully handles mismatched breakpoint count', () => {
+        const bp1 = {
+            breakpointId: 1,
+            errorCode: ERROR_CODES.OK,
+            hitCount: 0,
+            success: true
+        };
+        response = new ListBreakpointsResponse(
+            createListBreakpointsResponse({
+                requestId: 1,
+                num_breakpoints: 2,
+                breakpoints: [bp1]
+            }).toBuffer()
+        );
+        expect(response.success).to.be.false;
+        expect(response.breakpoints).to.eql([bp1]);
+    });
+
+    it('handles malformed breakpoint data', () => {
+        const bp1 = {
+            breakpointId: 1,
+            errorCode: ERROR_CODES.OK,
+            hitCount: 2,
+            success: true
+        };
+        response = new ListBreakpointsResponse(
+            createListBreakpointsResponse({
+                requestId: 1,
+                num_breakpoints: 2,
+                breakpoints: [
+                    bp1,
+                    {
+                        //missing all other bp properties
+                        breakpointId: 1
+                    }
+                ]
+            }).toBuffer()
+        );
+        expect(response.success).to.be.false;
+        expect(response.breakpoints).to.eql([bp1]);
+    });
+
+    it('handles malformed breakpoint data', () => {
+        const bp1 = {
+            breakpointId: 0,
+            errorCode: ERROR_CODES.OK,
+            success: true
+        };
+        response = new ListBreakpointsResponse(
+            createListBreakpointsResponse({
+                requestId: 1,
+                num_breakpoints: 2,
+                breakpoints: [bp1]
+            }).toBuffer()
+        );
+        expect(response.success).to.be.false;
+        //hitcount should not be set when bpId is zero
+        expect(response.breakpoints[0].hitCount).to.be.undefined;
+        //the breakpoint should not be verified if bpId === 0
+        expect(response.breakpoints[0].isVerified).to.be.false;
+    });
+
+    it('reads breakpoint data properly', () => {
+        const bp1 = {
+            breakpointId: 1,
+            errorCode: ERROR_CODES.OK,
+            hitCount: 0,
+            success: true
+        };
+        response = new ListBreakpointsResponse(
+            createListBreakpointsResponse({
+                requestId: 1,
+                breakpoints: [bp1]
+            }).toBuffer()
+        );
+        expect(response.success).to.be.true;
+        expect(response.breakpoints).to.eql([bp1]);
+        expect(response.breakpoints[0].isVerified).to.be.true;
+    });
+
+    it('reads breakpoint data properly', () => {
+        const bp1 = {
+            breakpointId: 1,
+            errorCode: ERROR_CODES.NOT_STOPPED,
+            hitCount: 0,
+            success: true
+        };
+        response = new ListBreakpointsResponse(
+            createListBreakpointsResponse({
+                requestId: 1,
+                breakpoints: [bp1]
+            }).toBuffer()
+        );
+        expect(
+            response.breakpoints[0].errorText
+        ).to.eql(
+            ERROR_CODES[ERROR_CODES.NOT_STOPPED]
+        );
+    });
+});

--- a/src/debugProtocol/responses/ListBreakpointsResponse.ts
+++ b/src/debugProtocol/responses/ListBreakpointsResponse.ts
@@ -1,0 +1,68 @@
+import { SmartBuffer } from 'smart-buffer';
+import { ERROR_CODES } from '../Constants';
+
+export class ListBreakpointsResponse {
+
+    constructor(buffer: Buffer) {
+        // The minimum size of a request
+        if (buffer?.byteLength >= 4) {
+            try {
+                let bufferReader = SmartBuffer.fromBuffer(buffer);
+                this.requestId = bufferReader.readUInt32LE(); // request_id
+
+                // Any request id less then one is an update and we should not process it here
+                if (this.requestId > 0) {
+                    this.errorCode = ERROR_CODES[bufferReader.readUInt32LE()];
+                    this.numBreakpoints = bufferReader.readUInt32LE(); // num_breakpoints - The number of breakpoints in the breakpoints array.
+
+                    // build the list of BreakpointInfo
+                    for (let i = 0; i < this.numBreakpoints; i++) {
+                        let breakpointInfo = new BreakpointInfo(bufferReader);
+                        if (breakpointInfo.success) {
+                            // All the necessary data was present, so keep this item
+                            this.breakpoints.push(breakpointInfo);
+                        }
+                    }
+
+                    this.readOffset = bufferReader.readOffset;
+                    this.success = (this.breakpoints.length === this.numBreakpoints);
+                }
+            } catch (error) {
+                // Could not parse
+            }
+        }
+    }
+    public success = false;
+    public readOffset = 0;
+
+    // response fields
+    public requestId = -1;
+    public numBreakpoints: number;
+    public breakpoints = [] as BreakpointInfo[];
+    public data = -1;
+    public errorCode: string;
+}
+
+export class BreakpointInfo {
+    constructor(bufferReader: SmartBuffer) {
+        // breakpoint_id - The ID assigned to the breakpoint. An ID greater than 0 indicates an active breakpoint. An ID of 0 denotes that the breakpoint has an error.
+        this.breakpointId = bufferReader.readUInt32LE();
+        // error_code - Indicates whether the breakpoint was successfully returned.
+        this.errorCode = ERROR_CODES[bufferReader.readUInt32LE()];
+
+        if (this.breakpointId > 0) {
+            // This argument is only present if the breakpoint_id is valid.
+            // ignore_count - Current state, decreases as breakpoint is executed.
+            this.hitCount = bufferReader.readUInt32LE();
+        }
+        this.success = true;
+    }
+
+    public get isVerified() {
+        return this.breakpointId > 0;
+    }
+    public success = false;
+    public breakpointId: number;
+    public errorCode: string;
+    public hitCount: number;
+}

--- a/src/debugProtocol/responses/ListBreakpointsResponse.ts
+++ b/src/debugProtocol/responses/ListBreakpointsResponse.ts
@@ -5,7 +5,7 @@ export class ListBreakpointsResponse {
 
     constructor(buffer: Buffer) {
         // The minimum size of a request
-        if (buffer?.byteLength >= 4) {
+        if (buffer?.byteLength >= 12) {
             try {
                 let bufferReader = SmartBuffer.fromBuffer(buffer);
                 this.requestId = bufferReader.readUInt32LE(); // request_id
@@ -18,10 +18,8 @@ export class ListBreakpointsResponse {
                     // build the list of BreakpointInfo
                     for (let i = 0; i < this.numBreakpoints; i++) {
                         let breakpointInfo = new BreakpointInfo(bufferReader);
-                        if (breakpointInfo.success) {
-                            // All the necessary data was present, so keep this item
-                            this.breakpoints.push(breakpointInfo);
-                        }
+                        // All the necessary data was present, so keep this item
+                        this.breakpoints.push(breakpointInfo);
                     }
 
                     this.readOffset = bufferReader.readOffset;
@@ -48,7 +46,7 @@ export class BreakpointInfo {
         // breakpoint_id - The ID assigned to the breakpoint. An ID greater than 0 indicates an active breakpoint. An ID of 0 denotes that the breakpoint has an error.
         this.breakpointId = bufferReader.readUInt32LE();
         // error_code - Indicates whether the breakpoint was successfully returned.
-        this.errorCode = ERROR_CODES[bufferReader.readUInt32LE()];
+        this.errorCode = bufferReader.readUInt32LE();
 
         if (this.breakpointId > 0) {
             // This argument is only present if the breakpoint_id is valid.
@@ -63,6 +61,12 @@ export class BreakpointInfo {
     }
     public success = false;
     public breakpointId: number;
-    public errorCode: string;
+    public errorCode: number;
+    /**
+     * The textual description of the error code
+     */
+    public get errorText() {
+        return ERROR_CODES[this.errorCode];
+    }
     public hitCount: number;
 }

--- a/src/debugProtocol/responses/RemoveBreakpointsResponse.ts
+++ b/src/debugProtocol/responses/RemoveBreakpointsResponse.ts
@@ -1,0 +1,4 @@
+import { ListBreakpointsResponse } from './ListBreakpointsResponse';
+
+//There's currently no difference between this response and the ListBreakpoints response
+export class RemoveBreakpointsResponse extends ListBreakpointsResponse { }


### PR DESCRIPTION
This adds the logic to the `Debugger` class to support breakpoint request/response flows. 

This does NOT add full dynamic breakpoint support quite yet, but this logic can be merged on its own. 

TODO:

- [x] unit tests