### PR TITLE
Fix complib breakpoints

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     ],
     rules: {
         '@typescript-eslint/array-type': 'off',
+        '@typescript-eslint/class-literal-property-style': 'off',
         '@typescript-eslint/consistent-type-assertions': 'off',
         '@typescript-eslint/explicit-function-return-type': 'off',
         '@typescript-eslint/explicit-member-accessibility': 'off',

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,7 +2,7 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "type": "node",
+      "type": "pwa-node",
       "request": "launch",
       "name": "Run Roku Sample Project",
       "skipFiles": [
@@ -10,7 +10,6 @@
       ],
       "program": "${workspaceFolder}/dist/index.js",
       "preLaunchTask": "tsc: build - tsconfig.json",
-      "protocol": "inspector",
       "internalConsoleOptions": "openOnSessionStart",
       "outFiles": [
         "${workspaceFolder}/dist/**/*.js"
@@ -18,7 +17,7 @@
     },
     {
       "name": "Debug Tests",
-      "type": "node",
+      "type": "pwa-node",
       "request": "launch",
       "smartStep": false,
       "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
@@ -32,7 +31,6 @@
         "500000"
       ],
       "cwd": "${workspaceRoot}",
-      "protocol": "inspector",
       "internalConsoleOptions": "openOnSessionStart"
     }
   ]

--- a/src/FileUtils.spec.ts
+++ b/src/FileUtils.spec.ts
@@ -261,4 +261,28 @@ describe('FileUtils', () => {
             expect(fileUtils.removeTrailingSlash('a')).to.equal('a');
         });
     });
+
+    describe('unPostfixFilePath', () => {
+        it('removes postfix from paths that contain it', () => {
+            expect(fileUtils.unPostfixFilePath(`source/main__lib1.brs`, '__lib1')).to.equal('source/main.brs');
+            expect(fileUtils.unPostfixFilePath(`components/component1__lib1.brs`, '__lib1')).to.equal('components/component1.brs');
+        });
+
+        it('removes postfix case insensitive', () => {
+            expect(fileUtils.unPostfixFilePath(`source/main__LIB1.brs`, '__lib1')).to.equal('source/main.brs');
+            expect(fileUtils.unPostfixFilePath(`source/MAIN__lib1.brs`, '__lib1')).to.equal('source/MAIN.brs');
+        });
+
+        it('does nothing to files without the postfix', () => {
+            expect(fileUtils.unPostfixFilePath(`source/main.brs`, '__lib1')).to.equal('source/main.brs');
+        });
+
+        it('does nothing to files with a different postfix', () => {
+            expect(fileUtils.unPostfixFilePath(`source/main__lib1.brs`, '__lib0')).to.equal('source/main__lib1.brs');
+        });
+
+        it('only removes the postfix from the end of the file', () => {
+            expect(fileUtils.unPostfixFilePath(`source/__lib1.brs/main.brs`, '__lib1')).to.equal('source/__lib1.brs/main.brs');
+        });
+    });
 });

--- a/src/FileUtils.ts
+++ b/src/FileUtils.ts
@@ -173,6 +173,33 @@ export class FileUtils {
     }
 
     /**
+     * Append a postfix to the filename BEFORE its file extension
+     */
+    public postfixFilePath(filePath: string, postfix: string, fileExtensions: string[]) {
+        let parsedPath = path.parse(filePath);
+
+        if (fileExtensions.includes(parsedPath.ext)) {
+            const regexp = new RegExp(parsedPath.ext + '$', 'i');
+            return filePath.replace(regexp, postfix + parsedPath.ext);
+        } else {
+            return filePath;
+        }
+    }
+
+    /**
+     * Given a file path, return a new path with the component library postfix removed
+     */
+    public unPostfixFilePath(filePath: string, postfix: string) {
+        let parts = path.parse(filePath);
+        const search = `${postfix}${parts.ext}`;
+        if (filePath.toLowerCase().endsWith(search.toLowerCase())) {
+            return fileUtils.replaceCaseInsensitive(filePath, search, parts.ext);
+        } else {
+            return filePath;
+        }
+    }
+
+    /**
      * Replace all directory separators with current OS separators,
      * force all drive letters to lower case (because that's what VSCode does sometimes so this makes it consistent)
      * @param thePath

--- a/src/managers/BreakpointManager.ts
+++ b/src/managers/BreakpointManager.ts
@@ -589,6 +589,8 @@ export class BreakpointManager {
                     for (const filePath in work) {
                         const fileWork = work[filePath];
                         for (const bp of fileWork) {
+                            bp.stagingFilePath = fileUtils.postfixFilePath(bp.stagingFilePath, project.postfix, ['.brs']);
+                            bp.pkgPath = fileUtils.postfixFilePath(bp.pkgPath, project.postfix, ['.brs']);
                             const key = [
                                 bp.stagingFilePath,
                                 bp.line,

--- a/src/managers/ProjectManager.spec.ts
+++ b/src/managers/ProjectManager.spec.ts
@@ -719,33 +719,4 @@ describe('ComponentLibraryProject', () => {
             });
         });
     });
-
-    describe('removeFileNamePostfix', () => {
-        let project: ComponentLibraryProject;
-        beforeEach(() => {
-            project = new ComponentLibraryProject(params);
-        });
-
-        it('removes postfix from paths that contain it', () => {
-            expect(project.removeFileNamePostfix(`source/main__lib0.brs`)).to.equal('source/main.brs');
-            expect(project.removeFileNamePostfix(`components/component1__lib0.brs`)).to.equal('components/component1.brs');
-        });
-
-        it('removes postfix case insensitive', () => {
-            expect(project.removeFileNamePostfix(`source/main__LIB0.brs`)).to.equal('source/main.brs');
-            expect(project.removeFileNamePostfix(`source/MAIN__lib0.brs`)).to.equal('source/MAIN.brs');
-        });
-
-        it('does nothing to files without the postfix', () => {
-            expect(project.removeFileNamePostfix(`source/main.brs`)).to.equal('source/main.brs');
-        });
-
-        it('does nothing to files with a different postfix', () => {
-            expect(project.removeFileNamePostfix(`source/main__lib1.brs`)).to.equal('source/main__lib1.brs');
-        });
-
-        it('only removes the postfix from the end of the file', () => {
-            expect(project.removeFileNamePostfix(`source/__lib1.brs/main.brs`)).to.equal('source/__lib1.brs/main.brs');
-        });
-    });
 });


### PR DESCRIPTION
Fixes a bug in the new dynamic breakpoint support over the debug protocol. 

Over telnet or the compile errors output, Roku truncates file paths after so many characters. In those situations, we can't determine if a file comes from a component library or the main pkg. To get around this, we append a `__lib0`, `__lib1`, etc to the end of every component library filename (based on which component library it's a member of) so we can map them back to the correct lib. The latest release forgot to take those paths into consideration.

So, for example, we're setting a breakpoint in
`core/components/Scene/MainScene.brs`
when it should actually be
`core/components/Scene/MainScene__lib0.brs`

This PR fixes that by properly accounting for complib file postfixes when sending breakpoints to the device.