### PR TITLE
Fix sideload crash when failed to delete sideloaded channel

### DIFF
--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -510,10 +510,14 @@ export class BrightScriptDebugSession extends BaseDebugSession {
         let packageIsPublished = false;
 
         //delete any currently installed dev channel (if enabled to do so)
-        if (this.launchConfiguration.deleteDevChannelBeforeInstall === true) {
-            await this.rokuDeploy.deleteInstalledChannel({
-                ...this.launchConfiguration
-            } as any as RokuDeployOptions);
+        try {
+            if (this.launchConfiguration.deleteDevChannelBeforeInstall === true) {
+                await this.rokuDeploy.deleteInstalledChannel({
+                    ...this.launchConfiguration
+                } as any as RokuDeployOptions);
+            }
+        } catch (e) {
+            this.logger.warn('Failed to delete the dev channel...probably not a big deal', e);
         }
 
         //publish the package to the target Roku


### PR DESCRIPTION
Sometimes calling "delete channel" fails from roku-deploy. Not sure why, but we should just try/catch it and move on. 