### PR TITLE
Fix stopOnEntry bug with deep links.

### DIFF
--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -379,9 +379,11 @@ export class BrightScriptDebugSession extends BaseDebugSession {
             await this.rokuAdapter.continue();
             //kill the app on the roku
             await this.rokuDeploy.pressHomeButton(this.launchConfiguration.host, this.launchConfiguration.remotePort);
+            //convert a hostname to an ip address
+            const deepLinkUrl = await util.resolveUrl(this.launchConfiguration.deepLinkUrl);
             //send the deep link http request
             await new Promise((resolve, reject) => {
-                request.post(this.launchConfiguration.deepLinkUrl, (err, response) => {
+                request.post(deepLinkUrl, (err, response) => {
                     return err ? reject(err) : resolve(response);
                 });
             });
@@ -1184,7 +1186,7 @@ export class BrightScriptDebugSession extends BaseDebugSession {
     public async handleEntryBreakpoint() {
         if (!this.enableDebugProtocol) {
             this.entryBreakpointWasHandled = true;
-            if (this.launchConfiguration.stopOnEntry) {
+            if (this.launchConfiguration.stopOnEntry || this.launchConfiguration.deepLinkUrl) {
                 await this.projectManager.registerEntryBreakpoint(this.projectManager.mainProject.stagingFolderPath);
             }
         }

--- a/src/util.ts
+++ b/src/util.ts
@@ -324,6 +324,19 @@ class Util {
         }
     }
 
+    /**
+     * Given a full URL, convert any dns name into its IP address and then return the full URL with the name replaced
+     */
+    public async resolveUrl(url: string, skipCache = false) {
+        //https://regex101.com/r/cSkoTx/1
+        const [, protocol, host] = /^((?:http[s]?|ftp):\/\/)?([^:\/\s]+)(:\d+)?([^?#]+)?(\?[^#]+)?(#.*)?$/.exec(url) ?? [];
+        if (host) {
+            const ipAddress = await this.dnsLookup(host);
+            url = protocol + ipAddress + url.substring(protocol.length + host.length);
+        }
+        return url;
+    }
+
     /*
      * Look up the ip address for a hostname. This is cached for the lifetime of the app, or bypassed with the `skipCache` parameter
      * @param host


### PR DESCRIPTION
Fixes #101 by always enabling `stopOnEntry` when the `deepLinkUrl` is provided.

Also fixes DNS resolving for deep links so you can use hostnames in deep link urls