### PR TITLE
Optional Chainging Operator errors in debug console

### DIFF
--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -283,6 +283,9 @@ describe('Util', () => {
             expect(util.getVariablePath('m.global.initialInputEvent.0[123]')).undefined;
             expect(util.getVariablePath('m.global.initialInputEvent.0[123]["this \"-that.thing"]')).undefined;
             expect(util.getVariablePath('m.global["something with a quote"]initialInputEvent.0[123]["this \"-that.thing"]')).undefined;
+            expect(util.getVariablePath('m.top.gridState?.leftEdgeTime')).undefined;
+            expect(util.getVariablePath('m.top.gridState?["leftEdgeTime"]')).undefined;
+            expect(util.getVariablePath('m.top.gridState?.["leftEdgeTime"]')).undefined;
         });
     });
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -296,9 +296,15 @@ class Util {
                 parts.unshift(value.name.text);
                 return parts;
             } else if (isDottedGetExpression(value)) {
+                if (value.dot.text.includes('?')) {
+                    return;
+                }
                 parts.unshift(value.name.text);
                 value = value.obj;
             } else if (isIndexedGetExpression(value)) {
+                if (value.questionDotToken?.text.includes('?') || value.openingSquare?.text.includes('?')) {
+                    return;
+                }
                 if (isLiteralExpression(value.index)) {
                     parts.unshift(
                         value.index.token.text


### PR DESCRIPTION
When evaluating an expression with the optional chaining operator, where the operator is not used for the last (rightmost) path part, an error results in the debug console.

The fix is to send the expression (a dotted chain of variable names) as a whole assignment. Example: m.top.b?.c => '_var = m.top.b?.c'

Tested on OS 12.5 and added unit tests to the roku-debug workspace