### PR TITLE
Fix lint issues, remove some disable comments

### DIFF
--- a/src/CompileErrorProcessor.ts
+++ b/src/CompileErrorProcessor.ts
@@ -181,8 +181,7 @@ export class CompileErrorProcessor {
         let errors: BrightScriptDebugCompileError[] = [];
         let getFileInfoRegEx = /^--- Line (\d*): (.*)$/gim;
         let match: RegExpExecArray;
-        // eslint-disable-next-line no-cond-assign
-        while (match = getFileInfoRegEx.exec(fileErrorText)) {
+        while ((match = getFileInfoRegEx.exec(fileErrorText))) {
             let lineNumber = parseInt(match[1]); // 1-based
             let errorText = 'ERR_COMPILE:';
             let message = this.sanitizeCompilePath(match[2]);

--- a/src/adapters/TelnetAdapter.ts
+++ b/src/adapters/TelnetAdapter.ts
@@ -296,7 +296,6 @@ export class TelnetAdapter {
 
                 if (this.isActivated) {
                     //watch for the start of the program
-                    // eslint-disable-next-line no-cond-assign
                     if (/\[scrpt.ctx.run.enter\]/i.exec(responseText.trim())) {
                         this.isAppRunning = true;
                         this.logger.log('Running beacon detected', { responseText });
@@ -304,7 +303,6 @@ export class TelnetAdapter {
                     }
 
                     //watch for the end of the program
-                    // eslint-disable-next-line no-cond-assign
                     if (/\[beacon.report\] \|AppExitComplete/i.exec(responseText.trim())) {
                         this.beginAppExit();
                     }
@@ -471,8 +469,7 @@ export class TelnetAdapter {
             let regexp = /#(\d+)\s+(?:function|sub)\s+([\$\w\d]+).*\s+file\/line:\s+(.*)\((\d+)\)/ig;
             let matches: RegExpExecArray;
             let frames: StackFrame[] = [];
-            // eslint-disable-next-line no-cond-assign
-            while (matches = regexp.exec(responseText)) {
+            while ((matches = regexp.exec(responseText))) {
                 //the first index is the whole string
                 //then the matches should be in pairs
                 for (let i = 1; i < matches.length; i += 4) {

--- a/src/managers/BreakpointManager.ts
+++ b/src/managers/BreakpointManager.ts
@@ -332,8 +332,7 @@ export class BreakpointManager {
             let match: RegExpExecArray;
 
             // Get all the value to evaluate as expressions
-            // eslint-disable-next-line no-cond-assign
-            while (match = expressionsCheck.exec(logMessage)) {
+            while ((match = expressionsCheck.exec(logMessage))) {
                 logMessage = logMessage.replace(match[0], `"; ${match[1]};"`);
             }
 

--- a/src/managers/FileManager.ts
+++ b/src/managers/FileManager.ts
@@ -108,8 +108,7 @@ export class FileManager {
         let result = {};
 
         //create a cache of all function names in this file
-        // eslint-disable-next-line no-cond-assign
-        while (match = regexp.exec(fileContents)) {
+        while ((match = regexp.exec(fileContents))) {
             let correctFunctionName = match[1];
             result[correctFunctionName.toLowerCase()] = correctFunctionName;
         }

--- a/src/managers/LocationManager.spec.ts
+++ b/src/managers/LocationManager.spec.ts
@@ -17,8 +17,7 @@ const sourceDirs = [
 describe('LocationManager', () => {
     let locationManager: LocationManager;
     let sourceMapManager: SourceMapManager;
-    // eslint-disable-next-line prefer-arrow-callback
-    beforeEach(function beforeEach() {
+    beforeEach(() => {
         sourceMapManager = new SourceMapManager();
         locationManager = new LocationManager(sourceMapManager);
         fsExtra.removeSync(tempDir);

--- a/src/managers/ProjectManager.ts
+++ b/src/managers/ProjectManager.ts
@@ -499,8 +499,7 @@ export class ComponentLibraryProject extends Project {
         let manifestValues: Record<string, string>;
 
         // search the outFile for replaceable values such as ${title}
-        // eslint-disable-next-line no-cond-assign
-        while (renamingMatch = regexp.exec(this.outFile)) {
+        while ((renamingMatch = regexp.exec(this.outFile))) {
             if (!manifestValues) {
                 // The first time a value is found we need to get the manifest values
                 manifestValues = await util.convertManifestToObject(manifestPath);

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import * as assert from 'assert';
 import { expect } from 'chai';
 import * as fsExtra from 'fs-extra';

--- a/src/util.ts
+++ b/src/util.ts
@@ -194,8 +194,7 @@ class Util {
         const regexp = /^((.*?)Brightscript\s+Debugger>\s*)(.*?)$/gm;
         let match: RegExpExecArray;
         const splitIndexes = [] as number[];
-        // eslint-disable-next-line no-cond-assign
-        while (match = regexp.exec(text)) {
+        while ((match = regexp.exec(text))) {
             const leadingAndBeaconText = match[1];
             const leadingText = match[2];
             const trailingText = match[3];


### PR DESCRIPTION
- Remove many `eslint-disable` comments in favor of in-code solutions
- Remove a stray `eslint-disable` in the middle of a file, and fixed the lint issues below that line in that file.