### PR TITLE
Better debug protocol launch handling

### DIFF
--- a/src/debugProtocol/Debugger.ts
+++ b/src/debugProtocol/Debugger.ts
@@ -146,7 +146,7 @@ export class Debugger {
                 const socket = new Net.Socket();
                 pendingSockets.add(socket);
                 socket.on('error', (error) => {
-                    console.info(Date.now(), 'Encountered an error connecting to the debug protocol socket. Ignoring and will try again soon', error);
+                    console.debug(Date.now(), 'Encountered an error connecting to the debug protocol socket. Ignoring and will try again soon', error);
                 });
                 socket.connect({ port: this.options.controllerPort, host: this.options.host }, () => {
                     cancelInterval();
@@ -182,13 +182,13 @@ export class Debugger {
                 this.unhandledData = buffer;
             }
 
-            this.logger.info(`on('data'): incoming bytes`, buffer.length);
+            this.logger.debug(`on('data'): incoming bytes`, buffer.length);
             const startBufferSize = this.unhandledData.length;
 
             this.parseUnhandledData(this.unhandledData);
 
             const endBufferSize = this.unhandledData?.length ?? 0;
-            this.logger.info(`buffer size before:`, startBufferSize, ', buffer size after:', endBufferSize, ', bytes consumed:', startBufferSize - endBufferSize);
+            this.logger.debug(`buffer size before:`, startBufferSize, ', buffer size after:', endBufferSize, ', bytes consumed:', startBufferSize - endBufferSize);
         });
 
         this.controllerClient.on('end', () => {


### PR DESCRIPTION
Fixes some stability issues when interacting with the debug protocol.

The previous code assumed that we would always get the handshake response first, then the IO_PORT_OPENED update next, and _then_ the rest of the debug protocol was active. However, this is incorrect. The IO_PORT_OPENED could happen at any point throughout the debug session, and should not be assumed to open at the start. 

This code properly decouples the IO_PORT_OPENED from the startup logic. now the IO port can be opened at any point, and the connection is considered "open" the moment the handshake is complete. 