### PR TITLE
Fix bug with compile error reporting

### DIFF
--- a/src/adapters/DebugProtocolAdapter.ts
+++ b/src/adapters/DebugProtocolAdapter.ts
@@ -340,10 +340,6 @@ export class DebugProtocolAdapter {
 
     public async watchCompileOutput() {
         let deferred = defer();
-        //If the debugProtocol supports compile error updates, don't scrape telnet logs for compile errors
-        if (this.supportsCompileErrorReporting) {
-            return deferred.resolve();
-        }
         try {
             this.compileClient = new Socket();
             this.compileErrorProcessor.on('diagnostics', (errors) => {


### PR DESCRIPTION
Fix an issue where compile errors would be encountered, but we don't have a connection to the debug protocol so they were never reported. This fixes it in two ways:
 - always scrape telnet output for compile errors (even when debug protocol is enabled)
 - when showing the compile error "exception" hack, don't wait for the adapter to resolve (because it might ever resolve)