### PR TITLE
Bugfix/UI flicker on invalidated events

### DIFF
--- a/src/adapters/customVariables/ifGetMessagePort.ts
+++ b/src/adapters/customVariables/ifGetMessagePort.ts
@@ -6,8 +6,8 @@ import { pushCustomVariableToContainer } from './utils';
 export function pushIfGetMessagePortVariables(adapter: DebugProtocolAdapter, expression: string, container: EvaluateContainer) {
     pushCustomVariableToContainer(adapter, container, {
         name: '$messagePort',
-        type: '',
-        presentationHint: { kind: 'virtual', lazy: true },
+        type: VariableType.Object,
+        presentationHint: { kind: 'virtual' },
         evaluateName: `${expression}.GetMessagePort()`,
         value: '',
         children: []

--- a/src/adapters/customVariables/ifImageMetadata.ts
+++ b/src/adapters/customVariables/ifImageMetadata.ts
@@ -6,8 +6,8 @@ import { pushCustomVariableToContainer } from './utils';
 export function pushIfImageMetadataVariables(adapter: DebugProtocolAdapter, expression: string, container: EvaluateContainer) {
     pushCustomVariableToContainer(adapter, container, {
         name: '$metadata',
-        type: '',
-        presentationHint: { kind: 'virtual', lazy: true },
+        type: VariableType.Object,
+        presentationHint: { kind: 'virtual' },
         evaluateName: `${expression}.GetMetadata()`,
         value: '',
         children: []
@@ -15,8 +15,8 @@ export function pushIfImageMetadataVariables(adapter: DebugProtocolAdapter, expr
 
     pushCustomVariableToContainer(adapter, container, {
         name: '$thumbnail',
-        type: '',
-        presentationHint: { kind: 'virtual', lazy: true },
+        type: VariableType.Object,
+        presentationHint: { kind: 'virtual' },
         evaluateName: `${expression}.GetThumbnail()`,
         value: '',
         children: []

--- a/src/adapters/customVariables/ifRegion.ts
+++ b/src/adapters/customVariables/ifRegion.ts
@@ -6,8 +6,8 @@ import { pushCustomVariableToContainer } from './utils';
 export function pushIfRegionVariables(adapter: DebugProtocolAdapter, expression: string, container: EvaluateContainer) {
     pushCustomVariableToContainer(adapter, container, {
         name: '$bitmap',
-        type: '',
-        presentationHint: { kind: 'virtual', lazy: true },
+        type: VariableType.Object,
+        presentationHint: { kind: 'virtual' },
         evaluateName: `${expression}.GetBitmap()`,
         value: '',
         children: []

--- a/src/adapters/customVariables/ifSGNodeChildren.ts
+++ b/src/adapters/customVariables/ifSGNodeChildren.ts
@@ -33,7 +33,7 @@ export function pushIfSGNodeChildrenVariables(adapter: DebugProtocolAdapter, exp
     pushCustomVariableToContainer(adapter, container, {
         name: '$scene',
         type: VariableType.SubtypedObject,
-        presentationHint: { kind: 'virtual', lazy: true },
+        presentationHint: { kind: 'virtual' },
         evaluateName: `${expression}.getScene()`,
         value: '',
         children: []

--- a/src/adapters/customVariables/ifSGNodeField.ts
+++ b/src/adapters/customVariables/ifSGNodeField.ts
@@ -16,7 +16,7 @@ export function pushIfSGNodeFieldVariables(adapter: DebugProtocolAdapter, expres
     pushCustomVariableToContainer(adapter, container, {
         name: '$threadInfo',
         type: VariableType.AssociativeArray,
-        presentationHint: { kind: 'virtual', lazy: true },
+        presentationHint: { kind: 'virtual' },
         evaluateName: `${expression}.threadInfo()`,
         value: VariableType.AssociativeArray,
         children: []

--- a/src/adapters/customVariables/ifSGNodeHttpAgentAccess.ts
+++ b/src/adapters/customVariables/ifSGNodeHttpAgentAccess.ts
@@ -6,8 +6,8 @@ import { pushCustomVariableToContainer } from './utils';
 export function pushIfSGNodeHttpAgentAccessVariables(adapter: DebugProtocolAdapter, expression: string, container: EvaluateContainer) {
     pushCustomVariableToContainer(adapter, container, {
         name: '$httpAgent',
-        type: '',
-        presentationHint: { kind: 'virtual', lazy: true },
+        type: VariableType.Object,
+        presentationHint: { kind: 'virtual' },
         evaluateName: `${expression}.getHttpAgent()`,
         value: '',
         children: []

--- a/src/adapters/customVariables/ifSGScreen.ts
+++ b/src/adapters/customVariables/ifSGScreen.ts
@@ -6,8 +6,8 @@ import { pushCustomVariableToContainer } from './utils';
 export function pushIfSGScreenVariables(adapter: DebugProtocolAdapter, expression: string, container: EvaluateContainer) {
     pushCustomVariableToContainer(adapter, container, {
         name: '$messagePort',
-        type: '',
-        presentationHint: { kind: 'virtual', lazy: true },
+        type: VariableType.Object,
+        presentationHint: { kind: 'virtual' },
         evaluateName: `${expression}.GetMessagePort()`,
         value: '',
         children: []
@@ -24,7 +24,7 @@ export function pushIfSGScreenVariables(adapter: DebugProtocolAdapter, expressio
 
     pushCustomVariableToContainer(adapter, container, {
         name: '$scene',
-        type: VariableType.Object,
+        type: VariableType.SubtypedObject,
         presentationHint: { kind: 'virtual' },
         evaluateName: `${expression}.GetScene()`,
         value: '',

--- a/src/adapters/customVariables/ifSocket.ts
+++ b/src/adapters/customVariables/ifSocket.ts
@@ -6,8 +6,8 @@ import { pushCustomVariableToContainer } from './utils';
 export function pushIfSocketVariables(adapter: DebugProtocolAdapter, expression: string, container: EvaluateContainer) {
     pushCustomVariableToContainer(adapter, container, {
         name: '$address',
-        type: '',
-        presentationHint: { kind: 'virtual', lazy: true },
+        type: VariableType.Object,
+        presentationHint: { kind: 'virtual' },
         evaluateName: `${expression}.GetAddress()`,
         value: '',
         children: []
@@ -15,8 +15,8 @@ export function pushIfSocketVariables(adapter: DebugProtocolAdapter, expression:
 
     pushCustomVariableToContainer(adapter, container, {
         name: '$sendToAddress',
-        type: '',
-        presentationHint: { kind: 'virtual', lazy: true },
+        type: VariableType.Object,
+        presentationHint: { kind: 'virtual' },
         evaluateName: `${expression}.GetSendToAddress()`,
         value: '',
         children: []
@@ -24,8 +24,8 @@ export function pushIfSocketVariables(adapter: DebugProtocolAdapter, expression:
 
     pushCustomVariableToContainer(adapter, container, {
         name: '$receivedFromAddress',
-        type: '',
-        presentationHint: { kind: 'virtual', lazy: true },
+        type: VariableType.Object,
+        presentationHint: { kind: 'virtual' },
         evaluateName: `${expression}.GetReceivedFromAddress()`,
         value: '',
         children: []

--- a/src/adapters/customVariables/ifSprite.ts
+++ b/src/adapters/customVariables/ifSprite.ts
@@ -60,8 +60,8 @@ export function pushIfSpriteVariables(adapter: DebugProtocolAdapter, expression:
 
     pushCustomVariableToContainer(adapter, container, {
         name: '$region',
-        type: '',
-        presentationHint: { kind: 'virtual', lazy: true },
+        type: VariableType.Object,
+        presentationHint: { kind: 'virtual' },
         evaluateName: `${expression}.GetRegion()`,
         value: '',
         children: []

--- a/src/adapters/customVariables/ifVideoPlayer.ts
+++ b/src/adapters/customVariables/ifVideoPlayer.ts
@@ -24,8 +24,8 @@ export function pushIfVideoPlayerVariables(adapter: DebugProtocolAdapter, expres
 
     pushCustomVariableToContainer(adapter, container, {
         name: '$captionRenderer',
-        type: 'roCaptionRenderer',
-        presentationHint: { kind: 'virtual', lazy: true },
+        type: VariableType.Object,
+        presentationHint: { kind: 'virtual' },
         evaluateName: `${expression}.GetCaptionRenderer()`,
         value: '',
         children: []

--- a/src/adapters/customVariables/ifXMLElement.ts
+++ b/src/adapters/customVariables/ifXMLElement.ts
@@ -42,8 +42,8 @@ export function pushIfXMLElementVariables(adapter: DebugProtocolAdapter, express
 
     pushCustomVariableToContainer(adapter, container, {
         name: '$childElements',
-        type: '',
-        presentationHint: { kind: 'virtual', lazy: true },
+        type: VariableType.List,
+        presentationHint: { kind: 'virtual' },
         evaluateName: `${expression}.GetChildElements()`,
         value: '',
         children: []
@@ -51,8 +51,8 @@ export function pushIfXMLElementVariables(adapter: DebugProtocolAdapter, express
 
     pushCustomVariableToContainer(adapter, container, {
         name: '$childNodes',
-        type: '',
-        presentationHint: { kind: 'virtual', lazy: true },
+        type: VariableType.List,
+        presentationHint: { kind: 'virtual' },
         evaluateName: `${expression}.GetChildNodes()`,
         value: '',
         children: []

--- a/src/adapters/customVariables/ifXMLList.ts
+++ b/src/adapters/customVariables/ifXMLList.ts
@@ -6,8 +6,8 @@ import { pushCustomVariableToContainer } from './utils';
 export function pushIfXMLListVariables(adapter: DebugProtocolAdapter, expression: string, container: EvaluateContainer) {
     pushCustomVariableToContainer(adapter, container, {
         name: '$attributes',
-        type: '',
-        presentationHint: { kind: 'virtual', lazy: true },
+        type: VariableType.List,
+        presentationHint: { kind: 'virtual' },
         evaluateName: `${expression}.GetAttributes()`,
         value: '',
         children: []
@@ -24,8 +24,8 @@ export function pushIfXMLListVariables(adapter: DebugProtocolAdapter, expression
 
     pushCustomVariableToContainer(adapter, container, {
         name: '$childElements',
-        type: '',
-        presentationHint: { kind: 'virtual', lazy: true },
+        type: VariableType.List,
+        presentationHint: { kind: 'virtual' },
         evaluateName: `${expression}.GetChildElements()`,
         value: '',
         children: []

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -1438,8 +1438,10 @@ export class BrightScriptDebugSession extends BaseDebugSession {
                 }
             }
 
+            // Only send the updated variables if we are not going to trigger an invalidated event.
+            // This is to prevent the UI from updating twice and makes the experience much smoother to the end user.
             response.body = {
-                variables: this.filterVariablesUpdates(updatedVariables, args, this.variables[args.variablesReference])
+                variables: sendInvalidatedEvent ? [] : this.filterVariablesUpdates(updatedVariables, args, this.variables[args.variablesReference])
             };
         } catch (error) {
             logger.error('Error during variablesRequest', error, { args });


### PR DESCRIPTION
- updates the variable request flow to return zero updated variables if an invalidated event will be triggered anyway to prevent double UI updates
- updated many custom virtual variables to object types and removed lazy as they will auto open when fetched and if the type changes they will update in place. Saving the user from needing to click the eyeball and then expand.