### PR TITLE
Add timeout for deviceinfo query so we don't wait too long

### DIFF
--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -276,7 +276,7 @@ export class BrightScriptDebugSession extends BaseDebugSession {
 
         // fetches the device info and parses the xml data to JSON object
         try {
-            this.deviceInfo = await rokuDeploy.getDeviceInfo({ host: this.launchConfiguration.host, remotePort: this.launchConfiguration.remotePort, enhance: true });
+            this.deviceInfo = await rokuDeploy.getDeviceInfo({ host: this.launchConfiguration.host, remotePort: this.launchConfiguration.remotePort, enhance: true, timeout: 4_000 });
         } catch (e) {
             return this.shutdown(`Unable to connect to roku at '${this.launchConfiguration.host}'. Verify the IP address is correct and that the device is powered on and connected to same network as this computer.`);
         }


### PR DESCRIPTION
Add a shorter timeout to the device-info query so we can more quickly cancel the debug session if something is going wrong.