### PR TITLE
Add support for case-sensitivity in getVariables protocol request

### DIFF
--- a/src/adapters/DebugProtocolAdapter.ts
+++ b/src/adapters/DebugProtocolAdapter.ts
@@ -211,7 +211,7 @@ export class DebugProtocolAdapter {
                 // TODO: Update once we know the exact version of the debug protocol this issue was fixed in.
                 // Due to casing issues with variables on protocol version <FUTURE_VERSION> and under we first need to try the request in the supplied case.
                 // If that fails we retry in lower case.
-                this.enableVariablesLowerCaseRetry = semver.satisfies(this.activeProtocolVersion, '*');
+                this.enableVariablesLowerCaseRetry = semver.satisfies(this.activeProtocolVersion, '<3.1.0');
                 // While execute was added as a command in 2.1.0. It has shortcoming that prevented us for leveraging the command.
                 // This was mostly addressed in the 3.0.0 release to the point where we were comfortable adding support for the command.
                 this.supportsExecuteCommand = semver.satisfies(this.activeProtocolVersion, '>=3.0.0');
@@ -477,6 +477,7 @@ export class DebugProtocolAdapter {
             variablePath = expression === '' ? [] : util.getVariablePath(expression?.toLowerCase());
             response = await this.socketDebugger.getVariables(variablePath, withChildren, frame.frameIndex, frame.threadIndex);
         }
+
 
         if (response.errorCode === ERROR_CODES.OK) {
             let mainContainer: EvaluateContainer;

--- a/src/debugProtocol/Constants.ts
+++ b/src/debugProtocol/Constants.ts
@@ -51,13 +51,42 @@ export enum UPDATE_TYPES {
     THREAD_ATTACHED = 3
 }
 
+export enum VARIABLE_REQUEST_FLAGS {
+    GET_CHILD_KEYS = 0x01,
+    CASE_SENSITIVITY_OPTIONS = 0x02
+}
+
 export enum VARIABLE_FLAGS {
+    /**
+     * value is a child of the requested variable
+     * e.g., an element of an array or field of an AA
+     */
     isChildKey = 0x01,
+    /**
+     * value is constant
+     */
     isConst = 0x02,
+    /**
+     * The referenced value is a container (e.g., a list or array)
+     */
     isContainer = 0x04,
+    /**
+     * The name is included in this VariableInfo
+     */
     isNameHere = 0x08,
+    /**
+     * value is reference-counted.
+     */
     isRefCounted = 0x10,
-    isValueHere = 0x20
+    /**
+     * value is included in this VariableInfo
+     */
+    isValueHere = 0x20,
+    /**
+     * Value is container, key lookup is case sensitive
+     * @since protocol 3.1.0
+     */
+    isKeysCaseSensitive = 0x40
 }
 
 export enum VARIABLE_TYPES {

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -268,18 +268,18 @@ describe('Util', () => {
             expect(util.getVariablePath('a[0]')).to.eql(['a', '0']);
             expect(util.getVariablePath('a[0].b')).to.eql(['a', '0', 'b']);
             expect(util.getVariablePath('a[0].b[0]')).to.eql(['a', '0', 'b', '0']);
-            expect(util.getVariablePath('a["b"]')).to.eql(['a', 'b']);
-            expect(util.getVariablePath('a["b"]["c"]')).to.eql(['a', 'b', 'c']);
-            expect(util.getVariablePath('a["b"][0]')).to.eql(['a', 'b', '0']);
-            expect(util.getVariablePath('a["b"].c[0]')).to.eql(['a', 'b', 'c', '0']);
-            expect(util.getVariablePath(`m_that["this -that.thing"]  .other[9]`)).to.eql(['m_that', 'this -that.thing', 'other', '9']);
+            expect(util.getVariablePath('a["b"]')).to.eql(['a', '"b"']);
+            expect(util.getVariablePath('a["b"]["c"]')).to.eql(['a', '"b"', '"c"']);
+            expect(util.getVariablePath('a["b"][0]')).to.eql(['a', '"b"', '0']);
+            expect(util.getVariablePath('a["b"].c[0]')).to.eql(['a', '"b"', 'c', '0']);
+            expect(util.getVariablePath(`m_that["this -that.thing"]  .other[9]`)).to.eql(['m_that', '"this -that.thing"', 'other', '9']);
             expect(util.getVariablePath(`a`)).to.eql(['a']);
             expect(util.getVariablePath(`boy5`)).to.eql(['boy5']);
             expect(util.getVariablePath(`super_man$`)).to.eql(['super_man$']);
             expect(util.getVariablePath(`_super_man$`)).to.eql(['_super_man$']);
-            expect(util.getVariablePath(`a["something with a quote"].c`)).to.eql(['a', 'something with a quote', 'c']);
+            expect(util.getVariablePath(`a["something with a quote"].c`)).to.eql(['a', '"something with a quote"', 'c']);
             expect(util.getVariablePath(`m.global.initialInputEvent`)).to.eql(['m', 'global', 'initialInputEvent']);
-            expect(util.getVariablePath(`m.["that"]`)).to.eql(['m', 'that']);
+            expect(util.getVariablePath(`m.["that"]`)).to.eql(['m', '"that"']);
         });
 
         it('rejects invalid patterns', () => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -308,8 +308,7 @@ class Util {
             } else if (isIndexedGetExpression(value)) {
                 if (isLiteralExpression(value.index)) {
                     parts.unshift(
-                        //remove leading and trailing quotes (won't hurt for numeric literals)
-                        value.index.token.text?.replace(/^"/, '').replace(/"$/, '')
+                        value.index.token.text
                     );
                 } else {
                     //if we found a non-literal value, this entire variable path is NOT a true variable path


### PR DESCRIPTION
Addds case sensitivity support in the `getVariables` debug protocol request. 

This is a backwards-compatible change since we check the protocol version when deciding how to proceed.

I even added some unit tests!