### PR TITLE
Add brightScriptConsolePort option. Use remotePort more

### DIFF
--- a/src/LaunchConfiguration.ts
+++ b/src/LaunchConfiguration.ts
@@ -161,7 +161,7 @@ export interface LaunchConfiguration extends DebugProtocol.LaunchRequestArgument
     remotePort?: number;
 
     /**
-     * The brightscript console port. In telnet mode this is the port used for the telnet connection. In debug protocol mode, this is where the compile errors show up.
+     * The brightscript console port. In telnet mode this is the port used for the telnet connection. In debug protocol mode, this is used to obtain compile errors from the device.
      */
     brightScriptConsolePort?: number;
 

--- a/src/LaunchConfiguration.ts
+++ b/src/LaunchConfiguration.ts
@@ -161,6 +161,11 @@ export interface LaunchConfiguration extends DebugProtocol.LaunchRequestArgument
     remotePort?: number;
 
     /**
+     * The brightscript console port. In telnet mode this is the port used for the telnet connection. In debug protocol mode, this is where the compile errors show up.
+     */
+    brightScriptConsolePort?: number;
+
+    /**
      * The path used for the staging folder of roku-deploy
      * This should generally be set to "${cwd}/.roku-deploy-staging", but that's ultimately up to the debug client.
      */

