### PR TITLE
Add `deleteDevChannelBeforeInstall` option

### DIFF
--- a/src/LaunchConfiguration.ts
+++ b/src/LaunchConfiguration.ts
@@ -260,6 +260,12 @@ export interface LaunchConfiguration extends DebugProtocol.LaunchRequestArgument
      * @default true
      */
     rendezvousTracking: boolean;
+
+    /**
+     * Delete any currently installed dev channel before starting the debug session
+     * @default false
+     */
+    deleteDevChannelBeforeInstall: boolean;
 }
 
 export interface ComponentLibraryConfiguration {

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -489,6 +489,14 @@ export class BrightScriptDebugSession extends BaseDebugSession {
         this.logger.log('Uploading zip');
         const start = Date.now();
         let packageIsPublished = false;
+
+        //delete any currently installed dev channel (if enabled to do so)
+        if (this.launchConfiguration.deleteDevChannelBeforeInstall === true) {
+            await this.rokuDeploy.deleteInstalledChannel({
+                ...this.launchConfiguration
+            } as any as RokuDeployOptions);
+        }
+
         //publish the package to the target Roku
         const publishPromise = this.rokuDeploy.publish({
             ...this.launchConfiguration,


### PR DESCRIPTION
Adds the `deleteDevChannelBeforeInstall` which, when enabled, will delete the dev channel before sideloading the new zip. 

This is being introduced as a result of a bug in the latest Roku OS 12.5 beta firmware (12.5.0 build 4105) that, if you're using the debug protocol debugger, it now requires you to delete the sideloaded dev channel between every launch. Otherwise, on subsequent launches it will completely ignore the "enable debug protocol" feature and instead kick off a telnet debug session. There's a caveat though: deleting the dev channel clears the dev channel registry if the device isn't signed. 

By adding this as an opt-in flag, devs can use the latest betas, but then if we get the issue fixed, they can disable it again without requiring another vscode extension release. 
