### PR TITLE
Discard breakpoints that got deleted before verified

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       - run: npm run build
       - run: npm run lint
       - run: npm run test
-      - run: npm run publish-coverage
+      #- run: npm run publish-coverage
   npm-release:
     #only run this task if a tag starting with 'v' was used to trigger this (i.e. a tagged release)
     if: startsWith(github.ref, 'refs/tags/v')

--- a/src/adapters/DebugProtocolAdapter.ts
+++ b/src/adapters/DebugProtocolAdapter.ts
@@ -294,6 +294,7 @@ export class DebugProtocolAdapter {
                 }
                 //if there were any unsuccessful breakpoint verifications, we need to ask the device to delete those breakpoints as they've gone missing on our side
                 if (unverifiableDeviceIds.length > 0) {
+                    this.logger.warn('Could not find breakpoints to verify. Removing from device:', { deviceBreakpointIds: unverifiableDeviceIds });
                     void this.socketDebugger.removeBreakpoints(unverifiableDeviceIds);
                 }
                 this.emit('breakpoints-verified', event);

--- a/src/adapters/DebugProtocolAdapter.ts
+++ b/src/adapters/DebugProtocolAdapter.ts
@@ -283,9 +283,18 @@ export class DebugProtocolAdapter {
 
             //handle when the device verifies breakpoints
             this.socketDebugger.on('breakpoints-verified', (event) => {
+                let unverifiableDeviceIds = [] as number[];
+
                 //mark the breakpoints as verified
                 for (let breakpoint of event?.breakpoints ?? []) {
-                    this.breakpointManager.verifyBreakpoint(breakpoint.id, true);
+                    const success = this.breakpointManager.verifyBreakpoint(breakpoint.id, true);
+                    if (!success) {
+                        unverifiableDeviceIds.push(breakpoint.id);
+                    }
+                }
+                //if there were any unsuccessful breakpoint verifications, we need to ask the device to delete those breakpoints as they've gone missing on our side
+                if (unverifiableDeviceIds.length > 0) {
+                    void this.socketDebugger.removeBreakpoints(unverifiableDeviceIds);
                 }
                 this.emit('breakpoints-verified', event);
             });

--- a/src/debugProtocol/PluginInterface.ts
+++ b/src/debugProtocol/PluginInterface.ts
@@ -28,6 +28,8 @@ export default class PluginInterface<TPlugin> {
 
     /**
      * Add a plugin to the end of the list of plugins
+     * @param plugin the plugin
+     * @param priority the priority for the plugin. Lower number means higher priority. (ex: 1 executes before 5)
      */
     public add<T extends TPlugin = TPlugin>(plugin: T, priority = 1) {
         const container = {
@@ -42,6 +44,38 @@ export default class PluginInterface<TPlugin> {
         });
 
         return plugin;
+    }
+
+    /**
+     * Adds a temporary plugin with a single event hook, and resolve a promise with the event from the next occurance of that event.
+     * Once the event fires for the first time, the plugin is unregistered.
+     * @param eventName the name of the event to subscribe to
+     * @param priority the priority for this event. Lower number means higher priority. (ex: 1 executes before 5)
+     */
+    public once<TEventType>(eventName: keyof TPlugin, priority = 1): Promise<TEventType> {
+        return this.onceIf(eventName, () => true, priority);
+    }
+
+    /**
+     * Adds a temporary plugin with a single event hook, and resolve a promise with the event from the next occurance of that event.
+     * Once the event fires for the first time and the matcher evaluates to true, the plugin is unregistered.
+     * @param eventName the name of the event to subscribe to
+     * @param matcher a function to call that, when true, will deregister this hander and return the event
+     * @param priority the priority for this event. Lower number means higher priority. (ex: 1 executes before 5)
+     */
+    public onceIf<TEventType>(eventName: keyof TPlugin, matcher: (TEventType) => boolean, priority = 1): Promise<TEventType> {
+        return new Promise((resolve) => {
+            const tempPlugin = {} as any;
+            tempPlugin[eventName] = (event) => {
+                if (matcher(event)) {
+                    //remove the temp plugin
+                    this.remove(tempPlugin);
+                    //resolve the promise with this event
+                    resolve(event);
+                }
+            };
+            this.add(tempPlugin, priority);
+        }) as any;
     }
 
     /**

--- a/src/debugProtocol/client/DebugProtocolClientPlugin.ts
+++ b/src/debugProtocol/client/DebugProtocolClientPlugin.ts
@@ -31,11 +31,11 @@ export interface ProvideResponseOrUpdateEvent {
     responseOrUpdate?: ProtocolResponse | ProtocolUpdate;
 }
 
-export interface BeforeSendRequestEvent {
+export interface BeforeSendRequestEvent<TRequest extends ProtocolRequest = ProtocolRequest> {
     client: DebugProtocolClient;
-    request: ProtocolRequest;
+    request: TRequest;
 }
-export type AfterSendRequestEvent = BeforeSendRequestEvent;
+export type AfterSendRequestEvent<TRequest extends ProtocolRequest = ProtocolRequest> = BeforeSendRequestEvent<TRequest>;
 
 export interface OnUpdateEvent {
     client: DebugProtocolClient;

--- a/src/debugProtocol/server/DebugProtocolServerPlugin.ts
+++ b/src/debugProtocol/server/DebugProtocolServerPlugin.ts
@@ -1,13 +1,14 @@
 import type { DebugProtocolServer } from './DebugProtocolServer';
 import type { Socket } from 'net';
 import type { ProtocolRequest, ProtocolResponse } from '../events/ProtocolEvent';
+import { DebugProtocolServerTestPlugin } from '../DebugProtocolServerTestPlugin.spec';
 
 export interface ProtocolServerPlugin {
     onServerStart?: Handler<OnServerStartEvent>;
     onClientConnected?: Handler<OnClientConnectedEvent>;
 
     provideRequest?: Handler<ProvideRequestEvent>;
-    provideResponse: Handler<ProvideResponseEvent>;
+    provideResponse?: Handler<ProvideResponseEvent>;
 
     beforeSendResponse?: Handler<BeforeSendResponseEvent>;
     afterSendResponse?: Handler<AfterSendResponseEvent>;
@@ -46,4 +47,3 @@ export interface BeforeSendResponseEvent {
 export type AfterSendResponseEvent = BeforeSendResponseEvent;
 
 export type Handler<T, R = void> = (event: T) => R;
-

--- a/src/managers/BreakpointManager.ts
+++ b/src/managers/BreakpointManager.ts
@@ -188,8 +188,11 @@ export class BreakpointManager {
         if (breakpoint) {
             breakpoint.verified = isVerified;
             this.queueVerifyEvent(breakpoint.hash);
+            return true;
+        } else {
+            //couldn't find the breakpoint. return false so the caller can handle that properly
+            return false;
         }
-        //TODO handle the else case, (might be caused by timing issues?)
     }
 
     /**


### PR DESCRIPTION
Sometimes there are timing issues where breakpoints are sent to the device, then deleted _before_ the device sent back the "verified" event for those. That would cause "phantom" breakpoints where the device has the bp, but the client doesn't show it.