### PR TITLE
Prevent corrupted breakpoints due to invalid sourceDirs, add more logging

### DIFF
--- a/src/adapters/DebugProtocolAdapter.ts
+++ b/src/adapters/DebugProtocolAdapter.ts
@@ -847,6 +847,7 @@ export class DebugProtocolAdapter {
         //we can't send breakpoints unless we're stopped (or in a protocol version that supports sending them while running).
         //So...if we're not stopped, quit now. (we'll get called again when the stop event happens)
         if (!this.client?.supportsBreakpointRegistrationWhileRunning && !this.isAtDebuggerPrompt) {
+            this.logger.info('Cannot sync breakpoints because the debugger', this.client.supportsBreakpointRegistrationWhileRunning ? 'does not support sending breakpoints while running' : 'is not paused');
             return;
         }
 

--- a/src/adapters/DebugProtocolAdapter.ts
+++ b/src/adapters/DebugProtocolAdapter.ts
@@ -855,6 +855,11 @@ export class DebugProtocolAdapter {
         const diff = await this.breakpointManager.getDiff(this.projectManager.getAllProjects());
         this.logger.log('Syncing breakpoints', diff);
 
+        if (diff.added.length === 0 && diff.removed.length === 0) {
+            this.logger.debug('No breakpoints to sync');
+            return;
+        }
+
         // REMOVE breakpoints (delete these breakpoints from the device)
         if (diff.removed.length > 0) {
             const response = await this.client.removeBreakpoints(
@@ -920,7 +925,6 @@ export class DebugProtocolAdapter {
                         breakpoints.map(x => x.srcHash)
                     );
                 }
-
             }
         }
     }

--- a/src/debugProtocol/client/DebugProtocolClient.ts
+++ b/src/debugProtocol/client/DebugProtocolClient.ts
@@ -46,7 +46,7 @@ import type { AddConditionalBreakpointsResponse } from '../events/responses/AddC
 
 export class DebugProtocolClient {
 
-    public logger = logger.createLogger(`[client]`);
+    public logger = logger.createLogger(`[dpclient]`);
 
     // The highest tested version of the protocol we support.
     public supportedVersionRange = '<=3.2.0';

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -804,7 +804,7 @@ export class BrightScriptDebugSession extends BaseDebugSession {
      * Called every time a breakpoint is created, modified, or deleted, for each file. This receives the entire list of breakpoints every time.
      */
     public async setBreakPointsRequest(response: DebugProtocol.SetBreakpointsResponse, args: DebugProtocol.SetBreakpointsArguments) {
-        this.logger.log('setBreakpointsRequest');
+        this.logger.log('setBreakpointsRequest', args);
         let sanitizedBreakpoints = this.breakpointManager.replaceBreakpoints(args.source.path, args.breakpoints);
         //sort the breakpoints
         let sortedAndFilteredBreakpoints = orderBy(sanitizedBreakpoints, [x => x.line, x => x.column]);
@@ -814,7 +814,6 @@ export class BrightScriptDebugSession extends BaseDebugSession {
         };
         this.sendResponse(response);
 
-        this.logger.debug('[setBreakpointsRequest] syncBreakpoints()', args);
         await this.rokuAdapter?.syncBreakpoints();
     }
 


### PR DESCRIPTION
Prevent breakpoints from becoming corrupted due to bad sourceDirs entries.
Also adds many `.debug` logs during the breakpoint flows.