### PR TITLE
Support complib breakpoints on 11.5.0

### DIFF
--- a/src/adapters/DebugProtocolAdapter.ts
+++ b/src/adapters/DebugProtocolAdapter.ts
@@ -689,7 +689,8 @@ export class DebugProtocolAdapter {
                     filePath: breakpoint.pkgPath,
                     lineNumber: breakpoint.line,
                     hitCount: !isNaN(hitCount) ? hitCount : undefined,
-                    key: breakpoint.hash
+                    key: breakpoint.hash,
+                    componentLibraryName: breakpoint.componentLibraryName
                 };
             });
 

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -1066,7 +1066,8 @@ export class BrightScriptDebugSession extends BaseDebugSession {
             this.clearState();
             const event: StoppedEvent = new StoppedEvent(
                 StoppedEventReason.breakpoint,
-                activeThread.threadId,
+                //Not sure why, but sometimes there is no active thread. Just pick thread 0 to prevent the app from totally crashing
+                activeThread?.threadId ?? 0,
                 '' //exception text
             );
             // Socket debugger will always stop all threads and supports multi thread inspection.

--- a/src/managers/BreakpointManager.ts
+++ b/src/managers/BreakpointManager.ts
@@ -4,7 +4,7 @@ import type { CodeWithSourceMap } from 'source-map';
 import { SourceNode } from 'source-map';
 import type { DebugProtocol } from 'vscode-debugprotocol';
 import { fileUtils, standardizePath } from '../FileUtils';
-import type { Project } from './ProjectManager';
+import type { ComponentLibraryProject, Project } from './ProjectManager';
 import { standardizePath as s } from 'roku-deploy';
 import type { SourceMapManager } from './SourceMapManager';
 import type { LocationManager } from './LocationManager';
@@ -280,7 +280,8 @@ export class BreakpointManager {
                         column: stagingLocation.columnIndex,
                         stagingFilePath: stagingLocation.filePath,
                         type: stagingLocationsResult.type,
-                        pkgPath: pkgPath
+                        pkgPath: pkgPath,
+                        componentLibraryName: (project as ComponentLibraryProject).name
                     };
                     if (!result[stagingLocation.filePath]) {
                         result[stagingLocation.filePath] = [];
@@ -720,6 +721,10 @@ export interface BreakpointWorkItem {
      * If set, this breakpoint will emit a log message at runtime and will not actually stop at the breakpoint
      */
     logMessage?: string;
+    /**
+     * The name of the component library this belongs to. Will be null for the main project
+     */
+    componentLibraryName?: string;
     /**
      * `sourceMap` means derived from a source map.
      * `fileMap` means derived from the {src;dest} entry used by roku-deploy

--- a/src/managers/ProjectManager.spec.ts
+++ b/src/managers/ProjectManager.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import * as fsExtra from 'fs-extra';
 import * as path from 'path';
+import { util } from '../util';
 import { rokuDeploy } from 'roku-deploy';
 import * as sinonActual from 'sinon';
 import { fileUtils, standardizePath as s } from '../FileUtils';
@@ -676,6 +677,7 @@ describe('ComponentLibraryProject', () => {
                 { src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }
             ]));
             sinon.stub(Project.prototype, 'stage').returns(Promise.resolve());
+            sinon.stub(util, 'convertManifestToObject').returns(Promise.resolve({}));
 
             await project.stage();
             expect(project.fileMappings[0]).to.eql({

--- a/src/util.ts
+++ b/src/util.ts
@@ -92,6 +92,8 @@ class Util {
                 let match = /(\w+)=(.+)/.exec(line);
                 if (match) {
                     manifestValues[match[1]] = match[2];
+                    //add match in all lower case too (for consistency)
+                    manifestValues[match[1]?.toLowerCase()] = match[2];
                 }
             }
 


### PR DESCRIPTION
Add support for complib-specific paths during breakpoint setting. 


- `"pkg:/<filepath>"` specifies a file in the channel,
- `"lib:/<library_name>/<filepath>"` specifies a file in a library
