### PR TITLE
Use `stagingDir` instead of stagingFolderPath

### DIFF
--- a/src/LaunchConfiguration.ts
+++ b/src/LaunchConfiguration.ts
@@ -260,8 +260,15 @@ export interface LaunchConfiguration extends DebugProtocol.LaunchRequestArgument
     /**
      * The path used for the staging folder of roku-deploy
      * This should generally be set to "${cwd}/.roku-deploy-staging", but that's ultimately up to the debug client.
+     * @deprecated use `stagingDir` instead
      */
     stagingFolderPath?: string;
+
+    /**
+     * Path used for the staging folder where files are written right before being packaged. This folder will contain any roku-debug related sourcemaps,
+     * as well as having breakpoints injected into source code
+     */
+    stagingDir?: string;
 
     /**
      * What level of debug server's internal logging should be performed in the debug session

--- a/src/debugSession/BrightScriptDebugSession.spec.ts
+++ b/src/debugSession/BrightScriptDebugSession.spec.ts
@@ -64,7 +64,7 @@ describe('BrightScriptDebugSession', () => {
         launchConfiguration = {
             rootDir: rootDir,
             outDir: outDir,
-            stagingFolderPath: stagingDir,
+            stagingDir: stagingDir,
             files: DefaultFiles
         } as any;
         session['launchConfiguration'] = launchConfiguration;
@@ -658,7 +658,7 @@ describe('BrightScriptDebugSession', () => {
         it('registers the entry breakpoint when stopOnEntry is enabled', async () => {
             (session as any).launchConfiguration = { stopOnEntry: true };
             session.projectManager.mainProject = <any>{
-                stagingFolderPath: stagingDir
+                stagingDir: stagingDir
             };
             let stub = sinon.stub(session.projectManager, 'registerEntryBreakpoint').returns(Promise.resolve());
             await session.handleEntryBreakpoint();
@@ -677,10 +677,10 @@ describe('BrightScriptDebugSession', () => {
         it('erases all staging folders when configured to do so', async () => {
             let stub = sinon.stub(fsExtra, 'removeSync').returns(null);
             session.projectManager.mainProject = <any>{
-                stagingFolderPath: 'stagingPathA'
+                stagingDir: 'stagingPathA'
             };
             session.projectManager.componentLibraryProjects.push(<any>{
-                stagingFolderPath: 'stagingPathB'
+                stagingDir: 'stagingPathB'
             });
             (session as any).launchConfiguration = {
                 retainStagingFolder: false
@@ -830,7 +830,7 @@ describe('BrightScriptDebugSession', () => {
                 session.projectManager.componentLibraryProjects.push(
                     new ComponentLibraryProject({
                         rootDir: complib1Dir,
-                        stagingFolderPath: stagingDir,
+                        stagingDir: stagingDir,
                         outDir: outDir,
                         libraryIndex: 1
                     } as Partial<ComponentLibraryConstructorParams> as any)

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -229,6 +229,7 @@ export class BrightScriptDebugSession extends BaseDebugSession {
         config.sceneGraphDebugCommandsPort ??= 8080;
         config.controlPort ??= 8081;
         config.brightScriptConsolePort ??= 8085;
+        config.stagingDir ??= config.stagingFolderPath;
         return config;
     }
 
@@ -628,7 +629,7 @@ export class BrightScriptDebugSession extends BaseDebugSession {
             raleTrackerTaskFileLocation: this.launchConfiguration.raleTrackerTaskFileLocation,
             injectRdbOnDeviceComponent: this.launchConfiguration.injectRdbOnDeviceComponent,
             rdbFilesBasePath: this.launchConfiguration.rdbFilesBasePath,
-            stagingFolderPath: this.launchConfiguration.stagingFolderPath
+            stagingDir: this.launchConfiguration.stagingDir
         });
 
         util.log('Moving selected files to staging area');
@@ -1439,7 +1440,7 @@ export class BrightScriptDebugSession extends BaseDebugSession {
         if (!this.enableDebugProtocol) {
             this.entryBreakpointWasHandled = true;
             if (this.launchConfiguration.stopOnEntry || this.launchConfiguration.deepLinkUrl) {
-                await this.projectManager.registerEntryBreakpoint(this.projectManager.mainProject.stagingFolderPath);
+                await this.projectManager.registerEntryBreakpoint(this.projectManager.mainProject.stagingDir);
             }
         }
     }
@@ -1468,14 +1469,14 @@ export class BrightScriptDebugSession extends BaseDebugSession {
 
             //if configured, delete the staging directory
             if (!this.launchConfiguration.retainStagingFolder) {
-                const stagingFolders = this.projectManager?.getStagingFolderPaths() ?? [];
-                this.logger.info('deleting staging folders', stagingFolders);
-                for (let stagingFolderPath of stagingFolders) {
+                const stagingDirs = this.projectManager?.getStagingDirs() ?? [];
+                this.logger.info('deleting staging folders', stagingDirs);
+                for (let stagingDir of stagingDirs) {
                     try {
-                        fsExtra.removeSync(stagingFolderPath);
+                        fsExtra.removeSync(stagingDir);
                     } catch (e) {
                         this.logger.error(e);
-                        util.log(`Error removing staging directory '${stagingFolderPath}': ${JSON.stringify(e)}`);
+                        util.log(`Error removing staging directory '${stagingDir}': ${JSON.stringify(e)}`);
                     }
                 }
             }

--- a/src/managers/BreakpointManager.spec.ts
+++ b/src/managers/BreakpointManager.spec.ts
@@ -388,7 +388,7 @@ describe('BreakpointManager', () => {
             await bpManager.writeBreakpointsForProject(new Project(<any>{
                 rootDir: rootDir,
                 outDir: outDir,
-                stagingFolderPath: stagingDir
+                stagingDir: stagingDir
             }));
 
             //it wrote the breakpoint in the correct location
@@ -429,7 +429,7 @@ describe('BreakpointManager', () => {
                     rootDir: rootDir,
                     outDir: s`${cwd}/out`,
                     sourceDirs: [sourceDir1],
-                    stagingFolderPath: stagingDir
+                    stagingDir: stagingDir
                 })
             );
 
@@ -467,7 +467,7 @@ describe('BreakpointManager', () => {
                     rootDir: rootDir,
                     outDir: s`${cwd}/out`,
                     sourceDirs: [sourceDir1, sourceDir2],
-                    stagingFolderPath: stagingDir
+                    stagingDir: stagingDir
                 })
             );
 
@@ -510,7 +510,7 @@ describe('BreakpointManager', () => {
                     rootDir: rootDir,
                     outDir: s`${cwd}/out`,
                     sourceDirs: [sourceDir1, sourceDir2],
-                    stagingFolderPath: stagingDir
+                    stagingDir: stagingDir
                 })
             );
 
@@ -552,7 +552,7 @@ describe('BreakpointManager', () => {
                     rootDir: rootDir,
                     outDir: s`${cwd}/out`,
                     sourceDirs: [sourceDir1, sourceDir2],
-                    stagingFolderPath: stagingDir
+                    stagingDir: stagingDir
                 })
             );
 
@@ -609,7 +609,7 @@ describe('BreakpointManager', () => {
                 ],
                 rootDir: s`${tmpDir}/dist`,
                 outDir: s`${tmpDir}/out`,
-                stagingFolderPath: stagingDir
+                stagingDir: stagingDir
             }));
 
             //the breakpoints should be placed in the proper locations
@@ -714,7 +714,7 @@ describe('BreakpointManager', () => {
                 files: [
                     'source/main.brs'
                 ],
-                stagingFolderPath: stagingDir,
+                stagingDir: stagingDir,
                 outDir: outDir,
                 rootDir: rootDir
             }));
@@ -726,7 +726,7 @@ describe('BreakpointManager', () => {
                 lineNumber: 2,
                 fileMappings: [],
                 rootDir: rootDir,
-                stagingFolderPath: stagingDir,
+                stagingDir: stagingDir,
                 enableSourceMaps: true
             });
 
@@ -775,7 +775,7 @@ describe('BreakpointManager', () => {
                 files: [
                     'source/main.brs'
                 ],
-                stagingFolderPath: stagingDir,
+                stagingDir: stagingDir,
                 outDir: outDir,
                 rootDir: rootDir
             }));
@@ -813,7 +813,7 @@ describe('BreakpointManager', () => {
                     dest: ''
                 }
             ],
-            stagingFolderPath: stagingDir,
+            stagingDir: stagingDir,
             outDir: outDir,
             rootDir: rootDir
         });

--- a/src/managers/BreakpointManager.ts
+++ b/src/managers/BreakpointManager.ts
@@ -368,7 +368,7 @@ export class BreakpointManager {
                         ...project?.sourceDirs ?? [],
                         project.rootDir
                     ],
-                    project.stagingFolderPath,
+                    project.stagingDir,
                     project.fileMappings
                 );
 
@@ -376,7 +376,7 @@ export class BreakpointManager {
                     let relativeStagingPath = fileUtils.replaceCaseInsensitive(
                         stagingLocation.filePath,
                         fileUtils.standardizePath(
-                            fileUtils.removeTrailingSlash(project.stagingFolderPath) + '/'
+                            fileUtils.removeTrailingSlash(project.stagingDir) + '/'
                         ),
                         ''
                     );
@@ -384,7 +384,7 @@ export class BreakpointManager {
                         //replace staging folder path with nothing (so we can build a pkg path)
                         .replaceCaseInsensitive(
                             s`${stagingLocation.filePath}`,
-                            s`${project.stagingFolderPath}`,
+                            s`${project.stagingDir}`,
                             ''
                         )
                         //force to unix path separators

--- a/src/managers/LocationManager.spec.ts
+++ b/src/managers/LocationManager.spec.ts
@@ -52,7 +52,7 @@ describe('LocationManager', () => {
 
             let location = await locationManager.getSourceLocation({
                 stagingFilePath: stagingFilePath,
-                stagingFolderPath: stagingDir,
+                stagingDir: stagingDir,
                 fileMappings: [],
                 rootDir: rootDir,
                 lineNumber: 1,
@@ -76,7 +76,7 @@ describe('LocationManager', () => {
 
                 let location = await locationManager.getSourceLocation({
                     stagingFilePath: s`${stagingDir}/lib1.brs`,
-                    stagingFolderPath: stagingDir,
+                    stagingDir: stagingDir,
                     fileMappings: [{
                         src: s`${rootDir}/lib1.brs`,
                         dest: s`${stagingDir}/lib1.brs`
@@ -116,7 +116,7 @@ describe('LocationManager', () => {
 
                 let location = await locationManager.getSourceLocation({
                     stagingFilePath: stagingFilePath,
-                    stagingFolderPath: stagingDir,
+                    stagingDir: stagingDir,
                     fileMappings: [],
                     rootDir: rootDir,
                     lineNumber: 3,
@@ -142,7 +142,7 @@ describe('LocationManager', () => {
 
                 let location = await locationManager.getSourceLocation({
                     stagingFilePath: s`${stagingDir}/lib1.brs`,
-                    stagingFolderPath: stagingDir,
+                    stagingDir: stagingDir,
                     fileMappings: [{
                         src: s`${sourceDirs[0]}/lib1.brs`,
                         dest: '/lib1.brs'
@@ -169,7 +169,7 @@ describe('LocationManager', () => {
 
                 let location = await locationManager.getSourceLocation({
                     stagingFilePath: s`${stagingDir}/lib1.brs`,
-                    stagingFolderPath: stagingDir,
+                    stagingDir: stagingDir,
                     fileMappings: [{
                         src: s`${sourceDirs[1]}/lib1.brs`,
                         dest: '/lib1.brs'
@@ -195,7 +195,7 @@ describe('LocationManager', () => {
 
                 let location = await locationManager.getSourceLocation({
                     stagingFilePath: s`${stagingDir}/lib1.brs`,
-                    stagingFolderPath: stagingDir,
+                    stagingDir: stagingDir,
                     fileMappings: [{
                         src: s`${sourceDirs[2]}/lib1.brs`,
                         dest: '/lib1.brs'

--- a/src/managers/LocationManager.ts
+++ b/src/managers/LocationManager.ts
@@ -18,7 +18,7 @@ export class LocationManager {
      */
     public async getSourceLocation(options: GetSourceLocationOptions): Promise<SourceLocation> {
         let rootDir = s`${options.rootDir}`;
-        let stagingFolderPath = s`${options.stagingFolderPath}`;
+        let stagingDir = s`${options.stagingDir}`;
         let currentFilePath = s`${options.stagingFilePath}`;
         let sourceDirs = options.sourceDirs ? options.sourceDirs.map(x => s`${x}`) : [];
         //throw out any sourceDirs pointing the rootDir
@@ -62,7 +62,7 @@ export class LocationManager {
         //if we have sourceDirs, rootDir is the project's OUTPUT folder, so skip looking for files there, and
         //instead walk backwards through sourceDirs until we find the file we want
         if (sourceDirs.length > 0) {
-            let relativeFilePath = fileUtils.getRelativePath(stagingFolderPath, currentFilePath);
+            let relativeFilePath = fileUtils.getRelativePath(stagingDir, currentFilePath);
             let sourceDirsFilePath = await fileUtils.findFirstRelativeFile(relativeFilePath, sourceDirs);
             //if we found a file in one of the sourceDirs, use that
             if (sourceDirsFilePath) {
@@ -104,18 +104,18 @@ export class LocationManager {
         sourceLineNumber: number,
         sourceColumnIndex: number,
         sourceDirs: string[],
-        stagingFolderPath: string,
+        stagingDir: string,
         fileMappings: Array<{ src: string; dest: string }>
     ): Promise<{ type: 'fileMap' | 'sourceDirs' | 'sourceMap'; locations: SourceLocation[] }> {
 
         sourceFilePath = s`${sourceFilePath}`;
         sourceDirs = sourceDirs.map(x => s`${x}`);
-        stagingFolderPath = s`${stagingFolderPath}`;
+        stagingDir = s`${stagingDir}`;
 
         //look through the sourcemaps in the staging folder for any instances of this source location
         let locations = await this.sourceMapManager.getGeneratedLocations(
             glob.sync('**/*.map', {
-                cwd: stagingFolderPath,
+                cwd: stagingDir,
                 absolute: true
             }),
             {
@@ -141,7 +141,7 @@ export class LocationManager {
         let parentFolderPath = fileUtils.findFirstParent(sourceFilePath, sourceDirs);
         if (parentFolderPath) {
             let relativeFilePath = fileUtils.replaceCaseInsensitive(sourceFilePath, parentFolderPath, '');
-            let stagingFilePathAbsolute = path.join(stagingFolderPath, relativeFilePath);
+            let stagingFilePathAbsolute = path.join(stagingDir, relativeFilePath);
             return {
                 type: 'sourceDirs',
                 locations: [{
@@ -180,7 +180,7 @@ export interface GetSourceLocationOptions {
     /**
      * The absolute path to the staging folder
      */
-    stagingFolderPath: string;
+    stagingDir: string;
 
     /**
      * The absolute path to the file in the staging folder

--- a/src/managers/ProjectManager.ts
+++ b/src/managers/ProjectManager.ts
@@ -58,12 +58,12 @@ export class ProjectManager {
     /**
      * Get the list of staging folder paths from all projects
      */
-    public getStagingFolderPaths() {
+    public getStagingDirs() {
         let projects = [
             ...(this.mainProject ? [this.mainProject] : []),
             ...(this.componentLibraryProjects ?? [])
         ];
-        return projects.map(x => x.stagingFolderPath);
+        return projects.map(x => x.stagingDir);
     }
 
     /**
@@ -126,7 +126,7 @@ export class ProjectManager {
                 fileMappings: project.fileMappings,
                 rootDir: project.rootDir,
                 stagingFilePath: stagingFileInfo.absolutePath,
-                stagingFolderPath: project.stagingFolderPath,
+                stagingDir: project.stagingDir,
                 sourceDirs: project.sourceDirs,
                 enableSourceMaps: this.launchConfiguration?.enableSourceMaps ?? true
             });
@@ -151,11 +151,11 @@ export class ProjectManager {
 
     /**
      *
-     * @param stagingFolderPath - the path to
+     * @param stagingDir - the path to
      */
-    public async registerEntryBreakpoint(stagingFolderPath: string) {
+    public async registerEntryBreakpoint(stagingDir: string) {
         //find the main function from the staging flder
-        let entryPoint = await fileUtils.findEntryPoint(stagingFolderPath);
+        let entryPoint = await fileUtils.findEntryPoint(stagingDir);
 
         //convert entry point staging location to source location
         let sourceLocation = await this.getSourceLocation(entryPoint.relativePath, entryPoint.lineNumber);
@@ -172,7 +172,7 @@ export class ProjectManager {
      * Given a debugger-relative file path, find the path to that file in the staging directory.
      * This supports the standard out dir, as well as component library out dirs
      * @param debuggerPath the path to the file which was provided by the debugger
-     * @param stagingFolderPath - the path to the root of the staging folder (where all of the files were copied before deployment)
+     * @param stagingDir - the path to the root of the staging folder (where all of the files were copied before deployment)
      * @return a full path to the file in the staging directory
      */
     public async getStagingFileInfo(debuggerPath: string) {
@@ -198,7 +198,7 @@ export class ProjectManager {
         if (util.getFileScheme(debuggerPath)) {
             relativePath = util.removeFileScheme(debuggerPath);
         } else {
-            relativePath = await fileUtils.findPartialFileInDirectory(debuggerPath, project.stagingFolderPath);
+            relativePath = await fileUtils.findPartialFileInDirectory(debuggerPath, project.stagingDir);
         }
         if (relativePath) {
             relativePath = fileUtils.removeLeadingSlash(
@@ -207,7 +207,7 @@ export class ProjectManager {
             );
             return {
                 relativePath: relativePath,
-                absolutePath: s`${project.stagingFolderPath}/${relativePath}`,
+                absolutePath: s`${project.stagingDir}/${relativePath}`,
                 project: project
             };
         } else {
@@ -226,7 +226,7 @@ export interface AddProjectParams {
     injectRdbOnDeviceComponent?: boolean;
     rdbFilesBasePath?: string;
     bsConst?: Record<string, boolean>;
-    stagingFolderPath?: string;
+    stagingDir?: string;
 }
 
 export class Project {
@@ -236,8 +236,7 @@ export class Project {
 
         assert(params?.outDir, 'outDir is required');
         this.outDir = fileUtils.standardizePath(params.outDir);
-
-        this.stagingFolderPath = params.stagingFolderPath ?? rokuDeploy.getOptions(this).stagingFolderPath;
+        this.stagingDir = params.stagingDir ?? rokuDeploy.getOptions(this).stagingDir;
         this.bsConst = params.bsConst;
         this.sourceDirs = (params.sourceDirs ?? [])
             //standardize every sourcedir
@@ -252,7 +251,7 @@ export class Project {
     public outDir: string;
     public sourceDirs: string[];
     public files: Array<FileEntry>;
-    public stagingFolderPath: string;
+    public stagingDir: string;
     public fileMappings: Array<{ src: string; dest: string }>;
     public bsConst: Record<string, boolean>;
     public injectRaleTrackerTask: boolean;
@@ -279,7 +278,7 @@ export class Project {
             for (let fileMapping of this.fileMappings) {
                 relativeFileMappings.push({
                     src: fileMapping.src,
-                    dest: fileUtils.replaceCaseInsensitive(fileMapping.dest, this.stagingFolderPath, '')
+                    dest: fileUtils.replaceCaseInsensitive(fileMapping.dest, this.stagingDir, '')
                 });
             }
             return Promise.resolve(relativeFileMappings);
@@ -288,7 +287,7 @@ export class Project {
         //copy all project files to the staging folder
         await rd.prepublishToStaging({
             rootDir: this.rootDir,
-            stagingFolderPath: this.stagingFolderPath,
+            stagingDir: this.stagingDir,
             files: this.files,
             outDir: this.outDir
         });
@@ -309,7 +308,7 @@ export class Project {
     private resolveFileMappingsForSourceDirs() {
         return Promise.all([
             this.fileMappings.map(async x => {
-                let stagingFilePathRelative = fileUtils.getRelativePath(this.stagingFolderPath, x.dest);
+                let stagingFilePathRelative = fileUtils.getRelativePath(this.stagingDir, x.dest);
                 let sourceDirFilePath = await fileUtils.findFirstRelativeFile(stagingFilePathRelative, this.sourceDirs);
                 if (sourceDirFilePath) {
                     x.src = sourceDirFilePath;
@@ -323,7 +322,7 @@ export class Project {
      */
     public async transformManifestWithBsConst() {
         if (this.bsConst) {
-            let manifestPath = s`${this.stagingFolderPath}/manifest`;
+            let manifestPath = s`${this.stagingDir}/manifest`;
             if (await fsExtra.pathExists(manifestPath)) {
                 // Update the bs_const values in the manifest in the staging folder before side loading the channel
                 let fileContents = (await fsExtra.readFile(manifestPath)).toString();
@@ -384,11 +383,11 @@ export class Project {
             return;
         }
         try {
-            await fsExtra.copy(this.raleTrackerTaskFileLocation, s`${this.stagingFolderPath}/components/TrackerTask.xml`);
+            await fsExtra.copy(this.raleTrackerTaskFileLocation, s`${this.stagingDir}/components/TrackerTask.xml`);
             this.logger.log('Tracker task successfully injected');
             // Search for the tracker task entry injection point
             const trackerReplacementResult = await replaceInFile({
-                files: `${this.stagingFolderPath}/**/*.+(xml|brs)`,
+                files: `${this.stagingDir}/**/*.+(xml|brs)`,
                 from: new RegExp(`^.*'\\s*${Project.RALE_TRACKER_ENTRY}.*$`, 'mig'),
                 to: (match: string) => {
                     // Strip off the comment
@@ -434,7 +433,7 @@ export class Project {
                 //only include files (i.e. skip directories)
                 if (await util.isFile(filePathAbsolute)) {
                     const relativePath = s`${filePathAbsolute}`.replace(s`${this.rdbFilesBasePath}`, '');
-                    const destinationPath = s`${this.stagingFolderPath}/${relativePath}`;
+                    const destinationPath = s`${this.stagingDir}/${relativePath}`;
                     promises.push(fsExtra.copy(filePathAbsolute, destinationPath));
                 }
                 await Promise.all(promises);
@@ -443,7 +442,7 @@ export class Project {
 
             // Search for the tracker task entry injection point
             const replacementResult = await replaceInFile({
-                files: `${this.stagingFolderPath}/**/*.+(xml|brs)`,
+                files: `${this.stagingDir}/**/*.+(xml|brs)`,
                 from: new RegExp(`^.*'\\s*${Project.RDB_ODC_ENTRY}.*$`, 'mig'),
                 to: (match: string) => {
                     // Strip off the comment
@@ -509,7 +508,7 @@ export class Project {
         let fileMappings = await rokuDeploy.getFilePaths(this.files, this.rootDir);
         for (let mapping of fileMappings) {
             //if the dest path is relative, make it absolute (relative to the staging dir)
-            mapping.dest = path.resolve(this.stagingFolderPath, mapping.dest);
+            mapping.dest = path.resolve(this.stagingDir, mapping.dest);
             //standardize the paths once here, and don't need to do it again anywhere else in this project
             mapping.src = fileUtils.standardizePath(mapping.src);
             mapping.dest = fileUtils.standardizePath(mapping.dest);
@@ -572,8 +571,8 @@ export class ComponentLibraryProject extends Project {
          */
         this.fileMappings = await this.getFileMappings();
 
-        let expectedManifestDestPath = fileUtils.standardizePath(`${this.stagingFolderPath}/manifest`).toLowerCase();
-        //find the file entry with the `dest` value of `${stagingFolderPath}/manifest` (case insensitive)
+        let expectedManifestDestPath = fileUtils.standardizePath(`${this.stagingDir}/manifest`).toLowerCase();
+        //find the file entry with the `dest` value of `${stagingDir}/manifest` (case insensitive)
         let manifestFileEntry = this.fileMappings.find(x => x.dest.toLowerCase() === expectedManifestDestPath);
         if (manifestFileEntry) {
             //read the manifest from `src` since nothing has been copied to staging yet
@@ -583,18 +582,18 @@ export class ComponentLibraryProject extends Project {
         }
         let fileNameWithoutExtension = path.basename(this.outFile, path.extname(this.outFile));
 
-        let defaultStagingFolderPath = this.stagingFolderPath;
+        let defaultStagingDir = this.stagingDir;
 
         //compute the staging folder path.
-        this.stagingFolderPath = s`${this.outDir}/${fileNameWithoutExtension}`;
+        this.stagingDir = s`${this.outDir}/${fileNameWithoutExtension}`;
 
         /*
-          The fileMappings were created using the default stagingFolderPath (because we need the manifest path
-          to compute the out file name and staging path), so we need to replace the default stagingFolderPath
-          with the actual stagingFolderPath.
+          The fileMappings were created using the default stagingDir (because we need the manifest path
+          to compute the out file name and staging path), so we need to replace the default stagingDir
+          with the actual stagingDir.
          */
         for (let fileMapping of this.fileMappings) {
-            fileMapping.dest = fileUtils.replaceCaseInsensitive(fileMapping.dest, defaultStagingFolderPath, this.stagingFolderPath);
+            fileMapping.dest = fileUtils.replaceCaseInsensitive(fileMapping.dest, defaultStagingDir, this.stagingDir);
         }
 
         return super.stage();
@@ -612,12 +611,12 @@ export class ComponentLibraryProject extends Project {
         let pathDetails = {};
         await Promise.all(this.fileMappings.map(async (fileMapping) => {
             let relativePath = fileUtils.removeLeadingSlash(
-                fileUtils.getRelativePath(this.stagingFolderPath, fileMapping.dest)
+                fileUtils.getRelativePath(this.stagingDir, fileMapping.dest)
             );
             let postfixedPath = fileUtils.postfixFilePath(relativePath, this.postfix, ['.brs']);
             if (postfixedPath !== relativePath) {
                 // Rename the brs files to include the postfix namespacing tag
-                await fsExtra.move(fileMapping.dest, path.join(this.stagingFolderPath, postfixedPath));
+                await fsExtra.move(fileMapping.dest, path.join(this.stagingDir, postfixedPath));
                 // Add to the map of original paths and the new paths
                 pathDetails[postfixedPath] = relativePath;
             }
@@ -626,8 +625,8 @@ export class ComponentLibraryProject extends Project {
         // Update all the file name references in the library to the new file names
         await replaceInFile({
             files: [
-                path.join(this.stagingFolderPath, '**/*.xml'),
-                path.join(this.stagingFolderPath, '**/*.brs')
+                path.join(this.stagingDir, '**/*.xml'),
+                path.join(this.stagingDir, '**/*.brs')
             ],
             from: /uri\s*=\s*"(.+)\.brs"/gi,
             to: (match: string) => {


### PR DESCRIPTION
Convert all internal usage of `stagingFolderPath` to `stagingDir`. Still support `stagingFolderPath` as a launch option, but we immediately set stagingDir to stagingFolderPath. 

`stagingDir` wins, and if not set, check for `stagingFolderPath`.