### PR TITLE
Exclude sourcemaps when sideloading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
             },
             "devDependencies": {
                 "@types/chai": "^4.2.22",
+                "@types/decompress": "^4.2.4",
                 "@types/dedent": "^0.7.0",
                 "@types/find-in-files": "^0.5.1",
                 "@types/fs-extra": "^9.0.13",
@@ -45,6 +46,7 @@
                 "@typescript-eslint/parser": "^5.2.0",
                 "chai": "^4.3.4",
                 "coveralls": "^3.1.1",
+                "decompress": "^4.2.1",
                 "dedent": "^0.7.0",
                 "eslint": "^8.1.0",
                 "eslint-plugin-no-only-tests": "^2.6.0",
@@ -646,6 +648,15 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@types/decompress": {
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/@types/decompress/-/decompress-4.2.4.tgz",
+            "integrity": "sha512-/C8kTMRTNiNuWGl5nEyKbPiMv6HA+0RbEXzFhFBEzASM6+oa4tJro9b8nj7eRlOFfuLdzUU+DS/GPDlvvzMOhA==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
         "node_modules/@types/dedent": {
             "version": "0.7.0",
             "dev": true,
@@ -1121,6 +1132,26 @@
             "version": "1.0.2",
             "license": "MIT"
         },
+        "node_modules/base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
+        },
         "node_modules/bcrypt-pbkdf": {
             "version": "1.0.2",
             "license": "BSD-3-Clause",
@@ -1133,6 +1164,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/bl": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+            "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
+            "dev": true,
+            "dependencies": {
+                "readable-stream": "^2.3.5",
+                "safe-buffer": "^5.1.1"
             }
         },
         "node_modules/bluebird": {
@@ -1401,6 +1442,61 @@
                 "url": "https://opencollective.com/browserslist"
             }
         },
