### PR TITLE
Add a specific message for the 577 error code

### DIFF
--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -566,7 +566,7 @@ export class BrightScriptDebugSession extends BaseDebugSession {
             if (statusCode && statusCode !== 200) {
                 switch (statusCode) {
                     case 577:
-                        message = 'DebugServer: Error (577) - Your device requires a system update before accepting connections. Follow these instructions to manually check for updates https://support.roku.com/article/208755668.'
+                        message = 'DebugServer: Error (577) - Your device requires a system update before accepting connections. Follow these instructions to manually check for updates https://support.roku.com/article/208755668.';
                         this.showPopupMessage(message, 'error', true);
                         await this.shutdown(message);
                         break;

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -562,10 +562,19 @@ export class BrightScriptDebugSession extends BaseDebugSession {
             packageIsPublished = true;
         }).catch(async (e) => {
             const statusCode = e?.results?.response?.statusCode;
-            const message = e.message as string;
+            let message = e.message as string;
             if (statusCode && statusCode !== 200) {
-                this.showPopupMessage(message, 'error', true);
-                await this.shutdown(message);
+                switch (statusCode) {
+                    case 577:
+                        message = 'DebugServer: Error (577) - Your device requires a system update before accepting connections. Follow these instructions to manually check for updates https://support.roku.com/article/208755668.'
+                        this.showPopupMessage(message, 'error', true);
+                        await this.shutdown(message);
+                        break;
+                    default:
+                        this.showPopupMessage(message, 'error', true);
+                        await this.shutdown(message);
+                        break;
+                }
                 throw e;
             }
             this.logger.error(e);


### PR DESCRIPTION
When getting the 577 error code, we will display this specific message so developers have an easier time fixing their issue.

<img width="270" alt="Screenshot 2024-11-20 at 10 14 07 AM" src="https://github.com/user-attachments/assets/23b3464b-4296-4209-ba57-4ef7452e10da">
