### PR TITLE
Explicitly set the version of the package glob

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
                 "fast-glob": "^3.2.11",
                 "find-in-files": "^0.5.0",
                 "fs-extra": "^10.0.0",
+                "glob": "^7.2.0",
                 "natural-orderby": "^2.0.3",
                 "portfinder": "^1.0.32",
                 "postman-request": "^2.88.1-postman.40",
@@ -3381,15 +3382,16 @@
             }
         },
         "node_modules/glob": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-            "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
             "deprecated": "Glob versions prior to v9 are no longer supported",
+            "license": "ISC",
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
                 "inherits": "2",
-                "minimatch": "^3.0.4",
+                "minimatch": "^3.1.1",
                 "once": "^1.3.0",
                 "path-is-absolute": "^1.0.0"
             },

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
         "fast-glob": "^3.2.11",
         "find-in-files": "^0.5.0",
         "fs-extra": "^10.0.0",
+        "glob": "^7.2.0",
         "natural-orderby": "^2.0.3",
         "portfinder": "^1.0.32",
         "postman-request": "^2.88.1-postman.40",


### PR DESCRIPTION
If a package only relied on `roku-debug`, the `glob` package might not be included, or a wrong version used.