### PR TITLE
Better handling of split log messages

### DIFF
--- a/src/adapters/DebugProtocolAdapter.ts
+++ b/src/adapters/DebugProtocolAdapter.ts
@@ -409,21 +409,18 @@ export class DebugProtocolAdapter {
             this.compileClient.on('data', (buffer) => {
                 let responseText = buffer.toString();
                 this.logger.info('CompileClient received data', { responseText });
-                if (!responseText.endsWith('\n')) {
-                    this.logger.debug('Buffer was split');
-                    // buffer was split, save the partial line
-                    lastPartialLine += responseText;
-                } else {
-                    if (lastPartialLine) {
-                        this.logger.debug('Previous response was split, so merging last response with this one', { lastPartialLine, responseText });
-                        // there was leftover lines, join the partial lines back together
-                        responseText = lastPartialLine + responseText;
-                        lastPartialLine = '';
-                    }
+
+                let logResult = util.handleLogFragments(lastPartialLine, buffer.toString());
+
+                // Save any remaining partial line for the next event
+                lastPartialLine = logResult.remaining;
+                if (logResult.completed) {
                     // Emit the completed io string.
-                    this.findWaitForDebuggerPrompt(responseText.trim());
-                    this.compileErrorProcessor.processUnhandledLines(responseText.trim());
-                    this.emit('unhandled-console-output', responseText.trim());
+                    this.findWaitForDebuggerPrompt(logResult.completed);
+                    this.compileErrorProcessor.processUnhandledLines(logResult.completed);
+                    this.emit('unhandled-console-output', logResult.completed);
+                } else {
+                    this.logger.debug('Buffer was split', lastPartialLine);
                 }
             });
 

--- a/src/debugProtocol/client/DebugProtocolClient.spec.ts
+++ b/src/debugProtocol/client/DebugProtocolClient.spec.ts
@@ -1188,7 +1188,7 @@ describe('DebugProtocolClient', () => {
             socket.write('hello\nworld\n');
 
             const output = await ioOutputPromise;
-            expect(output).to.eql('hello\nworld');
+            expect(output).to.eql('hello\nworld\n');
         });
 
         it('handles partial lines', async () => {
@@ -1217,7 +1217,7 @@ describe('DebugProtocolClient', () => {
             await outputMonitors[0].promise;
             socket.write('world\n');
             await outputMonitors[1].promise;
-            expect(await outputPromise).to.eql('hello world');
+            expect(await outputPromise).to.eql('hello world\n');
         });
 
         it('handles failed update', async () => {

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -668,8 +668,9 @@ export class BrightScriptDebugSession extends BaseDebugSession {
     private sendLogOutput(logOutput: string) {
         this.fileLoggingManager.writeRokuDeviceLog(logOutput);
         const lines = logOutput.split(/\r?\n/g);
-        for (let line of lines) {
-            line += '\n';
+        for (let i = 0; i < lines.length; i++) {
+            let line = lines[i];
+            line += i === lines.length - 1 ? '' : '\n';
             this.sendEvent(new OutputEvent(line, 'stdout'));
             this.sendEvent(new LogOutputEvent(line));
         }

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -670,7 +670,9 @@ export class BrightScriptDebugSession extends BaseDebugSession {
         const lines = logOutput.split(/\r?\n/g);
         for (let i = 0; i < lines.length; i++) {
             let line = lines[i];
-            line += i === lines.length - 1 ? '' : '\n';
+            if (i < lines.length - 1) {
+                line += '\n';
+            }
             this.sendEvent(new OutputEvent(line, 'stdout'));
             this.sendEvent(new LogOutputEvent(line));
         }

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -201,7 +201,7 @@ describe('Util', () => {
         });
     });
 
-    describe.only('processResponseChunk', () => {
+    describe('processResponseChunk', () => {
         it('handles no new lines', () => {
             expect(
                 util.handleLogFragments('', 'new string')

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -201,41 +201,41 @@ describe('Util', () => {
         });
     });
 
-    describe('processResponseChunk', () => {
+    describe('handleLogFragments', () => {
         it('handles no new lines', () => {
             expect(
                 util.handleLogFragments('', 'new string')
-            ).to.eql({ toEmit: '', remaining: 'new string' });
+            ).to.eql({ completed: '', remaining: 'new string' });
         });
 
         it('handles single new line', () => {
             expect(
                 util.handleLogFragments('', 'new string\n')
-            ).to.eql({ toEmit: 'new string\n', remaining: '' });
+            ).to.eql({ completed: 'new string\n', remaining: '' });
         });
 
         it('handles multiple new lines', () => {
             expect(
                 util.handleLogFragments('', 'new string\none new\nline\n')
-            ).to.eql({ toEmit: 'new string\none new\nline\n', remaining: '' });
+            ).to.eql({ completed: 'new string\none new\nline\n', remaining: '' });
         });
 
         it('handles partial lines', () => {
             expect(
                 util.handleLogFragments('', 'new string\none new\nline')
-            ).to.eql({ toEmit: 'new string\none new\n', remaining: 'line' });
+            ).to.eql({ completed: 'new string\none new\n', remaining: 'line' });
         });
 
         it('handles partial lines and concat', () => {
             expect(
                 util.handleLogFragments('new', ' string\none new\nline')
-            ).to.eql({ toEmit: 'new string\none new\n', remaining: 'line' });
+            ).to.eql({ completed: 'new string\none new\n', remaining: 'line' });
         });
 
         it('handles partial lines, concat, and new lines in the existing somehow', () => {
             expect(
                 util.handleLogFragments('new\n', ' string\none new\nline')
-            ).to.eql({ toEmit: 'new\n string\none new\n', remaining: 'line' });
+            ).to.eql({ completed: 'new\n string\none new\n', remaining: 'line' });
         });
     });
 

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -9,6 +9,7 @@ import * as dedent from 'dedent';
 import { util } from './util';
 import { util as bscUtil } from 'brighterscript';
 import { createSandbox } from 'sinon';
+import { describe } from 'mocha';
 const sinon = createSandbox();
 
 beforeEach(() => {
@@ -197,6 +198,44 @@ describe('Util', () => {
         it('should return undefined when the manifest is not found', async () => {
             let manifestObject = await util.convertManifestToObject(filePath);
             assert.equal(manifestObject, undefined);
+        });
+    });
+
+    describe.only('processResponseChunk', () => {
+        it('handles no new lines', () => {
+            expect(
+                util.handleLogFragments('', 'new string')
+            ).to.eql({ toEmit: '', remaining: 'new string' });
+        });
+
+        it('handles single new line', () => {
+            expect(
+                util.handleLogFragments('', 'new string\n')
+            ).to.eql({ toEmit: 'new string\n', remaining: '' });
+        });
+
+        it('handles multiple new lines', () => {
+            expect(
+                util.handleLogFragments('', 'new string\none new\nline\n')
+            ).to.eql({ toEmit: 'new string\none new\nline\n', remaining: '' });
+        });
+
+        it('handles partial lines', () => {
+            expect(
+                util.handleLogFragments('', 'new string\none new\nline')
+            ).to.eql({ toEmit: 'new string\none new\n', remaining: 'line' });
+        });
+
+        it('handles partial lines and concat', () => {
+            expect(
+                util.handleLogFragments('new', ' string\none new\nline')
+            ).to.eql({ toEmit: 'new string\none new\n', remaining: 'line' });
+        });
+
+        it('handles partial lines, concat, and new lines in the existing somehow', () => {
+            expect(
+                util.handleLogFragments('new\n', ' string\none new\nline')
+            ).to.eql({ toEmit: 'new\n string\none new\n', remaining: 'line' });
         });
     });
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -474,6 +474,24 @@ class Util {
     public isTransientVariable(variableName: string) {
         return /^__brs_.*?__$/.test(variableName);
     }
+
+    public handleLogFragments(currentFragment: string, newFragment: string): { completed: string; remaining: string } {
+        let lastNewlineIndex = newFragment.lastIndexOf('\n');
+        if (lastNewlineIndex === -1) {
+            currentFragment += newFragment;
+            return {
+                completed: '',
+                remaining: newFragment
+            };
+        }
+
+        let toEmit = currentFragment + newFragment.substring(0, lastNewlineIndex + 1);
+        let remaining = newFragment.substring(lastNewlineIndex + 1);
+        return {
+            completed: toEmit,
+            remaining
+        };
+    }
 }
 
 export function defer<T>() {


### PR DESCRIPTION
Fixes some bugs related to how we're handling split log messages. For example, if we received messages like this:
- `'hello w'`
- `'orld\nhow are you'`

We now join them together and emit `'hello world\n'` and hold onto `'how are you'` until we receive the next newline.

This fixes several issues related to incorrectly trimming newlines or leading whitespace chars. The console output should now be much more accurate to what the device originally sent. 