+        "node_modules/buffer": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
+            }
+        },
+        "node_modules/buffer-alloc": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+            "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+            "dev": true,
+            "dependencies": {
+                "buffer-alloc-unsafe": "^1.1.0",
+                "buffer-fill": "^1.0.0"
+            }
+        },
+        "node_modules/buffer-alloc-unsafe": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+            "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+            "dev": true
+        },
+        "node_modules/buffer-crc32": {
+            "version": "0.2.13",
+            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+            "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+            "dev": true,
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/buffer-fill": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+            "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
+            "dev": true
+        },
         "node_modules/buffer-from": {
             "version": "1.1.2",
             "dev": true,
@@ -1575,6 +1671,12 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/commander": {
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+            "dev": true
+        },
         "node_modules/commondir": {
             "version": "1.0.1",
             "dev": true,
@@ -1687,6 +1789,150 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/decompress": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.1.tgz",
+            "integrity": "sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==",
+            "dev": true,
+            "dependencies": {
+                "decompress-tar": "^4.0.0",
+                "decompress-tarbz2": "^4.0.0",
+                "decompress-targz": "^4.0.0",
+                "decompress-unzip": "^4.0.1",
+                "graceful-fs": "^4.1.10",
+                "make-dir": "^1.0.0",
+                "pify": "^2.3.0",
+                "strip-dirs": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/decompress-tar": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
+            "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
+            "dev": true,
+            "dependencies": {
+                "file-type": "^5.2.0",
+                "is-stream": "^1.1.0",
+                "tar-stream": "^1.5.2"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/decompress-tar/node_modules/is-stream": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+            "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/decompress-tarbz2": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
+            "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
+            "dev": true,
+            "dependencies": {
+                "decompress-tar": "^4.1.0",
+                "file-type": "^6.1.0",
+                "is-stream": "^1.1.0",
+                "seek-bzip": "^1.0.5",
+                "unbzip2-stream": "^1.0.9"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/decompress-tarbz2/node_modules/file-type": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
+            "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/decompress-tarbz2/node_modules/is-stream": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+            "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/decompress-targz": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
+            "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
+            "dev": true,
+            "dependencies": {
+                "decompress-tar": "^4.1.1",
+                "file-type": "^5.2.0",
+                "is-stream": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/decompress-targz/node_modules/is-stream": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+            "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/decompress-unzip": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
+            "integrity": "sha512-1fqeluvxgnn86MOh66u8FjbtJpAFv5wgCT9Iw8rcBqQcCo5tO8eiJw7NNTrvt9n4CRBVq7CstiS922oPgyGLrw==",
+            "dev": true,
+            "dependencies": {
+                "file-type": "^3.8.0",
+                "get-stream": "^2.2.0",
+                "pify": "^2.3.0",
+                "yauzl": "^2.4.2"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/decompress-unzip/node_modules/file-type": {
+            "version": "3.9.0",
+            "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+            "integrity": "sha512-RLoqTXE8/vPmMuTI88DAzhMYC99I8BWv7zYP4A1puo5HIjEJ5EX48ighy4ZyKMG9EDXxBgW6e++cn7d1xuFghA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/decompress/node_modules/make-dir": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+            "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+            "dev": true,
+            "dependencies": {
+                "pify": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/decompress/node_modules/make-dir/node_modules/pify": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+            "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/dedent": {
             "version": "0.7.0",
             "dev": true,
@@ -1780,6 +2026,15 @@
         "node_modules/emoji-regex": {
             "version": "8.0.0",
             "license": "MIT"
+        },
+        "node_modules/end-of-stream": {
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+            "dev": true,
+            "dependencies": {
+                "once": "^1.4.0"
+            }
         },
         "node_modules/enquirer": {
             "version": "2.3.6",
@@ -2117,6 +2372,15 @@
                 "reusify": "^1.0.4"
             }
         },
+        "node_modules/fd-slicer": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+            "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+            "dev": true,
+            "dependencies": {
+                "pend": "~1.2.0"
+            }
+        },
         "node_modules/file-entry-cache": {
             "version": "6.0.1",
             "dev": true,
@@ -2126,6 +2390,15 @@
             },
             "engines": {
                 "node": "^10.12.0 || >=12.0.0"
+            }
+        },
+        "node_modules/file-type": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
+            "integrity": "sha512-Iq1nJ6D2+yIO4c8HHg4fyVb8mAJieo1Oloy1mLLaB2PvezNedhBVm+QU7g0qM42aiMbRXTxKKwGD17rjKNJYVQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/file-url": {
@@ -2273,6 +2546,12 @@
             ],
             "license": "MIT"
         },
+        "node_modules/fs-constants": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+            "dev": true
+        },
         "node_modules/fs-extra": {
             "version": "10.0.0",
             "license": "MIT",
@@ -2362,6 +2641,19 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/get-stream": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+            "integrity": "sha512-AUGhbbemXxrZJRD5cDvKtQxLuYaIbNtDTK8YqupCI393Q2KSTreEsLUN3ZxAWFGiKTzL6nKuzfcIvieflUX9qA==",
+            "dev": true,
+            "dependencies": {
+                "object-assign": "^4.0.1",
+                "pinkie-promise": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/getpass": {
@@ -2531,6 +2823,26 @@
                 "npm": ">=1.3.7"
             }
         },
+        "node_modules/ieee754": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
+        },
         "node_modules/ignore": {
             "version": "4.0.6",
             "dev": true,
@@ -2635,6 +2947,12 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/is-natural-number": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
+            "integrity": "sha512-Y4LTamMe0DDQIIAlaer9eKebAlDSV6huy+TWhJVPlzZh2o4tRP5SQWFlLn5N0To4mDD22/qdOq+veo1cSISLgQ==",
+            "dev": true
         },
         "node_modules/is-number": {
             "version": "7.0.0",
@@ -3445,6 +3763,15 @@
                 "node": "*"
             }
         },
+        "node_modules/object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/once": {
             "version": "1.4.0",
             "license": "ISC",
@@ -3646,6 +3973,12 @@
                 "node": "*"
             }
         },
+        "node_modules/pend": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+            "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+            "dev": true
+        },
         "node_modules/performance-now": {
             "version": "2.1.0",
             "license": "MIT"
@@ -3663,6 +3996,36 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/pify": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+            "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/pinkie": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+            "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/pinkie-promise": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+            "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
+            "dev": true,
+            "dependencies": {
+                "pinkie": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/prelude-ls": {
@@ -4118,6 +4481,19 @@
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
             "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
         },
+        "node_modules/seek-bzip": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.6.tgz",
+            "integrity": "sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==",
+            "dev": true,
+            "dependencies": {
+                "commander": "^2.8.1"
+            },
+            "bin": {
+                "seek-bunzip": "bin/seek-bunzip",
+                "seek-table": "bin/seek-bzip-table"
+            }
+        },
         "node_modules/semver": {
             "version": "7.3.5",
             "license": "ISC",
@@ -4312,6 +4688,15 @@
                 "node": ">=8"
             }
         },
