### PR TITLE
Fix off-by-1 bug with threads over protocol

### DIFF
--- a/src/adapters/DebugProtocolAdapter.ts
+++ b/src/adapters/DebugProtocolAdapter.ts
@@ -601,7 +601,7 @@ export class DebugProtocolAdapter {
                     // isSelected: threadInfo.isPrimary,
                     filePath: threadInfo.fileName,
                     functionName: threadInfo.functionName,
-                    lineNumber: threadInfo.lineNumber + 1, //protocol is 0-based but 1-based is expected
+                    lineNumber: threadInfo.lineNumber + 1, //protocol is 1-based
                     lineContents: threadInfo.codeSnippet,
                     threadId: i
                 };


### PR DESCRIPTION
Fix a bug in the debug protocol where the wrong line numbers were being reported for the threads response. We had incorrectly assumed that the protocol reported 0-based line numbers, when in fact they are 1-based. 