### PR TITLE
Fix rendezvous crash

### DIFF
--- a/src/RendezvousTracker.ts
+++ b/src/RendezvousTracker.ts
@@ -111,15 +111,18 @@ export class RendezvousTracker {
         try {
             // Get ECP rendezvous data, parse it, and send it to event emitter
             let ecpData = await this.getEcpRendezvous();
-            for (let blockInfo of ecpData?.items ?? []) {
-                let duration = ((parseInt(blockInfo.endTime) - parseInt(blockInfo.startTime)) / 1000).toString();
-                this.rendezvousBlocks[blockInfo.id] = {
-                    fileName: await this.updateClientPathMap(blockInfo.file, parseInt(blockInfo.lineNumber)),
-                    lineNumber: blockInfo.lineNumber
-                };
-                this.parseRendezvousLog(this.rendezvousBlocks[blockInfo.id], duration);
+            const items = ecpData?.items ?? [];
+            if (items.length > 0) {
+                for (let blockInfo of items) {
+                    let duration = ((parseInt(blockInfo.endTime) - parseInt(blockInfo.startTime)) / 1000).toString();
+                    this.rendezvousBlocks[blockInfo.id] = {
+                        fileName: await this.updateClientPathMap(blockInfo.file, parseInt(blockInfo.lineNumber)),
+                        lineNumber: blockInfo.lineNumber
+                    };
+                    this.parseRendezvousLog(this.rendezvousBlocks[blockInfo.id], duration);
+                }
+                this.emit('rendezvous', this.rendezvousHistory);
             }
-            this.emit('rendezvous', this.rendezvousHistory);
         } catch (e) {
             //if there was an error pinging rendezvous, log the error but don't bring down the app
             console.error('There was an error fetching rendezvous data', e?.stack);

--- a/src/adapters/DebugProtocolAdapter.ts
+++ b/src/adapters/DebugProtocolAdapter.ts
@@ -637,14 +637,6 @@ export class DebugProtocolAdapter {
         this.emitter = undefined;
     }
 
-    // #region Rendezvous Tracker pass though functions
-    /**
-     * Passes the debug functions used to locate the client files and lines to the RendezvousTracker
-     */
-    public registerSourceLocator(sourceLocator: (debuggerPath: string, lineNumber: number) => Promise<SourceLocation>) {
-        this.rendezvousTracker.registerSourceLocator(sourceLocator);
-    }
-
     /**
      * Passes the log level down to the RendezvousTracker and ChanperfTracker
      * @param outputLevel the consoleOutput from the launch config
@@ -667,7 +659,6 @@ export class DebugProtocolAdapter {
     public clearChanperfHistory() {
         this.chanperfTracker.clearHistory();
     }
-    // #endregion
 
     public async syncBreakpoints() {
         //we can't send breakpoints unless we're stopped (or in a protocol version that supports sending them while running).

--- a/src/adapters/TelnetAdapter.ts
+++ b/src/adapters/TelnetAdapter.ts
@@ -1026,14 +1026,6 @@ export class TelnetAdapter {
         return Promise.resolve();
     }
 
-    // #region Rendezvous Tracker pass though functions
-    /**
-     * Passes the debug functions used to locate the client files and lines to the RendezvousTracker
-     */
-    public registerSourceLocator(sourceLocator: (debuggerPath: string, lineNumber: number) => Promise<SourceLocation>) {
-        this.rendezvousTracker.registerSourceLocator(sourceLocator);
-    }
-
     /**
      * Passes the log level down to the RendezvousTracker and ChanperfTracker
      * @param outputLevel the consoleOutput from the launch config
@@ -1056,7 +1048,6 @@ export class TelnetAdapter {
     public clearChanperfHistory() {
         this.chanperfTracker.clearHistory();
     }
-    // #endregion
 
     public async syncBreakpoints() {
         //we can't send dynamic breakpoints to the server...so just do nothing

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -306,11 +306,6 @@ export class BrightScriptDebugSession extends BaseDebugSession {
             //press the home button to ensure we're at the home screen
             await this.rokuDeploy.pressHomeButton(this.launchConfiguration.host, this.launchConfiguration.remotePort);
 
-            //pass the debug functions used to locate the client files and lines thought the adapter to the RendezvousTracker
-            this.rokuAdapter.registerSourceLocator(async (debuggerPath: string, lineNumber: number) => {
-                return this.projectManager.getSourceLocation(debuggerPath, lineNumber);
-            });
-
             //pass the log level down thought the adapter to the RendezvousTracker and ChanperfTracker
             this.rokuAdapter.setConsoleOutput(this.launchConfiguration.consoleOutput);
 
@@ -441,6 +436,11 @@ export class BrightScriptDebugSession extends BaseDebugSession {
 
     private async _initRendezvousTracking() {
         this.rendezvousTracker = new RendezvousTracker(this.deviceInfo);
+
+        //pass the debug functions used to locate the client files and lines thought the adapter to the RendezvousTracker
+        this.rendezvousTracker.registerSourceLocator(async (debuggerPath: string, lineNumber: number) => {
+            return this.projectManager.getSourceLocation(debuggerPath, lineNumber);
+        });
 
         // Send rendezvous events to the debug protocol client
         this.rendezvousTracker.on('rendezvous', (output) => {


### PR DESCRIPTION
Fixes issue with the new rendezvous tracking that would crash the debug session during the startup flow.
Seems that, if the compile times of the channel are long enough, Roku will reject sgrendezvous ECP requests during the compile flow. The fix is to just ignore failed http requests instead of crashing the entire debug session. 

Fixes https://github.com/rokucommunity/vscode-brightscript-language/issues/491