--- a/src/adapters/DebugProtocolAdapter.spec.ts
+++ b/src/adapters/DebugProtocolAdapter.spec.ts
@@ -13,7 +13,9 @@ describe('DebugProtocolAdapter', () => {
     let socketDebugger: Debugger;
     beforeEach(() => {
 
-        adapter = new DebugProtocolAdapter(null, null);
+        adapter = new DebugProtocolAdapter({
+            host: '127.0.0.1'
+        });
         socketDebugger = new Debugger(undefined);
         adapter['socketDebugger'] = socketDebugger;
     });

--- a/src/adapters/DebugProtocolAdapter.ts
+++ b/src/adapters/DebugProtocolAdapter.ts
@@ -295,7 +295,7 @@ export class DebugProtocolAdapter {
 
             //if the connection fails, reject the connect promise
             this.compileClient.addListener('error', (err) => {
-                deferred.reject(new Error(`Error with connection to: ${this.options.host} \n\n ${err.message} `));
+                deferred.reject(new Error(`Error with connection to: ${this.options.host}:${this.options.brightScriptConsolePort} \n\n ${err.message} `));
             });
             this.logger.info('Connecting via telnet to gether compile info', { host: this.options.host });
             this.compileClient.connect(this.options.brightScriptConsolePort, this.options.host, () => {

--- a/src/adapters/DebugProtocolAdapter.ts
+++ b/src/adapters/DebugProtocolAdapter.ts
@@ -12,16 +12,16 @@ import { ERROR_CODES, PROTOCOL_ERROR_CODES } from '../debugProtocol/Constants';
 import { defer, util } from '../util';
 import { logger } from '../logging';
 import * as semver from 'semver';
-import type { HighLevelType, RokuAdapterEvaluateResponse } from '../interfaces';
+import type { AdapterOptions, HighLevelType, RokuAdapterEvaluateResponse } from '../interfaces';
 
 /**
  * A class that connects to a Roku device over telnet debugger port and provides a standardized way of interacting with it.
  */
 export class DebugProtocolAdapter {
     constructor(
-        private host: string,
-        private stopOnEntry: boolean = false
+        private options: AdapterOptions
     ) {
+        util.normalizeAdapterOptions(this.options);
         this.emitter = new EventEmitter();
         this.chanperfTracker = new ChanperfTracker();
         this.rendezvousTracker = new RendezvousTracker();
@@ -195,10 +195,7 @@ export class DebugProtocolAdapter {
      */
     public async connect() {
         let deferred = defer();
-        this.socketDebugger = new Debugger({
-            host: this.host,
-            stopOnEntry: this.stopOnEntry
-        });
+        this.socketDebugger = new Debugger(this.options);
         try {
             // Emit IO from the debugger.
             // eslint-disable-next-line @typescript-eslint/no-misused-promises
@@ -269,7 +266,7 @@ export class DebugProtocolAdapter {
                 this.compileClient = undefined;
             }
 
-            this.logger.log(`Connected to device`, { host: this.host, connected: this.connected });
+            this.logger.log(`Connected to device`, { host: this.options.host, connected: this.connected });
             this.emit('connected', this.connected);
 
             //the adapter is connected and running smoothly. resolve the promise
@@ -298,11 +295,11 @@ export class DebugProtocolAdapter {
 
             //if the connection fails, reject the connect promise
             this.compileClient.addListener('error', (err) => {
-                deferred.reject(new Error(`Error with connection to: ${this.host} \n\n ${err.message} `));
+                deferred.reject(new Error(`Error with connection to: ${this.options.host} \n\n ${err.message} `));
             });
-            this.logger.info('Connecting via telnet to gether compile info', { host: this.host });
-            this.compileClient.connect(8085, this.host, () => {
-                this.logger.log(`Connected via telnet to gather compile info`, { host: this.host });
+            this.logger.info('Connecting via telnet to gether compile info', { host: this.options.host });
+            this.compileClient.connect(this.options.brightScriptConsolePort, this.options.host, () => {
+                this.logger.log(`Connected via telnet to gather compile info`, { host: this.options.host });
             });
 
             this.logger.debug('Waiting for the compile client to settle');

--- a/src/adapters/DebugProtocolAdapter.ts
+++ b/src/adapters/DebugProtocolAdapter.ts
@@ -299,7 +299,7 @@ export class DebugProtocolAdapter {
             });
             this.logger.info('Connecting via telnet to gather compile info', { host: this.options.host, port: this.options.brightScriptConsolePort });
             this.compileClient.connect(this.options.brightScriptConsolePort, this.options.host, () => {
-                this.logger.log(`Connected via telnet to gather compile info`, { host: this.options.host });
+                this.logger.log(`Connected via telnet to gather compile info`, { host: this.options.host, port: this.options.brightScriptConsolePort });
             });
 
             this.logger.debug('Waiting for the compile client to settle');

--- a/src/adapters/DebugProtocolAdapter.ts
+++ b/src/adapters/DebugProtocolAdapter.ts
@@ -297,7 +297,7 @@ export class DebugProtocolAdapter {
             this.compileClient.addListener('error', (err) => {
                 deferred.reject(new Error(`Error with connection to: ${this.options.host}:${this.options.brightScriptConsolePort} \n\n ${err.message} `));
             });
-            this.logger.info('Connecting via telnet to gether compile info', { host: this.options.host });
+            this.logger.info('Connecting via telnet to gather compile info', { host: this.options.host, port: this.options.brightScriptConsolePort });
             this.compileClient.connect(this.options.brightScriptConsolePort, this.options.host, () => {
                 this.logger.log(`Connected via telnet to gather compile info`, { host: this.options.host });
             });

--- a/src/adapters/TelnetAdapter.spec.ts
+++ b/src/adapters/TelnetAdapter.spec.ts
@@ -8,7 +8,9 @@ describe('TelnetAdapter ', () => {
     let adapter: TelnetAdapter;
 
     beforeEach(() => {
-        adapter = new TelnetAdapter('127.0.0.1');
+        adapter = new TelnetAdapter({
+            host: '127.0.0.1'
+        });
     });
 
     describe('getHighLevelTypeDetails', () => {

--- a/src/adapters/TelnetAdapter.ts
+++ b/src/adapters/TelnetAdapter.ts
@@ -240,7 +240,7 @@ export class TelnetAdapter {
             });
 
             const settlePromise = this.settle(client, 'data');
-            client.connect(8085, this.options.host, () => {
+            client.connect(this.options.brightScriptConsolePort, this.options.host, () => {
                 this.logger.log(`Telnet connection established to ${this.options.host}`);
                 this.connected = true;
                 this.emit('connected', this.connected);

--- a/src/adapters/TelnetAdapter.ts
+++ b/src/adapters/TelnetAdapter.ts
@@ -241,7 +241,7 @@ export class TelnetAdapter {
 
             const settlePromise = this.settle(client, 'data');
             client.connect(this.options.brightScriptConsolePort, this.options.host, () => {
-                this.logger.log(`Telnet connection established to ${this.options.host}`);
+                this.logger.log(`Telnet connection established to ${this.options.host}:${this.options.brightScriptConsolePort}`);
                 this.connected = true;
                 this.emit('connected', this.connected);
             });

--- a/src/adapters/TelnetAdapter.ts
+++ b/src/adapters/TelnetAdapter.ts
@@ -11,7 +11,7 @@ import { ChanperfTracker } from '../ChanperfTracker';
 import type { SourceLocation } from '../managers/LocationManager';
 import { defer, util } from '../util';
 import { logger } from '../logging';
-import type { RokuAdapterEvaluateResponse } from '../interfaces';
+import type { AdapterOptions, RokuAdapterEvaluateResponse } from '../interfaces';
 import { HighLevelType } from '../interfaces';
 import { TelnetRequestPipeline } from './TelnetRequestPipeline';
 
@@ -20,9 +20,13 @@ import { TelnetRequestPipeline } from './TelnetRequestPipeline';
  */
 export class TelnetAdapter {
     constructor(
-        private host: string,
-        private enableDebuggerAutoRecovery: boolean = false
+        private options: AdapterOptions & {
+            enableDebuggerAutoRecovery?: boolean;
+        }
     ) {
+        util.normalizeAdapterOptions(this.options);
+        this.options.enableDebuggerAutoRecovery ??= false;
+
         this.connected = false;
         this.emitter = new EventEmitter();
         this.debugStartRegex = /BrightScript Micro Debugger\./ig;
@@ -203,7 +207,7 @@ export class TelnetAdapter {
                 //ended MicroDebugger block
                 this.isInMicroDebugger = false;
             } else if (this.isInMicroDebugger) {
-                if (this.enableDebuggerAutoRecovery && line.startsWith('Break in ')) {
+                if (this.options.enableDebuggerAutoRecovery && line.startsWith('Break in ')) {
                     //this block is a break: skipping it
                     this.isNextBreakpointSkipped = true;
                 }
@@ -222,7 +226,7 @@ export class TelnetAdapter {
         try {
             this.logger.log('Pressing home button');
             //force roku to return to home screen. This gives the roku adapter some security in knowing new messages won't be appearing during initialization
-            await rokuDeploy.pressHomeButton(this.host);
+            await rokuDeploy.pressHomeButton(this.options.host, this.options.remotePort);
             let client: Socket = new Socket();
 
             //listen for the close event
@@ -232,12 +236,12 @@ export class TelnetAdapter {
 
             //if the connection fails, reject the connect promise
             client.addListener('error', (err) => {
-                deferred.reject(new Error(`Error with connection to: ${this.host} \n\n ${err.message} `));
+                deferred.reject(new Error(`Error with connection to: ${this.options.host} \n\n ${err.message} `));
             });
 
             const settlePromise = this.settle(client, 'data');
-            client.connect(8085, this.host, () => {
-                this.logger.log(`Telnet connection established to ${this.host}`);
+            client.connect(8085, this.options.host, () => {
+                this.logger.log(`Telnet connection established to ${this.options.host}`);
                 this.connected = true;
                 this.emit('connected', this.connected);
             });

--- a/src/adapters/TelnetAdapter.ts
+++ b/src/adapters/TelnetAdapter.ts
@@ -236,7 +236,7 @@ export class TelnetAdapter {
 
             //if the connection fails, reject the connect promise
             client.addListener('error', (err) => {
-                deferred.reject(new Error(`Error with connection to: ${this.options.host} \n\n ${err.message} `));
+                deferred.reject(new Error(`Error with connection to: ${this.options.host}:${this.options.brightScriptConsolePort} \n\n ${err.message} `));
             });
 
             const settlePromise = this.settle(client, 'data');

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -201,7 +201,7 @@ export class BrightScriptDebugSession extends BaseDebugSession {
             await this.runAutomaticSceneGraphCommands(this.launchConfiguration.autoRunSgDebugCommands);
 
             //press the home button to ensure we're at the home screen
-            await this.rokuDeploy.pressHomeButton(this.launchConfiguration.host);
+            await this.rokuDeploy.pressHomeButton(this.launchConfiguration.host, this.launchConfiguration.remotePort);
 
             //pass the debug functions used to locate the client files and lines thought the adapter to the RendezvousTracker
             this.rokuAdapter.registerSourceLocator(async (debuggerPath: string, lineNumber: number) => {
@@ -263,7 +263,7 @@ export class BrightScriptDebugSession extends BaseDebugSession {
                 this.sendEvent(new CompileFailureEvent(compileErrors));
                 //stop the roku adapter and exit the channel
                 void this.rokuAdapter.destroy();
-                void this.rokuDeploy.pressHomeButton(this.launchConfiguration.host);
+                void this.rokuDeploy.pressHomeButton(this.launchConfiguration.host, this.launchConfiguration.remotePort);
             });
 
             // close disconnect if required when the app is exited
@@ -279,7 +279,7 @@ export class BrightScriptDebugSession extends BaseDebugSession {
                         void this.rokuAdapter.destroy();
                     }
                     //return to the home screen
-                    await this.rokuDeploy.pressHomeButton(this.launchConfiguration.host);
+                    await this.rokuDeploy.pressHomeButton(this.launchConfiguration.host, this.launchConfiguration.remotePort);
                     this.shutdown();
                     this.sendEvent(new TerminatedEvent());
                 } else {
@@ -346,7 +346,7 @@ export class BrightScriptDebugSession extends BaseDebugSession {
             //if we are at a breakpoint, continue
             await this.rokuAdapter.continue();
             //kill the app on the roku
-            await this.rokuDeploy.pressHomeButton(this.launchConfiguration.host);
+            await this.rokuDeploy.pressHomeButton(this.launchConfiguration.host, this.launchConfiguration.remotePort);
             //send the deep link http request
             await new Promise((resolve, reject) => {
                 request.post(this.launchConfiguration.deepLinkUrl, (err, response) => {
@@ -932,7 +932,7 @@ export class BrightScriptDebugSession extends BaseDebugSession {
         }
         //return to the home screen
         if (!this.enableDebugProtocol) {
-            await this.rokuDeploy.pressHomeButton(this.launchConfiguration.host);
+            await this.rokuDeploy.pressHomeButton(this.launchConfiguration.host, this.launchConfiguration.remotePort);
         }
         this.componentLibraryServer.stop();
         this.sendResponse(response);
@@ -940,9 +940,9 @@ export class BrightScriptDebugSession extends BaseDebugSession {
 
     private createRokuAdapter(host: string) {
         if (this.enableDebugProtocol) {
-            this.rokuAdapter = new DebugProtocolAdapter(host, this.launchConfiguration.stopOnEntry);
+            this.rokuAdapter = new DebugProtocolAdapter(this.launchConfiguration);
         } else {
-            this.rokuAdapter = new TelnetAdapter(host, this.launchConfiguration.enableDebuggerAutoRecovery);
+            this.rokuAdapter = new TelnetAdapter(this.launchConfiguration);
         }
     }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -14,3 +14,9 @@ export interface RokuAdapterEvaluateResponse {
     type: 'message' | 'error';
     message: string;
 }
+
+export interface AdapterOptions {
+    host: string;
+    brightScriptConsolePort?: number;
+    remotePort?: number;
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -11,6 +11,7 @@ import type { BrightScriptDebugCompileError } from './CompileErrorProcessor';
 import { GENERAL_XML_ERROR } from './CompileErrorProcessor';
 import { serializeError } from 'serialize-error';
 import * as dns from 'dns';
+import type { AdapterOptions } from './interfaces';
 
 class Util {
     /**
@@ -380,6 +381,11 @@ class Util {
         const minutes = allocate(60000);
         const seconds = allocate(1000);
         return `${hours > 0 ? hours + 'h' : ''}${minutes > 0 ? minutes + 'm' : ''}${seconds > 0 ? seconds + 's' : ''}${ms > 0 ? ms + 'ms' : ''}`;
+    }
+
+    public normalizeAdapterOptions(options: AdapterOptions) {
+        options.brightScriptConsolePort ??= 8085;
+        options.remotePort ??= 8060;
     }
 }
 


### PR DESCRIPTION
- Use the `remotePort` launch configuration option when sending home presses
- refactor the adapters to use a common configuration object parameter instead of ordered params.
- add `brightScriptConsolePort` to override where telnet connects.