+        "node_modules/strip-dirs": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
+            "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
+            "dev": true,
+            "dependencies": {
+                "is-natural-number": "^4.0.1"
+            }
+        },
         "node_modules/strip-json-comments": {
             "version": "3.1.1",
             "dev": true,
@@ -4331,6 +4716,24 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/tar-stream": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+            "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+            "dev": true,
+            "dependencies": {
+                "bl": "^1.0.0",
+                "buffer-alloc": "^1.2.0",
+                "end-of-stream": "^1.0.0",
+                "fs-constants": "^1.0.0",
+                "readable-stream": "^2.3.0",
+                "to-buffer": "^1.1.1",
+                "xtend": "^4.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
             }
         },
         "node_modules/telnet-client": {
@@ -4369,6 +4772,18 @@
             "version": "0.2.0",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+            "dev": true
+        },
+        "node_modules/to-buffer": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+            "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
+            "dev": true
         },
         "node_modules/to-fast-properties": {
             "version": "2.0.0",
@@ -4539,6 +4954,16 @@
             },
             "engines": {
                 "node": ">=4.2.0"
+            }
+        },
+        "node_modules/unbzip2-stream": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+            "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+            "dev": true,
+            "dependencies": {
+                "buffer": "^5.2.1",
+                "through": "^2.3.8"
             }
         },
         "node_modules/universalify": {
@@ -4736,6 +5161,15 @@
                 "node": ">=4.0"
             }
         },
+        "node_modules/xtend": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.4"
+            }
+        },
         "node_modules/y18n": {
             "version": "4.0.3",
             "dev": true,
@@ -4812,6 +5246,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/yauzl": {
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+            "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+            "dev": true,
+            "dependencies": {
+                "buffer-crc32": "~0.2.3",
+                "fd-slicer": "~1.1.0"
             }
         },
         "node_modules/yocto-queue": {
@@ -5232,6 +5676,15 @@
             "version": "4.2.22",
             "dev": true
         },
+        "@types/decompress": {
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/@types/decompress/-/decompress-4.2.4.tgz",
+            "integrity": "sha512-/C8kTMRTNiNuWGl5nEyKbPiMv6HA+0RbEXzFhFBEzASM6+oa4tJro9b8nj7eRlOFfuLdzUU+DS/GPDlvvzMOhA==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
         "@types/dedent": {
             "version": "0.7.0",
             "dev": true
@@ -5530,6 +5983,12 @@
         "balanced-match": {
             "version": "1.0.2"
         },
+        "base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "dev": true
+        },
         "bcrypt-pbkdf": {
             "version": "1.0.2",
             "requires": {
@@ -5538,6 +5997,16 @@
         },
         "binary-extensions": {
             "version": "2.2.0"
+        },
+        "bl": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+            "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
+            "dev": true,
+            "requires": {
+                "readable-stream": "^2.3.5",
+                "safe-buffer": "^5.1.1"
+            }
         },
         "bluebird": {
             "version": "3.7.2"
@@ -5717,6 +6186,44 @@
                 "picocolors": "^1.0.0"
             }
         },
+        "buffer": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+            "dev": true,
+            "requires": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
+            }
+        },
+        "buffer-alloc": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+            "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+            "dev": true,
+            "requires": {
+                "buffer-alloc-unsafe": "^1.1.0",
+                "buffer-fill": "^1.0.0"
+            }
+        },
+        "buffer-alloc-unsafe": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+            "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+            "dev": true
+        },
+        "buffer-crc32": {
+            "version": "0.2.13",
+            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+            "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+            "dev": true
+        },
+        "buffer-fill": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+            "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
+            "dev": true
+        },
         "buffer-from": {
             "version": "1.1.2",
             "dev": true
@@ -5823,6 +6330,12 @@
                 "delayed-stream": "~1.0.0"
             }
         },
+        "commander": {
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+            "dev": true
+        },
         "commondir": {
             "version": "1.0.1",
             "dev": true
@@ -5897,6 +6410,126 @@
             "version": "1.2.0",
             "dev": true
         },
