### PR TITLE
Add `invalid` data type support

### DIFF
--- a/src/debugProtocol/responses/VariableResponse.spec.ts
+++ b/src/debugProtocol/responses/VariableResponse.spec.ts
@@ -1,0 +1,58 @@
+/* eslint-disable no-bitwise */
+import { VariableResponse } from './VariableResponse';
+import { createVariableResponse } from './responseCreationHelpers.spec';
+import { expect } from 'chai';
+import { ERROR_CODES, VARIABLE_FLAGS, VARIABLE_TYPES } from '../Constants';
+
+describe('VariableResponse', () => {
+
+    it('Properly parses invalid variable', () => {
+        let buffer = createVariableResponse({
+            requestId: 2,
+            errorCode: ERROR_CODES.OK,
+            variables: [{
+                name: 'person',
+                refCount: 2,
+                isConst: false,
+                variableType: VARIABLE_TYPES.AA,
+                keyType: VARIABLE_TYPES.String,
+                value: undefined,
+                children: [{
+                    name: 'firstName',
+                    refCount: 1,
+                    value: 'Bob',
+                    variableType: VARIABLE_TYPES.String,
+                    isConst: false
+                }, {
+                    name: 'lastName',
+                    refCount: 1,
+                    value: undefined,
+                    variableType: VARIABLE_TYPES.Invalid,
+                    isConst: false
+                }]
+            }],
+            includePacketLength: false
+        });
+
+        let response = new VariableResponse(buffer.toBuffer());
+        expect(
+            response.variables?.map(x => ({
+                name: x.name,
+                value: x.value,
+                isContainer: x.isContainer
+            }))
+        ).to.eql([{
+            name: 'person',
+            value: null,
+            isContainer: true
+        }, {
+            name: 'firstName',
+            value: 'Bob',
+            isContainer: false
+        }, {
+            name: 'lastName',
+            value: 'Invalid',
+            isContainer: false
+        }]);
+    });
+});

--- a/src/debugProtocol/responses/VariableResponse.ts
+++ b/src/debugProtocol/responses/VariableResponse.ts
@@ -127,8 +127,13 @@ export class VariableInfo {
                     this.value = 'Unknown';
                     this.success = true;
                     break;
+                case 'Invalid':
+                    this.value = 'Invalid';
+                    this.success = true;
+                    break;
                 case 'AA':
                 case 'Array':
+                case 'List':
                     this.value = null;
                     this.success = true;
                     break;


### PR DESCRIPTION
- Fixes bug in `VariableResponse` that was incorrectly skipping all object properties with a value of `invalid`
- don't hide `list` variables
- adds baseline VariableResponse test function
