### PR TITLE
Fix crash in bsc project when thread has error

### DIFF
--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -1864,15 +1864,20 @@ export class BrightScriptDebugSession extends BaseDebugSession {
                         }
 
                         const frame = this.rokuAdapter.getStackFrameById(args.frameId);
-                        let scopeFunctions = await this.projectManager.getScopeFunctionsForFile(frame.filePath as string);
-                        for (let scopeFunction of scopeFunctions) {
-                            if (!completions.has(`${scopeFunction.completionItemKind}-${scopeFunction.name.toLocaleLowerCase()}`)) {
-                                completions.set(`${scopeFunction.completionItemKind}-${scopeFunction.name.toLocaleLowerCase()}`, {
-                                    label: scopeFunction.name,
-                                    type: scopeFunction.completionItemKind,
-                                    sortText: '000000'
-                                });
+
+                        try {
+                            let scopeFunctions = await this.projectManager.getScopeFunctionsForFile(frame.filePath as string);
+                            for (let scopeFunction of scopeFunctions) {
+                                if (!completions.has(`${scopeFunction.completionItemKind}-${scopeFunction.name.toLocaleLowerCase()}`)) {
+                                    completions.set(`${scopeFunction.completionItemKind}-${scopeFunction.name.toLocaleLowerCase()}`, {
+                                        label: scopeFunction.name,
+                                        type: scopeFunction.completionItemKind,
+                                        sortText: '000000'
+                                    });
+                                }
                             }
+                        } catch (e) {
+                            this.logger.warn('Could not build list of scope functions for file', e);
                         }
                     }
                 }


### PR DESCRIPTION
Gracefully recover whenever the bsc project worker thread crashes (instead of bringing down the entire process...).

The fix was to observer the `.on('error'` event from the worker thread. But then also, when we reject a deferred, if nobody is listening then that will _also_ crash node so we need to immediately observer the rejection and ignore the error. 