### PR TITLE
Increase the timeout for debug protocol control

### DIFF
--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -416,7 +416,7 @@ export class BrightScriptDebugSession extends BaseDebugSession {
         //if it hasn't connected after 5 seconds, it probably will never connect.
         await Promise.race([
             connectPromise,
-            util.sleep(5000)
+            util.sleep(10000)
         ]);
         this.logger.log('Finished racing promises');
         //if the adapter is still not connected, then it will probably never connect. Abort.


### PR DESCRIPTION
For larger apps, it takes longer than 5 seconds to finish parsing and compiling the app. We need to increase our timeout as well. Ideally this would be configurable, but in the short term, just double the timeout length. 