### PR TITLE
Support relaunch debug protocol

### DIFF
--- a/src/adapters/DebugProtocolAdapter.spec.ts
+++ b/src/adapters/DebugProtocolAdapter.spec.ts
@@ -99,7 +99,7 @@ describe('DebugProtocolAdapter', function() {
         await adapter.connect();
         await adapter['createDebugProtocolClient']();
 
-        client = adapter['socketDebugger'];
+        client = adapter['client'];
         client['options'].shutdownTimeout = 100;
         client['options'].exitChannelTimeout = 100;
         //disable logging for tests because they clutter the test output

--- a/src/adapters/DebugProtocolAdapter.spec.ts
+++ b/src/adapters/DebugProtocolAdapter.spec.ts
@@ -94,7 +94,10 @@ describe('DebugProtocolAdapter', function() {
      * Handles the initial connection and the "stop at first byte code" flow
      */
     async function initialize() {
+        sinon.stub(adapter, 'processTelnetOutput').callsFake(async () => {});
+
         await adapter.connect();
+        await adapter['connectSocketDebugger']();
         client = adapter['socketDebugger'];
         client['options'].shutdownTimeout = 100;
         client['options'].exitChannelTimeout = 100;

--- a/src/adapters/DebugProtocolAdapter.spec.ts
+++ b/src/adapters/DebugProtocolAdapter.spec.ts
@@ -97,7 +97,8 @@ describe('DebugProtocolAdapter', function() {
         sinon.stub(adapter, 'processTelnetOutput').callsFake(async () => {});
 
         await adapter.connect();
-        await adapter['connectSocketDebugger']();
+        await adapter['createDebugProtocolClient']();
+
         client = adapter['socketDebugger'];
         client['options'].shutdownTimeout = 100;
         client['options'].exitChannelTimeout = 100;

--- a/src/adapters/DebugProtocolAdapter.ts
+++ b/src/adapters/DebugProtocolAdapter.ts
@@ -259,11 +259,13 @@ export class DebugProtocolAdapter {
             this.socketDebugger.on('close', () => {
                 this.emit('close');
                 this.beginAppExit();
+                void this.socketDebugger.destroy();
             });
 
             // Listen for the app exit event
             this.socketDebugger.on('app-exit', () => {
                 this.emit('app-exit');
+                void this.socketDebugger.destroy();
             });
 
             this.socketDebugger.on('suspend', (data) => {

--- a/src/adapters/DebugProtocolAdapter.ts
+++ b/src/adapters/DebugProtocolAdapter.ts
@@ -61,7 +61,7 @@ export class DebugProtocolAdapter {
     private compileErrorProcessor: CompileErrorProcessor;
     private emitter: EventEmitter;
     private chanperfTracker: ChanperfTracker;
-    private socketDebugger: DebugProtocolClient;
+    private client: DebugProtocolClient;
     private nextFrameId = 1;
 
     private stackFramesCache: Record<number, StackFrame> = {};
@@ -71,7 +71,7 @@ export class DebugProtocolAdapter {
      * Get the version of the protocol for the Roku device we're currently connected to.
      */
     public get activeProtocolVersion() {
-        return this.socketDebugger?.protocolVersion;
+        return this.client?.protocolVersion;
     }
 
     /**
@@ -203,7 +203,7 @@ export class DebugProtocolAdapter {
     }
 
     public get isAtDebuggerPrompt() {
-        return this.socketDebugger?.isStopped ?? false;
+        return this.client?.isStopped ?? false;
     }
 
     /**
@@ -220,12 +220,19 @@ export class DebugProtocolAdapter {
 
     public async createDebugProtocolClient() {
         let deferred = defer();
-        this.socketDebugger = new DebugProtocolClient(this.options);
-        await this.socketDebugger.connect();
+        if (this.client) {
+            await Promise.race([
+                util.sleep(2000),
+                await this.client.destroy()
+            ]);
+            this.client = undefined;
+        }
+        this.client = new DebugProtocolClient(this.options);
+        await this.client.connect();
         try {
             // Emit IO from the debugger.
             // eslint-disable-next-line @typescript-eslint/no-misused-promises
-            this.socketDebugger.on('io-output', async (responseText) => {
+            this.client.on('io-output', async (responseText) => {
                 if (typeof responseText === 'string') {
                     responseText = this.chanperfTracker.processLog(responseText);
                     responseText = await this.rendezvousTracker.processLog(responseText);
@@ -235,7 +242,7 @@ export class DebugProtocolAdapter {
             });
 
             // Emit IO from the debugger.
-            this.socketDebugger.on('protocol-version', (data: ProtocolVersionDetails) => {
+            this.client.on('protocol-version', (data: ProtocolVersionDetails) => {
                 if (data.errorCode === PROTOCOL_ERROR_CODES.SUPPORTED) {
                     this.emit('console-output', data.message);
                 } else if (data.errorCode === PROTOCOL_ERROR_CODES.NOT_TESTED) {
@@ -256,24 +263,26 @@ export class DebugProtocolAdapter {
             });
 
             // Listen for the close event
-            this.socketDebugger.on('close', () => {
+            this.client.on('close', () => {
                 this.emit('close');
                 this.beginAppExit();
-                void this.socketDebugger.destroy();
+                void this.client.destroy();
+                this.client = undefined;
             });
 
             // Listen for the app exit event
-            this.socketDebugger.on('app-exit', () => {
+            this.client.on('app-exit', () => {
                 this.emit('app-exit');
-                void this.socketDebugger.destroy();
+                void this.client.destroy();
+                this.client = undefined;
             });
 
-            this.socketDebugger.on('suspend', (data) => {
+            this.client.on('suspend', (data) => {
                 this.clearCache();
                 this.emit('suspend');
             });
 
-            this.socketDebugger.on('runtime-error', (data) => {
+            this.client.on('runtime-error', (data) => {
                 console.debug('hasRuntimeError!!', data);
                 this.emit('runtime-error', <BrightScriptRuntimeError>{
                     message: data.data.stopReasonDetail,
@@ -281,12 +290,12 @@ export class DebugProtocolAdapter {
                 });
             });
 
-            this.socketDebugger.on('cannot-continue', () => {
+            this.client.on('cannot-continue', () => {
                 this.emit('cannot-continue');
             });
 
             //handle when the device verifies breakpoints
-            this.socketDebugger.on('breakpoints-verified', (event) => {
+            this.client.on('breakpoints-verified', (event) => {
                 let unverifiableDeviceIds = [] as number[];
 
                 //mark the breakpoints as verified
@@ -299,12 +308,12 @@ export class DebugProtocolAdapter {
                 //if there were any unsuccessful breakpoint verifications, we need to ask the device to delete those breakpoints as they've gone missing on our side
                 if (unverifiableDeviceIds.length > 0) {
                     this.logger.warn('Could not find breakpoints to verify. Removing from device:', { deviceBreakpointIds: unverifiableDeviceIds });
-                    void this.socketDebugger.removeBreakpoints(unverifiableDeviceIds);
+                    void this.client.removeBreakpoints(unverifiableDeviceIds);
                 }
                 this.emit('breakpoints-verified', event);
             });
 
-            this.socketDebugger.on('compile-error', (update) => {
+            this.client.on('compile-error', (update) => {
                 let diagnostics: BSDebugDiagnostic[] = [];
                 diagnostics.push({
                     path: update.data.filePath,
@@ -316,7 +325,7 @@ export class DebugProtocolAdapter {
                 this.emit('diagnostics', diagnostics);
             });
 
-            this.socketDebugger.on('control-socket-connected', () => {
+            this.client.on('control-socket-connected', () => {
                 this.emit('app-ready');
             });
 
@@ -418,17 +427,17 @@ export class DebugProtocolAdapter {
      */
     public async stepOver(threadId: number) {
         this.clearCache();
-        return this.socketDebugger.stepOver(threadId);
+        return this.client.stepOver(threadId);
     }
 
     public async stepInto(threadId: number) {
         this.clearCache();
-        return this.socketDebugger.stepIn(threadId);
+        return this.client.stepIn(threadId);
     }
 
     public async stepOut(threadId: number) {
         this.clearCache();
-        return this.socketDebugger.stepOut(threadId);
+        return this.client.stepOut(threadId);
     }
 
     /**
@@ -436,7 +445,7 @@ export class DebugProtocolAdapter {
      */
     public async continue() {
         this.clearCache();
-        return this.socketDebugger.continue();
+        return this.client.continue();
     }
 
     /**
@@ -445,7 +454,7 @@ export class DebugProtocolAdapter {
     public async pause() {
         this.clearCache();
         //send the kill signal, which breaks into debugger mode
-        return this.socketDebugger.pause();
+        return this.client.pause();
     }
 
     /**
@@ -461,7 +470,7 @@ export class DebugProtocolAdapter {
      * @param command
      * @returns the output of the command (if possible)
      */
-    public async evaluate(command: string, frameId: number = this.socketDebugger.primaryThread): Promise<RokuAdapterEvaluateResponse> {
+    public async evaluate(command: string, frameId: number = this.client.primaryThread): Promise<RokuAdapterEvaluateResponse> {
         if (this.supportsExecuteCommand) {
             if (!this.isAtDebuggerPrompt) {
                 throw new Error('Cannot run evaluate: debugger is not paused');
@@ -473,7 +482,7 @@ export class DebugProtocolAdapter {
             }
             this.logger.log('evaluate ', { command, frameId });
 
-            const response = await this.socketDebugger.executeCommand(command, stackFrame.frameIndex, stackFrame.threadIndex);
+            const response = await this.client.executeCommand(command, stackFrame.frameIndex, stackFrame.threadIndex);
             this.logger.info('evaluate response', { command, response });
             if (response.data.executeSuccess) {
                 return {
@@ -499,14 +508,14 @@ export class DebugProtocolAdapter {
         }
     }
 
-    public async getStackTrace(threadIndex: number = this.socketDebugger.primaryThread) {
+    public async getStackTrace(threadIndex: number = this.client.primaryThread) {
         if (!this.isAtDebuggerPrompt) {
             throw new Error('Cannot get stack trace: debugger is not paused');
         }
         return this.resolve(`stack trace for thread ${threadIndex}`, async () => {
             let thread = await this.getThreadByThreadId(threadIndex);
             let frames: StackFrame[] = [];
-            let stackTraceData = await this.socketDebugger.getStackTrace(threadIndex);
+            let stackTraceData = await this.client.getStackTrace(threadIndex);
             for (let i = 0; i < stackTraceData?.data?.entries?.length ?? 0; i++) {
                 let frameData = stackTraceData.data.entries[i];
                 let stackFrame: StackFrame = {
@@ -565,13 +574,13 @@ export class DebugProtocolAdapter {
             variablePath[0] = variablePath[0].toLowerCase();
         }
 
-        let response = await this.socketDebugger.getVariables(variablePath, frame.frameIndex, frame.threadIndex);
+        let response = await this.client.getVariables(variablePath, frame.frameIndex, frame.threadIndex);
 
         if (this.enableVariablesLowerCaseRetry && response.data.errorCode !== ErrorCode.OK) {
             // Temporary workaround related to casing issues over the protocol
             logger.log(`Retrying expression as lower case:`, expression);
             variablePath = expression === '' ? [] : util.getVariablePath(expression?.toLowerCase());
-            response = await this.socketDebugger.getVariables(variablePath, frame.frameIndex, frame.threadIndex);
+            response = await this.client.getVariables(variablePath, frame.frameIndex, frame.threadIndex);
         }
         return response;
     }
@@ -709,14 +718,14 @@ export class DebugProtocolAdapter {
         }
         return this.resolve('threads', async () => {
             let threads: Thread[] = [];
-            let threadsResponse = await this.socketDebugger.threads();
+            let threadsResponse = await this.client.threads();
 
             for (let i = 0; i < threadsResponse.data?.threads?.length ?? 0; i++) {
                 let threadInfo = threadsResponse.data.threads[i];
                 let thread = <Thread>{
                     // NOTE: On THREAD_ATTACHED events the threads request is marking the wrong thread as primary.
                     // NOTE: Rely on the thead index from the threads update event.
-                    isSelected: this.socketDebugger.primaryThread === i,
+                    isSelected: this.client.primaryThread === i,
                     // isSelected: threadInfo.isPrimary,
                     filePath: threadInfo.filePath,
                     functionName: threadInfo.functionName,
@@ -762,9 +771,9 @@ export class DebugProtocolAdapter {
         this.isDestroyed = true;
 
         // destroy the debug client if it's defined
-        if (this.socketDebugger) {
+        if (this.client) {
             try {
-                await this.socketDebugger.destroy();
+                await this.client.destroy();
             } catch (e) {
                 this.logger.error(e);
             }
@@ -821,7 +830,7 @@ export class DebugProtocolAdapter {
     public async _syncBreakpoints() {
         //we can't send breakpoints unless we're stopped (or in a protocol version that supports sending them while running).
         //So...if we're not stopped, quit now. (we'll get called again when the stop event happens)
-        if (!this.socketDebugger?.supportsBreakpointRegistrationWhileRunning && !this.isAtDebuggerPrompt) {
+        if (!this.client?.supportsBreakpointRegistrationWhileRunning && !this.isAtDebuggerPrompt) {
             return;
         }
 
@@ -831,7 +840,7 @@ export class DebugProtocolAdapter {
 
         // REMOVE breakpoints (delete these breakpoints from the device)
         if (diff.removed.length > 0) {
-            const response = await this.socketDebugger.removeBreakpoints(
+            const response = await this.client.removeBreakpoints(
                 //TODO handle retrying to remove breakpoints that don't have deviceIds yet but might get one in the future
                 diff.removed.map(x => x.deviceId).filter(x => typeof x === 'number')
             );
@@ -867,7 +876,7 @@ export class DebugProtocolAdapter {
                 }
             }
             for (const breakpoints of [standardBreakpoints, conditionalBreakpoints]) {
-                const response = await this.socketDebugger.addBreakpoints(breakpoints);
+                const response = await this.client.addBreakpoints(breakpoints);
 
                 //if the response was successful, and we have the correct number of breakpoints in the response
                 if (response.data.errorCode === ErrorCode.OK && response?.data?.breakpoints?.length === breakpoints.length) {

--- a/src/adapters/DebugProtocolAdapter.ts
+++ b/src/adapters/DebugProtocolAdapter.ts
@@ -405,7 +405,7 @@ export class DebugProtocolAdapter {
         return deferred.promise;
     }
 
-    private async processUnhandedOutputForDebugPrompt(responseText: string) {
+    private async findWaitForDebuggerPrompt(responseText: string) {
         let lines = responseText.split(/\r?\n/g);
         for (const line of lines) {
             if (/Waiting for debugger on \d+\.\d+\.\d+\.\d+:8081/g.exec(line)) {

--- a/src/adapters/DebugProtocolAdapter.ts
+++ b/src/adapters/DebugProtocolAdapter.ts
@@ -46,7 +46,7 @@ export class DebugProtocolAdapter {
 
     private connectionDeferred = defer<void>();
 
-    public deferredConnectionPromise(): Promise<void> {
+    public isConnected(): Promise<void> {
         return this.connectionDeferred.promise;
     }
 

--- a/src/adapters/DebugProtocolAdapter.ts
+++ b/src/adapters/DebugProtocolAdapter.ts
@@ -217,7 +217,7 @@ export class DebugProtocolAdapter {
      */
     public async connect() {
         //Start processing telnet output to look for compile errors or the debugger prompt
-        //await this.processTelnetOutput();
+        await this.processTelnetOutput();
 
         let deferred = defer();
         this.socketDebugger = new DebugProtocolClient(this.options);
@@ -407,9 +407,13 @@ export class DebugProtocolAdapter {
         let lines = responseText.split(/\r?\n/g);
         for (const line of lines) {
             if (/Waiting for debugger on \d+\.\d+\.\d+\.\d+:8081/g.exec(line)) {
-                await this.socketDebugger.connect();
+                await this.connectSocketDebugger();
             }
         }
+    }
+
+    private async connectSocketDebugger() {
+        await this.socketDebugger.connect();
     }
 
     /**

--- a/src/adapters/TelnetAdapter.ts
+++ b/src/adapters/TelnetAdapter.ts
@@ -44,7 +44,7 @@ export class TelnetAdapter {
 
     private connectionDeferred = defer<void>();
 
-    public deferredConnectionPromise(): Promise<void> {
+    public isConnected(): Promise<void> {
         return this.connectionDeferred.promise;
     }
 

--- a/src/adapters/TelnetAdapter.ts
+++ b/src/adapters/TelnetAdapter.ts
@@ -306,6 +306,7 @@ export class TelnetAdapter {
                     return;
                 }
 
+                //emitting this signal so the BrightScriptDebugSession will successfully complete it's publish method.
                 if (/\[beacon.signal\] \|AppCompileComplete/i.exec(responseText.trim())) {
                     this.emit('app-ready');
                 }

--- a/src/adapters/TelnetAdapter.ts
+++ b/src/adapters/TelnetAdapter.ts
@@ -65,8 +65,6 @@ export class TelnetAdapter {
 
     private cache = {};
 
-    public readonly supportsMultipleRuns = true;
-
     /**
      * Does this adapter support the `execute` command (known as `eval` in telnet)
      */

--- a/src/adapters/TelnetAdapter.ts
+++ b/src/adapters/TelnetAdapter.ts
@@ -42,6 +42,12 @@ export class TelnetAdapter {
         });
     }
 
+    private connectionDeferred = defer<void>();
+
+    public deferredConnectionPromise(): Promise<void> {
+        return this.connectionDeferred.promise;
+    }
+
     public logger = logger.createLogger(`[tadapter]`);
     /**
      * Indicates whether the adapter has successfully established a connection with the device
@@ -239,6 +245,7 @@ export class TelnetAdapter {
             client.connect(this.options.brightScriptConsolePort, this.options.host, () => {
                 this.logger.log(`Telnet connection established to ${this.options.host}:${this.options.brightScriptConsolePort}`);
                 this.connected = true;
+                this.connectionDeferred.resolve();
                 this.emit('connected', this.connected);
             });
 

--- a/src/debugProtocol/client/DebugProtocolClient.ts
+++ b/src/debugProtocol/client/DebugProtocolClient.ts
@@ -185,6 +185,7 @@ export class DebugProtocolClient {
     public on<T = AllThreadsStoppedUpdate | ThreadAttachedUpdate>(eventName: 'runtime-error' | 'suspend', handler: (data: T) => void);
     public on(eventName: 'io-output', handler: (output: string) => void);
     public on(eventName: 'protocol-version', handler: (data: ProtocolVersionDetails) => void);
+    public on(eventName: 'control-connected', handler: () => void);
     public on(eventName: 'handshake-verified', handler: (data: HandshakeResponse) => void);
     // public on(eventname: 'rendezvous', handler: (output: RendezvousHistory) => void);
     // public on(eventName: 'runtime-error', handler: (error: BrightScriptRuntimeError) => void);
@@ -201,7 +202,7 @@ export class DebugProtocolClient {
     private emit(eventName: 'data', update: Buffer);
     private emit(eventName: 'breakpoints-verified', event: BreakpointsVerifiedEvent);
     private emit(eventName: 'suspend' | 'runtime-error', data: AllThreadsStoppedUpdate | ThreadAttachedUpdate);
-    private emit(eventName: 'app-exit' | 'cannot-continue' | 'close' | 'handshake-verified' | 'io-output' | 'protocol-version' | 'start', data?);
+    private emit(eventName: 'app-exit' | 'cannot-continue' | 'close' | 'handshake-verified' | 'io-output' | 'protocol-version' | 'control-connected' | 'start', data?);
     private async emit(eventName: string, data?) {
         //emit these events on next tick, otherwise they will be processed immediately which could cause issues
         await util.sleep(0);
@@ -253,6 +254,7 @@ export class DebugProtocolClient {
             client: this,
             server: connection
         });
+        await this.emit('control-connected');
         return connection;
     }
 
@@ -611,7 +613,6 @@ export class DebugProtocolClient {
                         return simulatedResponse;
                     }
                 }
-                console.log('Bronley');
                 //prop in the middle is missing, tried reading a prop on it
                 // ex: variablePathEntries = ["there", "thereButSetToInvalid", "definitelyNotThere"]
                 throw new Error(`Cannot read '${variablePathEntries[invalidPathIndex + 1]}'${parentVarType ? ` on type '${parentVarTypeText}'` : ''}`);

--- a/src/debugProtocol/client/DebugProtocolClient.ts
+++ b/src/debugProtocol/client/DebugProtocolClient.ts
@@ -185,7 +185,7 @@ export class DebugProtocolClient {
     public on<T = AllThreadsStoppedUpdate | ThreadAttachedUpdate>(eventName: 'runtime-error' | 'suspend', handler: (data: T) => void);
     public on(eventName: 'io-output', handler: (output: string) => void);
     public on(eventName: 'protocol-version', handler: (data: ProtocolVersionDetails) => void);
-    public on(eventName: 'control-connected', handler: () => void);
+    public on(eventName: 'control-socket-connected', handler: () => void);
     public on(eventName: 'handshake-verified', handler: (data: HandshakeResponse) => void);
     // public on(eventname: 'rendezvous', handler: (output: RendezvousHistory) => void);
     // public on(eventName: 'runtime-error', handler: (error: BrightScriptRuntimeError) => void);
@@ -202,7 +202,7 @@ export class DebugProtocolClient {
     private emit(eventName: 'data', update: Buffer);
     private emit(eventName: 'breakpoints-verified', event: BreakpointsVerifiedEvent);
     private emit(eventName: 'suspend' | 'runtime-error', data: AllThreadsStoppedUpdate | ThreadAttachedUpdate);
-    private emit(eventName: 'app-exit' | 'cannot-continue' | 'close' | 'handshake-verified' | 'io-output' | 'protocol-version' | 'control-connected' | 'start', data?);
+    private emit(eventName: 'app-exit' | 'cannot-continue' | 'close' | 'handshake-verified' | 'io-output' | 'protocol-version' | 'control-socket-connected' | 'start', data?);
     private async emit(eventName: string, data?) {
         //emit these events on next tick, otherwise they will be processed immediately which could cause issues
         await util.sleep(0);

--- a/src/debugProtocol/client/DebugProtocolClient.ts
+++ b/src/debugProtocol/client/DebugProtocolClient.ts
@@ -254,7 +254,7 @@ export class DebugProtocolClient {
             client: this,
             server: connection
         });
-        await this.emit('control-connected');
+        await this.emit('control-socket-connected');
         return connection;
     }
 

--- a/src/debugProtocol/client/DebugProtocolClient.ts
+++ b/src/debugProtocol/client/DebugProtocolClient.ts
@@ -220,7 +220,7 @@ export class DebugProtocolClient {
                 allowHalfOpen: false
             });
             socket.on('error', (error) => {
-                console.debug(Date.now(), 'Encountered an error connecting to the debug protocol socket. Ignoring and will try again soon', error);
+                console.debug(Date.now(), 'Encountered an error connecting to the debug protocol socket.', error);
             });
             socket.connect({ port: this.options.controlPort, host: this.options.host }, () => {
                 resolve(socket);

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -273,7 +273,6 @@ export class BrightScriptDebugSession extends BaseDebugSession {
 
             this.createRokuAdapter(this.rendezvousTracker);
             await this.connectRokuAdapter();
-            await (this.rokuAdapter as DebugProtocolAdapter).processTelnetOutput();
 
             await this.runAutomaticSceneGraphCommands(this.launchConfiguration.autoRunSgDebugCommands);
 

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -315,8 +315,8 @@ export class BrightScriptDebugSession extends BaseDebugSession {
             // close disconnect if required when the app is exited
             // eslint-disable-next-line @typescript-eslint/no-misused-promises
             this.rokuAdapter.on('app-exit', async () => {
-                if (this.launchConfiguration.stopDebuggerOnAppExit || !this.rokuAdapter.supportsMultipleRuns) {
-                    let message = `App exit event detected${this.rokuAdapter.supportsMultipleRuns ? ' and launchConfiguration.stopDebuggerOnAppExit is true' : ''}`;
+                if (this.launchConfiguration.stopDebuggerOnAppExit) {
+                    let message = `App exit event detected and launchConfiguration.stopDebuggerOnAppExit is true`;
                     message += ' - shutting down debug session';
 
                     this.logger.log('on app-exit', message);
@@ -326,6 +326,10 @@ export class BrightScriptDebugSession extends BaseDebugSession {
                     const message = 'App exit detected; but launchConfiguration.stopDebuggerOnAppExit is set to false, so keeping debug session running.';
                     this.logger.log('[launchRequest]', message);
                     this.sendEvent(new LogOutputEvent(message));
+                    if (this.enableDebugProtocol) {
+                        this.entryBreakpointWasHandled = false;
+                        await this.rokuAdapter.connect();
+                    }
                 }
             });
 

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -494,7 +494,7 @@ export class BrightScriptDebugSession extends BaseDebugSession {
         //the channel has been deployed. Wait for the adapter to finish connecting.
         //if it hasn't connected after 5 seconds, it probably will never connect.
         await Promise.race([
-            this.rokuAdapter.deferredConnectionPromise(),
+            this.rokuAdapter.isConnected(),
             util.sleep(10000)
         ]);
         this.logger.log('Finished racing promises');

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -316,6 +316,7 @@ export class BrightScriptDebugSession extends BaseDebugSession {
             // eslint-disable-next-line @typescript-eslint/no-misused-promises
             this.rokuAdapter.on('app-exit', async () => {
                 this.entryBreakpointWasHandled = false;
+                this.breakpointManager.clearBreakpointLastState();
 
                 if (this.launchConfiguration.stopDebuggerOnAppExit) {
                     let message = `App exit event detected and launchConfiguration.stopDebuggerOnAppExit is true`;

--- a/src/managers/BreakpointManager.ts
+++ b/src/managers/BreakpointManager.ts
@@ -811,6 +811,10 @@ export class BreakpointManager {
      */
     private isGetDiffRunning = false;
     private lastState = new Map<string, BreakpointWorkItem>();
+
+    public clearBreakpointLastState() {
+        this.lastState.clear();
+    }
 }
 
 export interface Diff {


### PR DESCRIPTION
Persist the debug session for debug protocol. This is accomplished by parsing the telnet logs for the line "Waiting for debugging connection" and then creating the control port. When the application is closed, we continue to parse the telnet logs for that line. When that line is detected the control port will be created again.

A new signal `app-ready` is emitted to let `BrightScriptDebugSession` know the debug adapters are ready. Both adapters have to emit this signal.

When the app is closed via a home key press, reset the breakpoint managers state for the debug protocol.