+        "decompress": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.1.tgz",
+            "integrity": "sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==",
+            "dev": true,
+            "requires": {
+                "decompress-tar": "^4.0.0",
+                "decompress-tarbz2": "^4.0.0",
+                "decompress-targz": "^4.0.0",
+                "decompress-unzip": "^4.0.1",
+                "graceful-fs": "^4.1.10",
+                "make-dir": "^1.0.0",
+                "pify": "^2.3.0",
+                "strip-dirs": "^2.0.0"
+            },
+            "dependencies": {
+                "make-dir": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+                    "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+                    "dev": true,
+                    "requires": {
+                        "pify": "^3.0.0"
+                    },
+                    "dependencies": {
+                        "pify": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                            "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+                            "dev": true
+                        }
+                    }
+                }
+            }
+        },
+        "decompress-tar": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
+            "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
+            "dev": true,
+            "requires": {
+                "file-type": "^5.2.0",
+                "is-stream": "^1.1.0",
+                "tar-stream": "^1.5.2"
+            },
+            "dependencies": {
+                "is-stream": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+                    "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+                    "dev": true
+                }
+            }
+        },
+        "decompress-tarbz2": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
+            "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
+            "dev": true,
+            "requires": {
+                "decompress-tar": "^4.1.0",
+                "file-type": "^6.1.0",
+                "is-stream": "^1.1.0",
+                "seek-bzip": "^1.0.5",
+                "unbzip2-stream": "^1.0.9"
+            },
+            "dependencies": {
+                "file-type": {
+                    "version": "6.2.0",
+                    "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
+                    "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==",
+                    "dev": true
+                },
+                "is-stream": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+                    "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+                    "dev": true
+                }
+            }
+        },
+        "decompress-targz": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
+            "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
+            "dev": true,
+            "requires": {
+                "decompress-tar": "^4.1.1",
+                "file-type": "^5.2.0",
+                "is-stream": "^1.1.0"
+            },
+            "dependencies": {
+                "is-stream": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+                    "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+                    "dev": true
+                }
+            }
+        },
+        "decompress-unzip": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
+            "integrity": "sha512-1fqeluvxgnn86MOh66u8FjbtJpAFv5wgCT9Iw8rcBqQcCo5tO8eiJw7NNTrvt9n4CRBVq7CstiS922oPgyGLrw==",
+            "dev": true,
+            "requires": {
+                "file-type": "^3.8.0",
+                "get-stream": "^2.2.0",
+                "pify": "^2.3.0",
+                "yauzl": "^2.4.2"
+            },
+            "dependencies": {
+                "file-type": {
+                    "version": "3.9.0",
+                    "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+                    "integrity": "sha512-RLoqTXE8/vPmMuTI88DAzhMYC99I8BWv7zYP4A1puo5HIjEJ5EX48ighy4ZyKMG9EDXxBgW6e++cn7d1xuFghA==",
+                    "dev": true
+                }
+            }
+        },
         "dedent": {
             "version": "0.7.0",
             "dev": true
@@ -5959,6 +6592,15 @@
         },
         "emoji-regex": {
             "version": "8.0.0"
+        },
+        "end-of-stream": {
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+            "dev": true,
+            "requires": {
+                "once": "^1.4.0"
+            }
         },
         "enquirer": {
             "version": "2.3.6",
@@ -6177,12 +6819,27 @@
                 "reusify": "^1.0.4"
             }
         },
+        "fd-slicer": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+            "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+            "dev": true,
+            "requires": {
+                "pend": "~1.2.0"
+            }
+        },
         "file-entry-cache": {
             "version": "6.0.1",
             "dev": true,
             "requires": {
                 "flat-cache": "^3.0.4"
             }
+        },
+        "file-type": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
+            "integrity": "sha512-Iq1nJ6D2+yIO4c8HHg4fyVb8mAJieo1Oloy1mLLaB2PvezNedhBVm+QU7g0qM42aiMbRXTxKKwGD17rjKNJYVQ==",
+            "dev": true
         },
         "file-url": {
             "version": "3.0.0"
@@ -6271,6 +6928,12 @@
             "version": "1.3.2",
             "dev": true
         },
+        "fs-constants": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+            "dev": true
+        },
         "fs-extra": {
             "version": "10.0.0",
             "requires": {
@@ -6320,6 +6983,16 @@
         "get-port": {
             "version": "5.1.1",
             "dev": true
+        },
+        "get-stream": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+            "integrity": "sha512-AUGhbbemXxrZJRD5cDvKtQxLuYaIbNtDTK8YqupCI393Q2KSTreEsLUN3ZxAWFGiKTzL6nKuzfcIvieflUX9qA==",
+            "dev": true,
+            "requires": {
+                "object-assign": "^4.0.1",
+                "pinkie-promise": "^2.0.0"
+            }
         },
         "getpass": {
             "version": "0.1.7",
@@ -6423,6 +7096,12 @@
                 "sshpk": "^1.7.0"
             }
         },
