### PR TITLE
Fix issue with truncated debugger paths

### DIFF
--- a/src/FileUtils.spec.ts
+++ b/src/FileUtils.spec.ts
@@ -37,6 +37,14 @@ describe('FileUtils', () => {
         it('removes leading ... when present', () => {
             expect(fileUtils.removeFileTruncation('...project1/main.brs')).to.equal('project1/main.brs');
         });
+
+        it('removes leading .../', () => {
+            expect(fileUtils.removeFileTruncation('.../project1/main.brs')).to.equal('project1/main.brs');
+        });
+
+        it('removes leading /', () => {
+            expect(fileUtils.removeFileTruncation('/project1/main.brs')).to.equal('project1/main.brs');
+        });
     });
 
     describe('pathEndsWith', () => {

--- a/src/FileUtils.ts
+++ b/src/FileUtils.ts
@@ -99,11 +99,12 @@ export class FileUtils {
     }
 
     /**
-     * The Roku telnet debugger truncates file paths, so this removes that truncation piece.
+     * The Roku telnet debugger truncates file paths, so this removes that leading truncation piece.
+     * This removes 0 or more leading dots, followed by 0 or more leading slashes
      * @param filePath
      */
     public removeFileTruncation(filePath: string) {
-        return filePath.startsWith('...') ? filePath.substring(3) : filePath;
+        return filePath.replace(/^\.*[\/\\]*/, '');
     }
 
     /**


### PR DESCRIPTION
Fixes an issue with truncated debugger paths that started with exactly 3 dots and a slash (i.e. `.../`)