### PR TITLE
Updated the breakpoint manager to fail inline break point requests

### DIFF
--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -93,6 +93,8 @@ export class BrightScriptDebugSession extends BaseDebugSession {
                 column: breakpoint.column,
                 verified: breakpoint.verified,
                 id: breakpoint.id,
+                reason: breakpoint.reason,
+                message: breakpoint.message,
                 source: {
                     path: breakpoint.srcPath
                 }

--- a/src/managers/BreakpointManager.spec.ts
+++ b/src/managers/BreakpointManager.spec.ts
@@ -1105,17 +1105,14 @@ describe('BreakpointManager', () => {
             });
         });
 
-        it('detects column number change (roku does not support this yet, but we might as well...)', async () => {
+        it('does not create work for inline breakpoints', async () => {
             bpManager.replaceBreakpoints(s`${rootDir}/source/main.brs`, [{
                 line: 2,
                 column: 4
             }]);
 
             await testDiffEquals({
-                added: [{
-                    line: 2,
-                    column: 4
-                }]
+                added: []
             });
 
             bpManager.replaceBreakpoints(s`${rootDir}/source/main.brs`, [{
@@ -1124,44 +1121,8 @@ describe('BreakpointManager', () => {
             }]);
 
             await testDiffEquals({
-                removed: [{
-                    line: 2,
-                    column: 4
-                }],
-                added: [{
-                    line: 2,
-                    column: 8
-                }]
-            });
-        });
-
-        it('maintains breakpoint IDs', async () => {
-            bpManager.replaceBreakpoints(s`${rootDir}/source/main.brs`, [{
-                line: 2,
-                column: 4
-            }]);
-
-            await testDiffEquals({
-                added: [{
-                    line: 2,
-                    column: 4
-                }]
-            });
-
-            bpManager.replaceBreakpoints(s`${rootDir}/source/main.brs`, [{
-                line: 2,
-                column: 8
-            }]);
-
-            await testDiffEquals({
-                removed: [{
-                    line: 2,
-                    column: 4
-                }],
-                added: [{
-                    line: 2,
-                    column: 8
-                }]
+                removed: [],
+                added: []
             });
         });
 


### PR DESCRIPTION
The BP manager would not mark inline breakpoints as failed in the UI and would also try to send these to the device when there was no need to do so.