+        "ieee754": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+            "dev": true
+        },
         "ignore": {
             "version": "4.0.6",
             "dev": true
@@ -6487,6 +7166,12 @@
             "requires": {
                 "is-extglob": "^2.1.1"
             }
+        },
+        "is-natural-number": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
+            "integrity": "sha512-Y4LTamMe0DDQIIAlaer9eKebAlDSV6huy+TWhJVPlzZh2o4tRP5SQWFlLn5N0To4mDD22/qdOq+veo1cSISLgQ==",
+            "dev": true
         },
         "is-number": {
             "version": "7.0.0"
@@ -7009,6 +7694,12 @@
         "oauth-sign": {
             "version": "0.9.0"
         },
+        "object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+            "dev": true
+        },
         "once": {
             "version": "1.4.0",
             "requires": {
@@ -7132,6 +7823,12 @@
             "version": "1.1.1",
             "dev": true
         },
+        "pend": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+            "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+            "dev": true
+        },
         "performance-now": {
             "version": "2.1.0"
         },
@@ -7141,6 +7838,27 @@
         },
         "picomatch": {
             "version": "2.3.0"
+        },
+        "pify": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+            "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+            "dev": true
+        },
+        "pinkie": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+            "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
+            "dev": true
+        },
+        "pinkie-promise": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+            "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
+            "dev": true,
+            "requires": {
+                "pinkie": "^2.0.0"
+            }
         },
         "prelude-ls": {
             "version": "1.2.1",
@@ -7435,6 +8153,15 @@
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
             "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
         },
+        "seek-bzip": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.6.tgz",
+            "integrity": "sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==",
+            "dev": true,
+            "requires": {
+                "commander": "^2.8.1"
+            }
+        },
         "semver": {
             "version": "7.3.5",
             "requires": {
@@ -7566,6 +8293,15 @@
                 "ansi-regex": "^5.0.1"
             }
         },
+        "strip-dirs": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
+            "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
+            "dev": true,
+            "requires": {
+                "is-natural-number": "^4.0.1"
+            }
+        },
         "strip-json-comments": {
             "version": "3.1.1",
             "dev": true
@@ -7574,6 +8310,21 @@
             "version": "7.2.0",
             "requires": {
                 "has-flag": "^4.0.0"
+            }
+        },
+        "tar-stream": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+            "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+            "dev": true,
+            "requires": {
+                "bl": "^1.0.0",
+                "buffer-alloc": "^1.2.0",
+                "end-of-stream": "^1.0.0",
+                "fs-constants": "^1.0.0",
+                "readable-stream": "^2.3.0",
+                "to-buffer": "^1.1.1",
+                "xtend": "^4.0.0"
             }
         },
         "telnet-client": {
@@ -7598,6 +8349,18 @@
         },
         "text-table": {
             "version": "0.2.0",
+            "dev": true
+        },
+        "through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+            "dev": true
+        },
+        "to-buffer": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+            "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
             "dev": true
         },
         "to-fast-properties": {
@@ -7692,6 +8455,16 @@
         "typescript": {
             "version": "4.4.4",
             "dev": true
+        },
+        "unbzip2-stream": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+            "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+            "dev": true,
+            "requires": {
+                "buffer": "^5.2.1",
+                "through": "^2.3.8"
+            }
         },
         "universalify": {
             "version": "0.1.2"
@@ -7833,6 +8606,12 @@
             "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
             "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
         },
+        "xtend": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+            "dev": true
+        },
         "y18n": {
             "version": "4.0.3",
             "dev": true
@@ -7883,6 +8662,16 @@
                     "version": "4.0.0",
                     "dev": true
                 }
