### PR TITLE
Update DebugProtocolClient supported version range

### DIFF
--- a/src/debugProtocol/client/DebugProtocolClient.ts
+++ b/src/debugProtocol/client/DebugProtocolClient.ts
@@ -49,7 +49,7 @@ export class DebugProtocolClient {
     public logger = logger.createLogger(`[client]`);
 
     // The highest tested version of the protocol we support.
-    public supportedVersionRange = '<=3.0.0';
+    public supportedVersionRange = '<=3.2.0';
 
     constructor(
         options?: ConstructorOptions


### PR DESCRIPTION
Updates the supported version range to consider 3.2.0 as supported. 