### PR TITLE
Bugfix/do not alter out file path for libraries

### DIFF
--- a/src/managers/ProjectManager.spec.ts
+++ b/src/managers/ProjectManager.spec.ts
@@ -667,8 +667,8 @@ describe('ComponentLibraryProject', () => {
         });
     });
 
-    describe('postfixFiles', () => {
-        it('skips "common:/" paths', async () => {
+    describe('addPostFixToPath', () => {
+        it('adds postfix if path is 1) pkg:/ or 2) relative - no spaces in url', async () => {
             let project = new ComponentLibraryProject(params);
             project.fileMappings = [];
             fsExtra.outputFileSync(`${params.stagingFolderPath}/source/main.brs`, '');
@@ -687,6 +687,29 @@ describe('ComponentLibraryProject', () => {
                     <script type="text/brightscript" uri="common:/LibCore/v30/bslCore.brs"/>
                     <script type="text/brightscript" uri="CustomComponent__lib0.brs"/>
                     <script type="text/brightscript" uri="pkg:/source/utils__lib0.brs"/>
+                </component>
+            `);
+        });
+    
+        it('adds postfix if path is 1) pkg:/ or 2) relative - plus spaces in url', async () => {
+            let project = new ComponentLibraryProject(params);
+            project.fileMappings = [];
+            fsExtra.outputFileSync(`${params.stagingFolderPath}/source/main.brs`, '');
+            fsExtra.outputFileSync(`${params.stagingFolderPath}/components/Component1.xml`, `
+                <component name="CustomComponent" extends="Rectangle">
+                    <script type="text/brightscript" uri = "common:/LibCore/v30/bslCore.brs"/>
+                    <script type="text/brightscript" uri = "CustomComponent.brs"/>
+                    <script type="text/brightscript" uri = "pkg:/source/utils.brs"/>
+                </component>
+            `);
+            await project.postfixFiles();
+            expect(
+                fsExtra.readFileSync(`${params.stagingFolderPath}/components/Component1.xml`).toString()
+            ).to.eql(`
+                <component name="CustomComponent" extends="Rectangle">
+                    <script type="text/brightscript" uri = "common:/LibCore/v30/bslCore.brs"/>
+                    <script type="text/brightscript" uri = "CustomComponent__lib0.brs"/>
+                    <script type="text/brightscript" uri = "pkg:/source/utils__lib0.brs"/>
                 </component>
             `);
         });

--- a/src/managers/ProjectManager.spec.ts
+++ b/src/managers/ProjectManager.spec.ts
@@ -667,6 +667,31 @@ describe('ComponentLibraryProject', () => {
         });
     });
 
+    describe('postfixFiles', () => {
+        it('skips "common:/" paths', async () => {
+            let project = new ComponentLibraryProject(params);
+            project.fileMappings = [];
+            fsExtra.outputFileSync(`${params.stagingFolderPath}/source/main.brs`, '');
+            fsExtra.outputFileSync(`${params.stagingFolderPath}/components/Component1.xml`, `
+                <component name="CustomComponent" extends="Rectangle">
+                    <script type="text/brightscript" uri="common:/LibCore/v30/bslCore.brs"/>
+                    <script type="text/brightscript" uri="CustomComponent.brs"/>
+                    <script type="text/brightscript" uri="pkg:/source/utils.brs"/>
+                </component>
+            `);
+            await project.postfixFiles();
+            expect(
+                fsExtra.readFileSync(`${params.stagingFolderPath}/components/Component1.xml`).toString()
+            ).to.eql(`
+                <component name="CustomComponent" extends="Rectangle">
+                    <script type="text/brightscript" uri="common:/LibCore/v30/bslCore.brs"/>
+                    <script type="text/brightscript" uri="CustomComponent__lib0.brs"/>
+                    <script type="text/brightscript" uri="pkg:/source/utils__lib0.brs"/>
+                </component>
+            `);
+        });
+    });
+
     describe('stage', () => {
         it('computes stagingFolderPath before calling getFileMappings', async () => {
             delete params.stagingFolderPath;

--- a/src/managers/ProjectManager.spec.ts
+++ b/src/managers/ProjectManager.spec.ts
@@ -690,7 +690,7 @@ describe('ComponentLibraryProject', () => {
                 </component>
             `);
         });
-    
+
         it('adds postfix if path is 1) pkg:/ or 2) relative - plus spaces in url', async () => {
             let project = new ComponentLibraryProject(params);
             project.fileMappings = [];

--- a/src/managers/ProjectManager.ts
+++ b/src/managers/ProjectManager.ts
@@ -601,12 +601,19 @@ export class ComponentLibraryProject extends Project {
             ],
             from: /uri\s*=\s*"(.+)\.brs"/gi,
             to: (match) => {
-
-                // do not alter file ending if it's an external library eg with a common:/ file path
-                if (match.toLowerCase().startsWith('uri="common:/')) {
-                    return match;
-                } else {
+                // only alter file ending if it is a) pkg:/ url or b) relative url 
+                let isPkgUrl = false
+                let isRelativeUrl = false                
+                if (/^uri\s*=\s*"pkg:\//i.exec(match)) {
+                    isPkgUrl = true
+                }
+                if (!(/:\//i.exec(match))) {
+                    isRelativeUrl = true 
+                }
+                if (isPkgUrl || isRelativeUrl){
                     return match.replace('.brs', this.postfix + '.brs');
+                } else {
+                    return match;
                 }
             }
         });

--- a/src/managers/ProjectManager.ts
+++ b/src/managers/ProjectManager.ts
@@ -601,7 +601,19 @@ export class ComponentLibraryProject extends Project {
             ],
             from: /uri\s*=\s*"(.+)\.brs"/gi,
             to: (match) => {
-                return match.replace('.brs', this.postfix + '.brs');
+
+                // do not alter file ending if it's an external library eg with a common:/ file path
+                let fileMatch = true;
+                if (match.includes('common:/')) {
+                    fileMatch = false;
+                }
+
+                if (fileMatch) {
+                    return match.replace('.brs', this.postfix + '.brs');
+                } else {
+
+                    return match
+                }
             }
         });
     }

--- a/src/managers/ProjectManager.ts
+++ b/src/managers/ProjectManager.ts
@@ -603,7 +603,7 @@ export class ComponentLibraryProject extends Project {
             to: (match) => {
 
                 // do not alter file ending if it's an external library eg with a common:/ file path
-                if (match.startsWith('uri="common:/')) {
+                if (match.toLowerCase().startsWith('uri="common:/')) {
                     return match;
                 } else {
                     return match.replace('.brs', this.postfix + '.brs');

--- a/src/managers/ProjectManager.ts
+++ b/src/managers/ProjectManager.ts
@@ -600,17 +600,11 @@ export class ComponentLibraryProject extends Project {
                 path.join(this.stagingFolderPath, '**/*.brs')
             ],
             from: /uri\s*=\s*"(.+)\.brs"/gi,
-            to: (match) => {
-                // only alter file ending if it is a) pkg:/ url or b) relative url 
-                let isPkgUrl = false
-                let isRelativeUrl = false                
-                if (/^uri\s*=\s*"pkg:\//i.exec(match)) {
-                    isPkgUrl = true
-                }
-                if (!(/:\//i.exec(match))) {
-                    isRelativeUrl = true 
-                }
-                if (isPkgUrl || isRelativeUrl){
+            to: (match: string) => {
+                // only alter file ending if it is a) pkg:/ url or b) relative url
+                let isPkgUrl = !!/^uri\s*=\s*"pkg:\//i.exec(match);
+                let isRelativeUrl = !/:\//i.exec(match);
+                if (isPkgUrl || isRelativeUrl) {
                     return match.replace('.brs', this.postfix + '.brs');
                 } else {
                     return match;

--- a/src/managers/ProjectManager.ts
+++ b/src/managers/ProjectManager.ts
@@ -603,16 +603,10 @@ export class ComponentLibraryProject extends Project {
             to: (match) => {
 
                 // do not alter file ending if it's an external library eg with a common:/ file path
-                let fileMatch = true;
-                if (match.includes('common:/')) {
-                    fileMatch = false;
-                }
-
-                if (fileMatch) {
-                    return match.replace('.brs', this.postfix + '.brs');
+                if (match.startsWith('uri="common:/')) {
+                    return match;
                 } else {
-
-                    return match
+                    return match.replace('.brs', this.postfix + '.brs');
                 }
             }
         });


### PR DESCRIPTION
Regarding issue 106 https://github.com/rokucommunity/roku-debug/issues/106 I am creating a pull request.

This

1) does not alter the file path for library paths specified in XML script tags eg

```
<script type="text/brightscript" uri="common:/LibCore/v30/bslCore.brs"/>
```

these paths are not altered when generating the 'out' directory.

Normal files are altered by appending a '__lib0' (or similar) to the end.

2) create a test to verify that the above code is working.
