### PR TITLE
Fix ecp limited crash

### DIFF
--- a/src/RendezvousTracker.ts
+++ b/src/RendezvousTracker.ts
@@ -38,7 +38,7 @@ export class RendezvousTracker {
      * Determine if the current Roku device supports the ECP rendezvous tracking feature
      */
     public get doesHostSupportEcpRendezvousTracking() {
-        let softwareVersion = this.deviceInfo?.softwareVersion;
+        let softwareVersion: string = this.deviceInfo?.softwareVersion ?? '0.0.0';
         if (!semver.valid(softwareVersion)) {
             softwareVersion = '0.0.0';
         }
@@ -170,6 +170,7 @@ export class RendezvousTracker {
             // Toggle ECP tracking off and on to clear the log and then continue tracking
             let untrack = await this.toggleEcpRendezvousTracking('untrack');
             let track = await this.toggleEcpRendezvousTracking('track');
+
             const isEcpTrackingEnabled = untrack && track && await this.getIsEcpRendezvousTrackingEnabled();
             if (isEcpTrackingEnabled) {
                 this.logger.info('ECP tracking is enabled');
@@ -239,7 +240,7 @@ export class RendezvousTracker {
 
     /**
      * Enable/Disable ECP Rendezvous tracking on the Roku device
-     * @returns true if successful, false if there was an issue setting the value
+     * @returns true if the request succeeded, false if there was an issue setting the value, and does _not_ indicate the final enabled/disabled state of the setting.
      */
     public async toggleEcpRendezvousTracking(toggle: 'track' | 'untrack'): Promise<boolean> {
         try {
@@ -249,7 +250,8 @@ export class RendezvousTracker {
                 //not sure if we need this, but it works...so probably better to just leave it here
                 { body: '' }
             );
-            return true;
+            //this was successful if we got a 200 level status code (200-299)
+            return response.statusCode >= 200 && response.statusCode < 300;
         } catch (e) {
             return false;
         }

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -405,7 +405,12 @@ export class BrightScriptDebugSession extends BaseDebugSession {
                 util.log(`Connecting to Roku via telnet at ${this.launchConfiguration.host}:${this.launchConfiguration.brightScriptConsolePort}`);
             }
 
-            await this.initRendezvousTracking();
+            //activate rendezvous tracking (if enabled). Log the error and move on if it crashes, this shouldn't bring down the session.
+            try {
+                await this.initRendezvousTracking();
+            } catch (e) {
+                this.logger.error('Failed to initialize rendezvous tracking', e);
+            }
 
             this.createRokuAdapter(this.rendezvousTracker);
             await this.connectRokuAdapter();


### PR DESCRIPTION
Fixes a crash related to the new "limited" modes of the ECP features of Roku. The bug was related to rendezvous tracking not being safe enough to sanitize the http responses when enabling/disabling the feature, and the crash would bring down the entire debug session. Now we sanitize better, and also try/catch the whole flow so it's safer.