### PR TITLE
Prevent crash during rendezvous tracking

### DIFF
--- a/src/managers/ProjectManager.spec.ts
+++ b/src/managers/ProjectManager.spec.ts
@@ -216,6 +216,12 @@ describe('ProjectManager', () => {
     });
 
     describe('getSourceLocation', () => {
+        it(`does not crash when file is missing`, async () => {
+            manager.mainProject.fileMappings = [];
+            let sourceLocation = await manager.getSourceLocation('pkg:/source/file-we-dont-know-about.brs', 1);
+            expect(n(sourceLocation.filePath)).to.equal(n(`${stagingFolderPath}/source/file-we-dont-know-about.brs`));
+        });
+
         it('handles truncated paths', async () => {
             //mock fsExtra so we don't have to create actual files
             sinon.stub(fsExtra as any, 'pathExists').callsFake((filePath: string) => {
@@ -275,7 +281,6 @@ describe('ProjectManager', () => {
             sourceLocation = await manager.getSourceLocation('pkg:/source/file2.brs', 1);
             expect(n(sourceLocation.filePath)).to.equal(n(`${rootDir}/source/file2.brs`));
         });
-
     });
 });
 

--- a/src/managers/ProjectManager.ts
+++ b/src/managers/ProjectManager.ts
@@ -118,15 +118,15 @@ export class ProjectManager {
         });
 
         //if sourcemaps are disabled, account for the breakpoint offsets
-        if (this.launchConfiguration?.enableSourceMaps === false) {
+        if (sourceLocation && this.launchConfiguration?.enableSourceMaps === false) {
             sourceLocation.lineNumber = this.getLineNumberOffsetByBreakpoints(sourceLocation.filePath, sourceLocation.lineNumber);
         }
 
-        if (!sourceLocation.filePath) {
+        if (!sourceLocation?.filePath) {
             //couldn't find a source location. At least send back the staging file information so the user can still debug
             return {
                 filePath: stagingFileInfo.absolutePath,
-                lineNumber: sourceLocation.lineNumber || debuggerLineNumber,
+                lineNumber: sourceLocation?.lineNumber || debuggerLineNumber,
                 columnIndex: 0
             } as SourceLocation;
         } else {


### PR DESCRIPTION
Prevent a crash when handling rendezvous paths from files NOT found in the files array or in staging folder.