+            }
+        },
+        "yauzl": {
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+            "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+            "dev": true,
+            "requires": {
+                "buffer-crc32": "~0.2.3",
+                "fd-slicer": "~1.1.0"
             }
         },
         "yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     },
     "devDependencies": {
         "@types/chai": "^4.2.22",
+        "@types/decompress": "^4.2.4",
         "@types/dedent": "^0.7.0",
         "@types/find-in-files": "^0.5.1",
         "@types/fs-extra": "^9.0.13",
@@ -68,6 +69,7 @@
         "@typescript-eslint/parser": "^5.2.0",
         "chai": "^4.3.4",
         "coveralls": "^3.1.1",
+        "decompress": "^4.2.1",
         "dedent": "^0.7.0",
         "eslint": "^8.1.0",
         "eslint-plugin-no-only-tests": "^2.6.0",

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -401,6 +401,8 @@ export class BrightScriptDebugSession extends BaseDebugSession {
             connectPromise = this.connectRokuAdapter().catch(e => this.logger.error(e));
         }
 
+        this.logger.log('Uploading zip');
+        const start = Date.now();
         let packageIsPublished = false;
         //publish the package to the target Roku
         const publishPromise = this.rokuDeploy.publish({
@@ -411,6 +413,8 @@ export class BrightScriptDebugSession extends BaseDebugSession {
         });
 
         await publishPromise;
+
+        this.logger.log(`Uploading zip took ${Date.now() - start}ms`);
 
         //the channel has been deployed. Wait for the adapter to finish connecting.
         //if it hasn't connected after 5 seconds, it probably will never connect.

--- a/src/managers/ProjectManager.spec.ts
+++ b/src/managers/ProjectManager.spec.ts
@@ -10,6 +10,7 @@ import { Project, ComponentLibraryProject, ProjectManager } from './ProjectManag
 import { BreakpointManager } from './BreakpointManager';
 import { SourceMapManager } from './SourceMapManager';
 import { LocationManager } from './LocationManager';
+import * as decompress from 'decompress';
 
 let sinon = sinonActual.createSandbox();
 let n = fileUtils.standardizePath.bind(fileUtils);
@@ -639,6 +640,26 @@ describe('Project', () => {
             await doTest(xmlSample.replace('<ENTRY>', `sub init()\n            m.something = true\n             '        ${Project.RDB_ODC_ENTRY}      \n        end sub`), expectedXml, 'xml');
         });
     });
+
+
+    describe('zipPackage', () => {
+        it('excludes sourcemaps', async () => {
+            fsExtra.outputFileSync(`${project.stagingFolderPath}/manifest`, '#stuff');
+            fsExtra.outputFileSync(`${project.stagingFolderPath}/source/main.brs`, 'sub main() : end sub');
+            fsExtra.outputFileSync(`${project.stagingFolderPath}/source/main.brs.map`, '{}');
+            await project.zipPackage({ retainStagingFolder: true });
+            const zipPath = path.join(
+                project.outDir,
+                fsExtra.readdirSync(project.outDir).find(x => x?.toLowerCase().endsWith('.zip'))
+            );
+
+            await decompress(zipPath, `${tempPath}/extracted`);
+            expect(fsExtra.pathExistsSync(`${tempPath}/extracted/manifest`)).to.be.true;
+            expect(fsExtra.pathExistsSync(`${tempPath}/extracted/source/main.brs`)).to.be.true;
+            expect(fsExtra.pathExistsSync(`${tempPath}/extracted/source/main.brs.map`)).to.be.false;
+        });
+    });
+
 });
 
 describe('ComponentLibraryProject', () => {


### PR DESCRIPTION
Exclude sourcemaps from the sideloaded zips, because sourcemaps are large and they cause longer zipping, uploading, and on-device compile times when present. 

Timing results for a large internal brighterscript app:

_**Sourcemaps INCLUDED**_
- Packaging projects took: `3s180ms`, Uploading zip took `7731ms`, AppCompileComplete --------> Duration(`5565ms`)
- Packaging projects took: `2s912ms`, Uploading zip took `7118ms`, AppCompileComplete --------> Duration(`5467ms`)
- Packaging projects took: `2s907ms`, Uploading zip took `7072ms`, AppCompileComplete --------> Duration(`5681ms`)

_**Sourcemaps EXCLUDED**_
- Packaging projects took: `2s331ms`, Uploading zip took `5927ms`,  AppCompileComplete --------> Duration(`4143ms`)
- Packaging projects took: `2s305ms`, Uploading zip took `5899ms`,  AppCompileComplete --------> Duration(`3959ms`)
- Packaging projects took: `2s411ms`, Uploading zip took `5920ms`,  AppCompileComplete --------> Duration(`3972ms`)