### PR TITLE
Fix crash in rendezvous parser for missing files

### DIFF
--- a/src/RendezvousTracker.spec.ts
+++ b/src/RendezvousTracker.spec.ts
@@ -286,6 +286,18 @@ describe('BrightScriptFileUtils ', () => {
                 await rendezvousTracker.processLog(text)
             ).to.eql(text);
         });
+
+        it('does not crash for files not found by the source locator', async () => {
+            //return undefined for all sources requested
+            rendezvousTracker.registerSourceLocator(() => {
+                return undefined;
+            });
+            expect(
+                (await rendezvousTracker.processLog(`10-16 01:42:27.126 [sg.node.BLOCK] Rendezvous[2442] at roku_ads_lib:/libsource/Roku_Ads_SG_Wrappers.brs(1262)\r\n`
+                )).trim()
+            ).to.eql('');
+            //the test passes if it doesn't explode on the file path
+        });
     });
 
     describe('clearHistory', () => {

--- a/src/RendezvousTracker.ts
+++ b/src/RendezvousTracker.ts
@@ -90,7 +90,7 @@ export class RendezvousTracker {
                     // detected the completion of a rendezvous event
                     dataChanged = true;
                     let blockInfo = this.rendezvousBlocks[id];
-                    let clientLineNumber: string = this.clientPathsMap[blockInfo.fileName].clientLines[blockInfo.lineNumber].toString();
+                    let clientLineNumber: string = this.clientPathsMap[blockInfo.fileName]?.clientLines[blockInfo.lineNumber].toString() ?? blockInfo.lineNumber;
 
                     if (this.rendezvousHistory.occurrences[blockInfo.fileName]) {
                         // file is in history
@@ -189,13 +189,15 @@ export class RendezvousTracker {
                 }
             }
             let sourceLocation = await this.getSourceLocation(fileName, lineNumber);
-            this.clientPathsMap[fileName] = {
-                clientPath: sourceLocation.filePath,
-                clientLines: {
-                    //TODO - should the line be 1 or 0 based?
-                    [lineNumber]: sourceLocation.lineNumber
-                }
-            };
+            if (sourceLocation) {
+                this.clientPathsMap[fileName] = {
+                    clientPath: sourceLocation.filePath,
+                    clientLines: {
+                        //TODO - should the line be 1 or 0 based?
+                        [lineNumber]: sourceLocation.lineNumber
+                    }
+                };
+            }
         } else if (!this.clientPathsMap[fileName].clientLines[lineNumber]) {
             // Add new client line to clint path map
             this.clientPathsMap[fileName].clientLines[lineNumber] = (await this.getSourceLocation(fileName, lineNumber)).lineNumber;
@@ -226,7 +228,7 @@ export class RendezvousTracker {
     private createLineObject(fileName: string, lineNumber: number, duration?: string): RendezvousLineInfo {
         return {
             clientLineNumber: lineNumber,
-            clientPath: this.clientPathsMap[fileName].clientPath,
+            clientPath: this.clientPathsMap[fileName]?.clientPath ?? fileName,
             hitCount: 1,
             totalTime: this.getTime(duration),
             type: 'lineInfo'


### PR DESCRIPTION
Fixes a bug in the rendezvous parser that would crash anytime a file was received that we couldn't find the source code for. 

![image](https://user-images.githubusercontent.com/2544493/196014893-cb68a856-febf-41ca-a8c9-dcb3449206c1.png)
