### PR TITLE
Add more logs to track how long each step takes while sideloading

### DIFF
--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -700,7 +700,7 @@ export class BrightScriptDebugSession extends BaseDebugSession {
 
         await publishPromise;
 
-        this.logger.log(`[duration] Uploading zip took ${Date.now() - start}ms`);
+        this.logger.log(`[duration] Uploading zip took: ${Date.now() - start}ms`);
 
         //the channel has been deployed. Wait for the adapter to finish connecting.
         //if it hasn't connected after 5 seconds, it probably will never connect.

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -369,7 +369,7 @@ export class BrightScriptDebugSession extends BaseDebugSession {
     }
 
     public async launchRequest(response: DebugProtocol.LaunchResponse, config: LaunchConfiguration) {
-        const logEnd = this.logger.timeStart('log', '[launchRequest] launch');
+        const logEnd = this.logger.timeStart('log', '[launchRequest] [duration] launch');
 
         this.resetSessionState();
 
@@ -421,7 +421,7 @@ export class BrightScriptDebugSession extends BaseDebugSession {
                 this.prepareMainProject(),
                 this.prepareAndHostComponentLibraries(this.launchConfiguration.componentLibraries, this.launchConfiguration.componentLibrariesPort)
             ]);
-            this.logger.log(`Packaging projects took: ${(util.formatTime(Date.now() - start))}`);
+            this.logger.log(`[duration] Packaging projects took: ${(util.formatTime(Date.now() - start))}`);
 
             if (this.enableDebugProtocol) {
                 util.log(`Connecting to Roku via the BrightScript debug protocol at ${this.launchConfiguration.host}:${this.launchConfiguration.controlPort}`);
@@ -431,13 +431,17 @@ export class BrightScriptDebugSession extends BaseDebugSession {
 
             //activate rendezvous tracking (if enabled). Log the error and move on if it crashes, this shouldn't bring down the session.
             try {
+                const start = Date.now();
                 await this.initRendezvousTracking();
+                this.logger.log(`[duration] Init rendezvous tracking took: ${(util.formatTime(Date.now() - start))}`);
             } catch (e) {
                 this.logger.error('Failed to initialize rendezvous tracking', e);
             }
 
+            const connectAdapterStart = Date.now();
             this.createRokuAdapter(this.rendezvousTracker);
             await this.connectRokuAdapter();
+            this.logger.log(`[duration] Connect adapter took: ${(util.formatTime(Date.now() - connectAdapterStart))}`);
 
             await this.runAutomaticSceneGraphCommands(this.launchConfiguration.autoRunSgDebugCommands);
 
@@ -696,7 +700,7 @@ export class BrightScriptDebugSession extends BaseDebugSession {
 
         await publishPromise;
 
-        this.logger.log(`Uploading zip took ${Date.now() - start}ms`);
+        this.logger.log(`[duration] Uploading zip took ${Date.now() - start}ms`);
 
         //the channel has been deployed. Wait for the adapter to finish connecting.
         //if it hasn't connected after 5 seconds, it probably will never connect.

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -369,7 +369,7 @@ export class BrightScriptDebugSession extends BaseDebugSession {
     }
 
     public async launchRequest(response: DebugProtocol.LaunchResponse, config: LaunchConfiguration) {
-        const logEnd = this.logger.timeStart('log', '[launchRequest] [duration] launch');
+        const logEnd = this.logger.timeStart('log', '[launchRequest] launch');
 
         this.resetSessionState();
 
@@ -415,13 +415,13 @@ export class BrightScriptDebugSession extends BaseDebugSession {
         let error: Error;
         this.logger.log('[launchRequest] Packaging and deploying to roku');
         try {
-            const start = Date.now();
+            const packageEnd = this.logger.timeStart('log', 'Packaging');
             //build the main project and all component libraries at the same time
             await Promise.all([
                 this.prepareMainProject(),
                 this.prepareAndHostComponentLibraries(this.launchConfiguration.componentLibraries, this.launchConfiguration.componentLibrariesPort)
             ]);
-            this.logger.log(`[duration] Packaging projects took: ${(util.formatTime(Date.now() - start))}`);
+            packageEnd();
 
             if (this.enableDebugProtocol) {
                 util.log(`Connecting to Roku via the BrightScript debug protocol at ${this.launchConfiguration.host}:${this.launchConfiguration.controlPort}`);
@@ -431,17 +431,17 @@ export class BrightScriptDebugSession extends BaseDebugSession {
 
             //activate rendezvous tracking (if enabled). Log the error and move on if it crashes, this shouldn't bring down the session.
             try {
-                const start = Date.now();
+                const rendezvousEnd = this.logger.timeStart('log', 'Rendezvous tracking');
                 await this.initRendezvousTracking();
-                this.logger.log(`[duration] Init rendezvous tracking took: ${(util.formatTime(Date.now() - start))}`);
+                rendezvousEnd();
             } catch (e) {
                 this.logger.error('Failed to initialize rendezvous tracking', e);
             }
 
-            const connectAdapterStart = Date.now();
+            const connectAdapterEnd = this.logger.timeStart('log', 'Connect adapter');
             this.createRokuAdapter(this.rendezvousTracker);
             await this.connectRokuAdapter();
-            this.logger.log(`[duration] Connect adapter took: ${(util.formatTime(Date.now() - connectAdapterStart))}`);
+            connectAdapterEnd();
 
             await this.runAutomaticSceneGraphCommands(this.launchConfiguration.autoRunSgDebugCommands);
 
@@ -644,8 +644,7 @@ export class BrightScriptDebugSession extends BaseDebugSession {
     }
 
     private async publish() {
-        this.logger.log('Uploading zip');
-        const start = Date.now();
+        const uploadingEnd = this.logger.timeStart('log', 'Uploading zip');
         let packageIsPublished = false;
 
         //delete any currently installed dev channel (if enabled to do so)
@@ -700,7 +699,7 @@ export class BrightScriptDebugSession extends BaseDebugSession {
 
         await publishPromise;
 
-        this.logger.log(`[duration] Uploading zip took: ${Date.now() - start}ms`);
+        uploadingEnd();
 
         //the channel has been deployed. Wait for the adapter to finish connecting.
         //if it hasn't connected after 5 seconds, it probably will never connect.


### PR DESCRIPTION
Added more logs to track awaited steps in `launchRequest` function.

<img width="640" height="202" alt="Screenshot 2025-08-11 at 11 12 01 AM" src="https://github.com/user-attachments/assets/f1bf094e-99cc-493f-be7c-7bdfc4070ae3" />

Fixes #196 
