### PR TITLE
Limit the range of scopes

### DIFF
--- a/src/bsc/BscProject.ts
+++ b/src/bsc/BscProject.ts
@@ -1,4 +1,5 @@
-import { ProgramBuilder } from 'brighterscript';
+import type { BrsFile, Position, Range } from 'brighterscript';
+import { isFunctionExpression, ProgramBuilder } from 'brighterscript';
 import type { MaybePromise } from '../interfaces';
 import type { DebugProtocol } from '@vscode/debugprotocol';
 
@@ -46,6 +47,21 @@ export class BscProject {
                 completionItemKind: count === scopes.length ? 'function' : 'text'
             };
         });
+    }
+
+    /**
+     * Get the range of the scope that contains the specified position
+     */
+    public getScopeRange(options: { relativePath: string; position: Position }): MaybePromise<Range> {
+        try {
+            const file = this.programBuilder.program.getFile<BrsFile>(options.relativePath);
+            const expression = file.getClosestExpression(options.position);
+            const parentFunction = expression.findAncestor(isFunctionExpression);
+
+            return parentFunction.range;
+        } catch (error) {
+            return undefined;
+        }
     }
 
     public dispose() {

--- a/src/bsc/BscProjectThreaded.ts
+++ b/src/bsc/BscProjectThreaded.ts
@@ -1,4 +1,5 @@
-import { Deferred, type ProgramBuilder } from 'brighterscript';
+import { Deferred } from 'brighterscript';
+import type { Position, ProgramBuilder, Range } from 'brighterscript';
 import type { ExtractMethods, DisposableLike, MaybePromise } from '../interfaces';
 import type { BscProject, ScopeFunction } from './BscProject';
 import { bscProjectWorkerPool } from './threading/BscProjectWorkerPool';
@@ -85,12 +86,17 @@ export class BscProjectThreaded implements ExtractMethods<BscProject> {
     }
 
     /**
-     * Get all of the functions avaiable for all scopes for this file.
-     * @param relativePath path to the file relative to rootDir
-     * @returns
+     * Get all of the functions available for all scopes for this file.
      */
     public async getScopeFunctionsForFile(options: { relativePath: string }): Promise<Array<ScopeFunction>> {
         return this.sendStandardRequest('getScopeFunctionsForFile', options);
+    }
+
+    /**
+     * Get the range of the scope that contains the specified position
+     */
+    public getScopeRange(options: { relativePath: string; position: Position }): Promise<Range> {
+        return this.sendStandardRequest('getScopeRange', options);
     }
 
     /**

--- a/src/debugSession/BrightScriptDebugSession.spec.ts
+++ b/src/debugSession/BrightScriptDebugSession.spec.ts
@@ -1541,7 +1541,7 @@ describe('BrightScriptDebugSession', () => {
     describe('completionsRequest', () => {
         describe('getClosestCompletionDetails', () => {
             it('handles empty string columnsStartAt1 false', () => {
-                session['initRequestArgs']['columnsStartAt1'] = false;
+                session['_clientColumnsStartAt1'] = false;
                 expect(session['getClosestCompletionDetails']({
                     text: '',
                     column: 0,
@@ -1553,7 +1553,7 @@ describe('BrightScriptDebugSession', () => {
             });
 
             it('handles empty string columnsStartAt1 true', () => {
-                session['initRequestArgs']['columnsStartAt1'] = true;
+                session['_clientColumnsStartAt1'] = true;
                 expect(session['getClosestCompletionDetails']({
                     text: '',
                     column: 1,
@@ -1565,7 +1565,7 @@ describe('BrightScriptDebugSession', () => {
             });
 
             it('handles bad variable path columnsStartAt1 false', () => {
-                session['initRequestArgs']['columnsStartAt1'] = false;
+                session['_clientColumnsStartAt1'] = false;
                 expect(session['getClosestCompletionDetails']({
                     text: '1bad.path',
                     column: 9,
@@ -1575,7 +1575,7 @@ describe('BrightScriptDebugSession', () => {
             });
 
             it('handles bad variable path columnsStartAt1 true', () => {
-                session['initRequestArgs']['columnsStartAt1'] = true;
+                session['_clientColumnsStartAt1'] = true;
                 expect(session['getClosestCompletionDetails']({
                     text: '1bad.path',
                     column: 10,
@@ -1585,7 +1585,7 @@ describe('BrightScriptDebugSession', () => {
             });
 
             it('handles simple input of just variable path columnsStartAt1 false', () => {
-                session['initRequestArgs']['columnsStartAt1'] = false;
+                session['_clientColumnsStartAt1'] = false;
                 expect(session['getClosestCompletionDetails']({
                     text: 'person.name',
                     column: 11,
@@ -1597,7 +1597,7 @@ describe('BrightScriptDebugSession', () => {
             });
 
             it('handles simple input of just variable path columnsStartAt1 true', () => {
-                session['initRequestArgs']['columnsStartAt1'] = true;
+                session['_clientColumnsStartAt1'] = true;
                 expect(session['getClosestCompletionDetails']({
                     text: 'person.name',
                     column: 12,
@@ -1609,7 +1609,7 @@ describe('BrightScriptDebugSession', () => {
             });
 
             it('handles simple input of just variable path with training period columnsStartAt1 false', () => {
-                session['initRequestArgs']['columnsStartAt1'] = false;
+                session['_clientColumnsStartAt1'] = false;
                 expect(session['getClosestCompletionDetails']({
                     text: 'person.name.',
                     column: 12,
@@ -1621,7 +1621,7 @@ describe('BrightScriptDebugSession', () => {
             });
 
             it('handles simple input of just variable path with training period columnsStartAt1 true', () => {
-                session['initRequestArgs']['columnsStartAt1'] = true;
+                session['_clientColumnsStartAt1'] = true;
                 expect(session['getClosestCompletionDetails']({
                     text: 'person.name.',
                     column: 13,
@@ -1633,7 +1633,7 @@ describe('BrightScriptDebugSession', () => {
             });
 
             it('handles simple input of just variable path columnsStartAt1 false but cursor is not at the end', () => {
-                session['initRequestArgs']['columnsStartAt1'] = false;
+                session['_clientColumnsStartAt1'] = false;
                 expect(session['getClosestCompletionDetails']({
                     text: 'person.name',
                     column: 9,
@@ -1643,7 +1643,7 @@ describe('BrightScriptDebugSession', () => {
             });
 
             it('handles simple input of just variable path columnsStartAt1 true but cursor is not at the end', () => {
-                session['initRequestArgs']['columnsStartAt1'] = true;
+                session['_clientColumnsStartAt1'] = true;
                 expect(session['getClosestCompletionDetails']({
                     text: 'person.name',
                     column: 10,
@@ -1653,7 +1653,7 @@ describe('BrightScriptDebugSession', () => {
             });
 
             it('returns undefined following closing brackets columnsStartAt1 false but cursor is not at the end', () => {
-                session['initRequestArgs']['columnsStartAt1'] = false;
+                session['_clientColumnsStartAt1'] = false;
                 expect(session['getClosestCompletionDetails']({
                     text: 'getPerson().name',
                     column: 16,
@@ -1670,7 +1670,7 @@ describe('BrightScriptDebugSession', () => {
             });
 
             it('returns undefined following closing brackets columnsStartAt1 true but cursor is not at the end', () => {
-                session['initRequestArgs']['columnsStartAt1'] = true;
+                session['_clientColumnsStartAt1'] = true;
                 expect(session['getClosestCompletionDetails']({
                     text: 'getPerson().name',
                     column: 17,
@@ -1688,7 +1688,7 @@ describe('BrightScriptDebugSession', () => {
 
 
             it('input after a open bracket columnsStartAt1 false', () => {
-                session['initRequestArgs']['columnsStartAt1'] = false;
+                session['_clientColumnsStartAt1'] = false;
                 expect(session['getClosestCompletionDetails']({
                     text: 'getValue(person.name',
                     column: 20,
@@ -1709,7 +1709,7 @@ describe('BrightScriptDebugSession', () => {
             });
 
             it('input after a open bracket columnsStartAt1 true', () => {
-                session['initRequestArgs']['columnsStartAt1'] = true;
+                session['_clientColumnsStartAt1'] = true;
                 expect(session['getClosestCompletionDetails']({
                     text: 'getValue(person.name',
                     column: 21,
@@ -1730,7 +1730,7 @@ describe('BrightScriptDebugSession', () => {
             });
 
             it('input after a open bracket with training closing bracket columnsStartAt1 false', () => {
-                session['initRequestArgs']['columnsStartAt1'] = false;
+                session['_clientColumnsStartAt1'] = false;
                 expect(session['getClosestCompletionDetails']({
                     text: 'getValue(person.name)',
                     column: 20,
@@ -1742,7 +1742,7 @@ describe('BrightScriptDebugSession', () => {
             });
 
             it('input after a open bracket with training closing bracket columnsStartAt1 true', () => {
-                session['initRequestArgs']['columnsStartAt1'] = true;
+                session['_clientColumnsStartAt1'] = true;
                 expect(session['getClosestCompletionDetails']({
                     text: 'getValue(person.name)',
                     column: 21,
@@ -1754,7 +1754,7 @@ describe('BrightScriptDebugSession', () => {
             });
 
             it('input after a open bracket with training closing bracket columnsStartAt1 false', () => {
-                session['initRequestArgs']['columnsStartAt1'] = false;
+                session['_clientColumnsStartAt1'] = false;
                 expect(session['getClosestCompletionDetails']({
                     text: 'getValue(person.name, test)',
                     column: 26,
@@ -1775,7 +1775,7 @@ describe('BrightScriptDebugSession', () => {
             });
 
             it('input after a open bracket with training closing bracket columnsStartAt1 true', () => {
-                session['initRequestArgs']['columnsStartAt1'] = true;
+                session['_clientColumnsStartAt1'] = true;
                 expect(session['getClosestCompletionDetails']({
                     text: 'getValue(person.name, test)',
                     column: 27,
@@ -1796,8 +1796,8 @@ describe('BrightScriptDebugSession', () => {
             });
 
             it('handles multiline inout columnsStartAt1 false linesStartAt1 false', () => {
-                session['initRequestArgs']['columnsStartAt1'] = false;
-                session['initRequestArgs']['linesStartAt1'] = false;
+                session['_clientColumnsStartAt1'] = false;
+                session['_clientLinesStartAt1'] = false;
 
                 // cursor is on the first line
                 expect(session['getClosestCompletionDetails']({
@@ -1820,8 +1820,8 @@ describe('BrightScriptDebugSession', () => {
             });
 
             it('handles multiline inout columnsStartAt1 true linesStartAt1 true', () => {
-                session['initRequestArgs']['columnsStartAt1'] = true;
-                session['initRequestArgs']['linesStartAt1'] = true;
+                session['_clientColumnsStartAt1'] = true;
+                session['_clientLinesStartAt1'] = true;
 
                 // cursor is on the first line
                 expect(session['getClosestCompletionDetails']({

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -66,8 +66,8 @@ export class BrightScriptDebugSession extends BaseDebugSession {
         super();
 
         // this debugger uses one-based lines and columns
-        this.setDebuggerLinesStartAt1(true);
-        this.setDebuggerColumnsStartAt1(true);
+        this.setDebuggerLinesStartAt1(false);
+        this.setDebuggerColumnsStartAt1(false);
 
         //give util a reference to this session to assist in logging across the entire module
         util._debugSession = this;
@@ -2458,6 +2458,56 @@ export class BrightScriptDebugSession extends BaseDebugSession {
                 await this.projectManager.registerEntryBreakpoint(this.projectManager.mainProject.stagingDir);
             }
         }
+    }
+
+    /**
+     * Converts a debugger line number to a client line number.
+     *
+     * @param debuggerLine - The line number from the debugger as zero based.
+     * @param defaultDebuggerLine - An optional default line number, as zero based, to use if `debuggerLine` is not provided.
+     * @returns The corresponding client line number.
+     */
+    private toClientLine(debuggerLine: number, defaultDebuggerLine?: number) {
+        return this.convertDebuggerLineToClient(debuggerLine ?? defaultDebuggerLine);
+    }
+
+    /**
+     * Converts a debugger column number to a client column number.
+     *
+     * @param debuggerLine - The column number from the debugger as zero based.
+     * @param defaultDebuggerLine - An optional default column number, as zero based, to use if `debuggerLine` is not provided.
+     * @returns The corresponding client column number.
+     */
+    private toClientColumn(debuggerLine: number, defaultDebuggerLine?: number) {
+        return this.convertDebuggerColumnToClient(debuggerLine ?? defaultDebuggerLine);
+    }
+
+    /**
+     * Converts a client line number to a debugger line number.
+     *
+     * @param clientLine - The line number from the client.
+     * @param defaultDebuggerLine - An optional default line number, as zero based, to use if `clientLine` is not provided.
+     * @returns The corresponding debugger line number as zero based.
+     */
+    private toDebuggerLine(clientLine: number, defaultDebuggerLine?: number) {
+        if (typeof clientLine === 'number') {
+            return this.convertClientLineToDebugger(clientLine);
+        }
+        return defaultDebuggerLine;
+    }
+
+    /**
+     * Converts a client column number to a debugger column number.
+     *
+     * @param clientLine - The column number from the client.
+     * @param defaultDebuggerLine - An optional default column number, as zero based, to use if `clientLine` is not provided.
+     * @returns The corresponding debugger column number as zero based.
+     */
+    private toDebuggerColumn(clientLine: number, defaultDebuggerLine?: number) {
+        if (typeof clientLine === 'number') {
+            return this.convertClientColumnToDebugger(clientLine);
+        }
+        return defaultDebuggerLine;
     }
 
     private shutdownPromise: Promise<void> | undefined = undefined;

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -2490,13 +2490,13 @@ export class BrightScriptDebugSession extends BaseDebugSession {
         }
 
         try {
-            void this.rendezvousTracker?.destroy?.();
+            await this.rendezvousTracker?.destroy?.();
         } catch (e) {
             this.logger.error(e);
         }
 
         try {
-            this.sourceMapManager?.destroy?.();
+            await this.sourceMapManager?.destroy?.();
         } catch (e) {
             this.logger.error(e);
         }

--- a/src/managers/SourceMapManager.ts
+++ b/src/managers/SourceMapManager.ts
@@ -5,6 +5,7 @@ import { standardizePath as s, fileUtils } from '../FileUtils';
 import * as path from 'path';
 import type { SourceLocation } from './LocationManager';
 import { logger } from '../logging';
+import type { MaybePromise } from '../interfaces';
 
 /**
  * Unifies access to source files across the whole project
@@ -119,14 +120,19 @@ export class SourceMapManager {
         }
     }
 
-    private sourceMapConsumerCache: Record<string, SourceMapConsumer> = {};
+    private sourceMapConsumerCache: Record<string, MaybePromise<SourceMapConsumer>> = {};
 
     private async getSourceMapConsumer(sourceMapPath: string, parsedSourceMap: RawSourceMap) {
         let consumer = this.sourceMapConsumerCache[sourceMapPath];
         if (!consumer) {
-            consumer = await new SourceMapConsumer(parsedSourceMap);
+            this.sourceMapConsumerCache[sourceMapPath] = new SourceMapConsumer(parsedSourceMap);
+        }
+
+        if (typeof (consumer as Promise<SourceMapConsumer>)?.then === 'function') {
+            consumer = await consumer;
             this.sourceMapConsumerCache[sourceMapPath] = consumer;
         }
+
         return consumer;
     }
 
@@ -170,11 +176,18 @@ export class SourceMapManager {
         return locations;
     }
 
-    public destroy() {
+    public async destroy() {
         // Clean up all source map consumers
         for (let key in this.sourceMapConsumerCache) {
-            let consumer = this.sourceMapConsumerCache[key];
-            consumer?.destroy?.();
+            try {
+                let consumer = this.sourceMapConsumerCache[key];
+                if (typeof (consumer as Promise<SourceMapConsumer>)?.then === 'function') {
+                    consumer = await consumer;
+                }
+                (consumer as SourceMapConsumer)?.destroy?.();
+            } catch (error) {
+                this.logger.error('Error destroying source map consumer', key, { error });
+            }
         }
     }
 }

--- a/src/managers/SourceMapManager.ts
+++ b/src/managers/SourceMapManager.ts
@@ -125,7 +125,8 @@ export class SourceMapManager {
     private async getSourceMapConsumer(sourceMapPath: string, parsedSourceMap: RawSourceMap) {
         let consumer = this.sourceMapConsumerCache[sourceMapPath];
         if (!consumer) {
-            this.sourceMapConsumerCache[sourceMapPath] = new SourceMapConsumer(parsedSourceMap);
+            consumer = new SourceMapConsumer(parsedSourceMap);
+            this.sourceMapConsumerCache[sourceMapPath] = consumer;
         }
 
         if (typeof (consumer as Promise<SourceMapConsumer>)?.then === 'function') {


### PR DESCRIPTION
Improves the `scopes` request to limit to only the closest function body of the current line. This significantly improves the inline variables presentation during debug sessions. Here's a quick example: 

**Before:**
![image](https://github.com/user-attachments/assets/b71313c1-8cde-4282-9208-8911f86fdfdc)

**After:** (notice the variables in init no longer have inline variable highlights)
![image](https://github.com/user-attachments/assets/d4b28849-753a-4dc8-8f69-4f7380985632)



