### PR TITLE
Ignore breakpoints from unsupported files

### DIFF
--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -81,8 +81,8 @@ export class BrightScriptDebugSession extends BaseDebugSession {
         this.sourceMapManager = new SourceMapManager();
         this.locationManager = new LocationManager(this.sourceMapManager);
         this.breakpointManager = new BreakpointManager(this.sourceMapManager, this.locationManager);
-        //send newly-verified breakpoints to vscode
-        this.breakpointManager.on('breakpoints-verified', (data) => this.onDeviceBreakpointsChanged('changed', data));
+        //send breakpoint state changes to vscode
+        this.breakpointManager.on('breakpoints-changed', (data: { breakpoints: AugmentedSourceBreakpoint[] }) => this.onBreakpointChanged(data));
         this.projectManager = new ProjectManager({
             breakpointManager: this.breakpointManager,
             locationManager: this.locationManager
@@ -90,9 +90,8 @@ export class BrightScriptDebugSession extends BaseDebugSession {
         this.fileLoggingManager = new FileLoggingManager();
     }
 
-    private onDeviceBreakpointsChanged(eventName: 'changed' | 'new', data: { breakpoints: AugmentedSourceBreakpoint[] }) {
-        this.logger.info('Sending verified device breakpoints to client', data);
-        //send all verified breakpoints to the client
+    private onBreakpointChanged(data: { breakpoints: AugmentedSourceBreakpoint[] }) {
+        this.logger.info('Sending breakpoint changes to client', data);
         for (const breakpoint of data.breakpoints) {
             const event: DebugProtocol.Breakpoint = {
                 line: breakpoint.line,
@@ -105,7 +104,11 @@ export class BrightScriptDebugSession extends BaseDebugSession {
                     path: breakpoint.srcPath
                 }
             };
-            this.sendEvent(new BreakpointEvent(eventName, event));
+            // Determine the DAP event reason from the breakpoint state:
+            // - 'failed' breakpoints (e.g. unsupported file types) should be removed from the client
+            // - all other state changes are updates to existing breakpoints
+            const reason = breakpoint.reason === 'failed' ? 'removed' : 'changed';
+            this.sendEvent(new BreakpointEvent(reason, event));
         }
     }
 
@@ -415,7 +418,6 @@ export class BrightScriptDebugSession extends BaseDebugSession {
             return this.shutdown(`Could not resolve ip address for host '${this.launchConfiguration.host}'`);
         }
 
-        
         // fetches the device info and parses the xml data to JSON object
         try {
             this.deviceInfo = await rokuDeploy.getDeviceInfo({ host: this.launchConfiguration.host, remotePort: this.launchConfiguration.remotePort, enhance: true, timeout: 4_000 });
@@ -428,11 +430,9 @@ export class BrightScriptDebugSession extends BaseDebugSession {
             }
             return this.shutdown(`Unable to connect to roku at '${this.launchConfiguration.host}'. Verify the IP address is correct and that the device is powered on and connected to same network as this computer.`);
         }
-        
         if (this.deviceInfo && !this.deviceInfo.developerEnabled) {
             return this.shutdown(`Developer mode is not enabled for host '${this.launchConfiguration.host}'.`);
         }
-        
         await this.initializeProfiling();
         //initialize all file logging (rokuDevice, debugger, etc)
         this.fileLoggingManager.activate(this.launchConfiguration?.fileLogging, this.cwd);
@@ -547,7 +547,6 @@ export class BrightScriptDebugSession extends BaseDebugSession {
             await this.tryProfilingConnectOnStart();
 
             await this.publish();
-            
 
             //hack for certain roku devices that lock up when this event is emitted (no idea why!).
             if (this.launchConfiguration.emitChannelPublishedEvent) {

--- a/src/managers/BreakpointManager.spec.ts
+++ b/src/managers/BreakpointManager.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import * as fsExtra from 'fs-extra';
 import { SourceMapConsumer, SourceNode } from 'source-map';
-import type { BreakpointWorkItem } from './BreakpointManager';
+import type { AugmentedSourceBreakpoint, BreakpointWorkItem } from './BreakpointManager';
 import { BreakpointManager } from './BreakpointManager';
 import { fileUtils, standardizePath as s } from '../FileUtils';
 import { ComponentLibraryProject, Project, ProjectManager } from './ProjectManager';
@@ -568,6 +568,396 @@ describe('BreakpointManager', () => {
 
             expect(fsExtra.readFileSync(`${stagingDir}/source/main.brs`).toString()).to.equal(`sub main()\n    print 1\nSTOP\n    print 2\nend sub`);
         });
+
+        describe('unsupported file type filtering', () => {
+
+            it('allows breakpoints in .brs files (no transpiling)', async () => {
+                // Scenario: no transpiling, breakpoint in source/main.brs → stagingDir/source/main.brs
+                fsExtra.writeFileSync(`${rootDir}/source/main.brs`, `sub main()\n    print 1\nend sub`);
+                fsExtra.copyFileSync(`${rootDir}/source/main.brs`, `${stagingDir}/source/main.brs`);
+
+                bpManager.replaceBreakpoints(s`${rootDir}/source/main.brs`, [{ line: 2 }]);
+
+                await bpManager.writeBreakpointsForProject(new Project(<any>{
+                    rootDir: rootDir,
+                    outDir: outDir,
+                    stagingDir: stagingDir
+                }));
+
+                // Breakpoint should be written (STOP injected)
+                expect(fsExtra.readFileSync(`${stagingDir}/source/main.brs`).toString()).to.contain('STOP');
+                // Breakpoint should be verified
+                const bp = bpManager['getBreakpointsForFile'](s`${rootDir}/source/main.brs`)[0];
+                expect(bp.verified).to.be.true;
+            });
+
+            it('allows breakpoints in .xml files', async () => {
+                fsExtra.writeFileSync(`${rootDir}/source/comp.xml`, `<component>\n  <script/>\n</component>`);
+                fsExtra.copyFileSync(`${rootDir}/source/comp.xml`, `${stagingDir}/source/comp.xml`);
+
+                bpManager.replaceBreakpoints(s`${rootDir}/source/comp.xml`, [{ line: 2 }]);
+
+                await bpManager.writeBreakpointsForProject(new Project(<any>{
+                    rootDir: rootDir,
+                    outDir: outDir,
+                    stagingDir: stagingDir
+                }));
+
+                // Breakpoint should be written
+                const bp = bpManager['getBreakpointsForFile'](s`${rootDir}/source/comp.xml`)[0];
+                expect(bp.verified).to.be.true;
+            });
+
+            it('allows breakpoints when .bs transpiles to .brs in staging', async () => {
+                // Scenario: BrighterScript transpiling. Breakpoint set in src/source/main.bs,
+                // transpiles to dist/source/main.brs, copied to stagingDir/source/main.brs.
+                // The staging file is .brs so the breakpoint should be accepted.
+                fsExtra.writeFileSync(`${sourceDir1}/source/main.bs`, `sub main()\n    print 1\nend sub`);
+                // The transpiled output lands in rootDir as .brs
+                fsExtra.writeFileSync(`${rootDir}/source/main.brs`, `sub main()\n    print 1\nend sub`);
+                fsExtra.copyFileSync(`${rootDir}/source/main.brs`, `${stagingDir}/source/main.brs`);
+
+                // Create a source map that maps staging .brs back to .bs source
+                const sourceNode = new SourceNode(null, null, null, [
+                    new SourceNode(1, 0, s`${sourceDir1}/source/main.bs`, 'sub main()\n'),
+                    new SourceNode(2, 0, s`${sourceDir1}/source/main.bs`, '    print 1\n'),
+                    new SourceNode(3, 0, s`${sourceDir1}/source/main.bs`, 'end sub')
+                ]);
+                const result = sourceNode.toStringWithSourceMap();
+                fsExtra.writeFileSync(`${stagingDir}/source/main.brs.map`, JSON.stringify(result.map));
+                sourceMapManager.set(`${stagingDir}/source/main.brs.map`, JSON.stringify(result.map));
+
+                bpManager.replaceBreakpoints(s`${sourceDir1}/source/main.bs`, [{ line: 2 }]);
+
+                await bpManager.writeBreakpointsForProject(new Project(<any>{
+                    rootDir: rootDir,
+                    outDir: outDir,
+                    stagingDir: stagingDir
+                }));
+
+                // Breakpoint should be verified because staging file is .brs
+                const bp = bpManager['getBreakpointsForFile'](s`${sourceDir1}/source/main.bs`)[0];
+                expect(bp.verified).to.be.true;
+            });
+
+            it('rejects breakpoints when staging file is not .brs or .xml (e.g. .json)', async () => {
+                // Scenario: Python that does NOT compile to BrightScript.
+                // src/source/script.py => dist/source/script.json => stagingDir/source/script.json
+                // The staging file is .json, so the breakpoint should be rejected.
+                fsExtra.writeFileSync(`${rootDir}/source/script.json`, `{"main": true}`);
+                fsExtra.copyFileSync(`${rootDir}/source/script.json`, `${stagingDir}/source/script.json`);
+
+                bpManager.replaceBreakpoints(s`${rootDir}/source/script.json`, [{ line: 1 }]);
+
+                let unsupportedEvent: { breakpoints: any[] } | undefined;
+                bpManager.on('breakpoints-changed', (data) => {
+                    unsupportedEvent = data;
+                });
+
+                await bpManager.writeBreakpointsForProject(new Project(<any>{
+                    rootDir: rootDir,
+                    outDir: outDir,
+                    stagingDir: stagingDir
+                }));
+
+                // The .json file should NOT have STOP injected
+                expect(fsExtra.readFileSync(`${stagingDir}/source/script.json`).toString()).not.to.contain('STOP');
+
+                // Breakpoint should be marked as failed
+                const bp = bpManager['getBreakpointsForFile'](s`${rootDir}/source/script.json`)[0];
+                expect(bp.verified).to.be.false;
+                expect(bp.reason).to.equal('failed');
+                expect(bp.message).to.contain('.json');
+                expect(bp.message).to.contain('not a supported Roku file type');
+
+                // The event is queued via process.nextTick, so wait for it
+                await new Promise<void>(resolve => {
+                    process.nextTick(resolve);
+                });
+                expect(unsupportedEvent).to.exist;
+                expect(unsupportedEvent.breakpoints).to.have.lengthOf(1);
+            });
+
+            it('rejects breakpoints for .py files that transpile to .json in staging', async () => {
+                // Scenario: Python → JSON (not BrightScript).
+                // Breakpoint in .py, source map points to .py, but staging file is .json.
+                fsExtra.writeFileSync(`${sourceDir1}/source/utils.py`, `def hello():\n    print("hi")\n`);
+                fsExtra.writeFileSync(`${rootDir}/source/utils.json`, `{"hello": true}\n`);
+                fsExtra.copyFileSync(`${rootDir}/source/utils.json`, `${stagingDir}/source/utils.json`);
+
+                // Source map from .json back to .py
+                const sourceNode = new SourceNode(null, null, null, [
+                    new SourceNode(1, 0, s`${sourceDir1}/source/utils.py`, '{"hello": true}\n'),
+                    new SourceNode(2, 0, s`${sourceDir1}/source/utils.py`, '\n'),
+                    new SourceNode(3, 0, s`${sourceDir1}/source/utils.py`, '')
+                ]);
+                const result = sourceNode.toStringWithSourceMap();
+                fsExtra.writeFileSync(`${stagingDir}/source/utils.json.map`, JSON.stringify(result.map));
+                sourceMapManager.set(`${stagingDir}/source/utils.json.map`, JSON.stringify(result.map));
+
+                bpManager.replaceBreakpoints(s`${sourceDir1}/source/utils.py`, [{ line: 2 }]);
+
+                let unsupportedEvent: { breakpoints: any[] } | undefined;
+                bpManager.on('breakpoints-changed', (data) => {
+                    unsupportedEvent = data;
+                });
+
+                await bpManager.writeBreakpointsForProject(new Project(<any>{
+                    rootDir: rootDir,
+                    outDir: outDir,
+                    stagingDir: stagingDir
+                }));
+
+                // .json file should NOT have STOP injected
+                expect(fsExtra.readFileSync(`${stagingDir}/source/utils.json`).toString()).not.to.contain('STOP');
+
+                // Breakpoint should be marked as failed
+                const bp = bpManager['getBreakpointsForFile'](s`${sourceDir1}/source/utils.py`)[0];
+                expect(bp.verified).to.be.false;
+                expect(bp.reason).to.equal('failed');
+
+                // The event is queued via process.nextTick, so wait for it
+                await new Promise<void>(resolve => {
+                    process.nextTick(resolve);
+                });
+                expect(unsupportedEvent).to.exist;
+            });
+
+            it('allows .py breakpoints when they transpile to .brs in staging', async () => {
+                // Scenario: Hypothetical py-to-brs tool.
+                // src/source/main.py => dist/source/main.brs => stagingDir/source/main.brs
+                // The staging file is .brs so the breakpoint should be accepted.
+                fsExtra.writeFileSync(`${sourceDir1}/source/main.py`, `sub main()\n    print 1\nend sub`);
+                fsExtra.writeFileSync(`${rootDir}/source/main.brs`, `sub main()\n    print 1\nend sub`);
+                fsExtra.copyFileSync(`${rootDir}/source/main.brs`, `${stagingDir}/source/main.brs`);
+
+                // Source map from .brs back to .py
+                const sourceNode = new SourceNode(null, null, null, [
+                    new SourceNode(1, 0, s`${sourceDir1}/source/main.py`, 'sub main()\n'),
+                    new SourceNode(2, 0, s`${sourceDir1}/source/main.py`, '    print 1\n'),
+                    new SourceNode(3, 0, s`${sourceDir1}/source/main.py`, 'end sub')
+                ]);
+                const result = sourceNode.toStringWithSourceMap();
+                fsExtra.writeFileSync(`${stagingDir}/source/main.brs.map`, JSON.stringify(result.map));
+                sourceMapManager.set(`${stagingDir}/source/main.brs.map`, JSON.stringify(result.map));
+
+                bpManager.replaceBreakpoints(s`${sourceDir1}/source/main.py`, [{ line: 2 }]);
+
+                const verifiedEvents: AugmentedSourceBreakpoint[] = [];
+                bpManager.on('breakpoints-changed', (data) => {
+                    verifiedEvents.push(...data.breakpoints);
+                });
+
+                await bpManager.writeBreakpointsForProject(new Project(<any>{
+                    rootDir: rootDir,
+                    outDir: outDir,
+                    stagingDir: stagingDir
+                }));
+
+                // Breakpoint SHOULD be verified because staging file is .brs
+                const bp = bpManager['getBreakpointsForFile'](s`${sourceDir1}/source/main.py`)[0];
+                expect(bp.verified).to.be.true;
+
+                // Wait for queued events, then verify none were marked as unsupported
+                await new Promise<void>(resolve => {
+                    process.nextTick(resolve);
+                });
+                expect(verifiedEvents.every(b => b.reason !== 'failed')).to.be.true;
+            });
+
+            it('does not include unsupported breakpoints in getDiff results', async () => {
+                // Breakpoints in unsupported files should not appear in diff work items
+                fsExtra.writeFileSync(`${rootDir}/source/main.brs`, `sub main()\n    print 1\nend sub`);
+                fsExtra.writeFileSync(`${rootDir}/source/script.json`, `{"main": true}`);
+                fsExtra.copyFileSync(`${rootDir}/source/main.brs`, `${stagingDir}/source/main.brs`);
+                fsExtra.copyFileSync(`${rootDir}/source/script.json`, `${stagingDir}/source/script.json`);
+
+                bpManager.replaceBreakpoints(s`${rootDir}/source/main.brs`, [{ line: 2 }]);
+                bpManager.replaceBreakpoints(s`${rootDir}/source/script.json`, [{ line: 1 }]);
+
+                const project = new Project(<any>{
+                    rootDir: rootDir,
+                    outDir: outDir,
+                    stagingDir: stagingDir
+                });
+
+                const diff = await bpManager.getDiff([project]);
+
+                // Only the .brs breakpoint should appear in the diff
+                expect(diff.added).to.have.lengthOf(1);
+                expect(diff.added[0].pkgPath).to.equal('pkg:/source/main.brs');
+            });
+
+            it('does not crash when file extension cannot be determined', async () => {
+                // Safety: if somehow a staging file has no extension, allow it through
+                fsExtra.writeFileSync(`${rootDir}/source/main.brs`, `sub main()\n    print 1\nend sub`);
+                fsExtra.copyFileSync(`${rootDir}/source/main.brs`, `${stagingDir}/source/main.brs`);
+
+                bpManager.replaceBreakpoints(s`${rootDir}/source/main.brs`, [{ line: 2 }]);
+
+                // This should not throw
+                await bpManager.writeBreakpointsForProject(new Project(<any>{
+                    rootDir: rootDir,
+                    outDir: outDir,
+                    stagingDir: stagingDir
+                }));
+            });
+
+            it('rejects breakpoints in manifest files', async () => {
+                // The manifest file is not a debuggable file type
+                fsExtra.writeFileSync(`${rootDir}/manifest`, `title=MyApp\nmajor_version=1\nminor_version=0`);
+                fsExtra.copyFileSync(`${rootDir}/manifest`, `${stagingDir}/manifest`);
+
+                bpManager.replaceBreakpoints(s`${rootDir}/manifest`, [{ line: 1 }]);
+
+                await bpManager.writeBreakpointsForProject(new Project(<any>{
+                    rootDir: rootDir,
+                    outDir: outDir,
+                    stagingDir: stagingDir
+                }));
+
+                // Breakpoint should be marked as failed
+                const bp = bpManager['getBreakpointsForFile'](s`${rootDir}/manifest`)[0];
+                expect(bp.verified).to.be.false;
+                expect(bp.reason).to.equal('failed');
+                expect(bp.message).to.contain('not a supported Roku file type');
+            });
+
+            it('allows breakpoints in non-standard extension files referenced by XML <script> tags', async () => {
+                // Roku loads any file referenced by <script uri="..."> as BrightScript,
+                // regardless of the file extension. So pkg:/source/lib.abc is valid if
+                // an XML component references it.
+                const libContent = `sub doStuff()\n    print "hello"\nend sub`;
+                fsExtra.writeFileSync(`${rootDir}/source/lib.abc`, libContent);
+                fsExtra.copyFileSync(`${rootDir}/source/lib.abc`, `${stagingDir}/source/lib.abc`);
+
+                // Create an XML component that references the .abc file via <script>
+                fsExtra.ensureDirSync(`${stagingDir}/components`);
+                fsExtra.writeFileSync(`${stagingDir}/components/MyComp.xml`, [
+                    '<component name="MyComp" extends="Group">',
+                    '    <script type="text/brightscript" uri="pkg:/source/lib.abc" />',
+                    '</component>'
+                ].join('\n'));
+
+                bpManager.replaceBreakpoints(s`${rootDir}/source/lib.abc`, [{ line: 2 }]);
+
+                await bpManager.writeBreakpointsForProject(new Project(<any>{
+                    rootDir: rootDir,
+                    outDir: outDir,
+                    stagingDir: stagingDir
+                }));
+
+                // Breakpoint should be verified because the file is referenced by a <script> tag
+                const bp = bpManager['getBreakpointsForFile'](s`${rootDir}/source/lib.abc`)[0];
+                expect(bp.verified).to.be.true;
+                // STOP should be injected into the file
+                expect(fsExtra.readFileSync(`${stagingDir}/source/lib.abc`).toString()).to.contain('STOP');
+            });
+
+            it('rejects breakpoints in non-standard extension files NOT referenced by XML <script> tags', async () => {
+                // A .abc file that is NOT referenced by any XML <script> tag should be rejected
+                const libContent = `some random content`;
+                fsExtra.writeFileSync(`${rootDir}/source/lib.abc`, libContent);
+                fsExtra.copyFileSync(`${rootDir}/source/lib.abc`, `${stagingDir}/source/lib.abc`);
+
+                // Create an XML component that does NOT reference lib.abc
+                fsExtra.ensureDirSync(`${stagingDir}/components`);
+                fsExtra.writeFileSync(`${stagingDir}/components/MyComp.xml`, [
+                    '<component name="MyComp" extends="Group">',
+                    '    <script type="text/brightscript" uri="pkg:/source/other.brs" />',
+                    '</component>'
+                ].join('\n'));
+
+                bpManager.replaceBreakpoints(s`${rootDir}/source/lib.abc`, [{ line: 1 }]);
+
+                await bpManager.writeBreakpointsForProject(new Project(<any>{
+                    rootDir: rootDir,
+                    outDir: outDir,
+                    stagingDir: stagingDir
+                }));
+
+                // Breakpoint should be rejected
+                const bp = bpManager['getBreakpointsForFile'](s`${rootDir}/source/lib.abc`)[0];
+                expect(bp.verified).to.be.false;
+                expect(bp.reason).to.equal('failed');
+            });
+
+            it('allows breakpoints in files referenced by relative URI in <script> tags', async () => {
+                // <script uri="./Animator.brs" /> is relative to the XML file's directory
+                const libContent = `sub animate()\n    print "go"\nend sub`;
+                fsExtra.ensureDirSync(`${rootDir}/components`);
+                fsExtra.ensureDirSync(`${stagingDir}/components`);
+                fsExtra.writeFileSync(`${rootDir}/components/Animator.xyz`, libContent);
+                fsExtra.copyFileSync(`${rootDir}/components/Animator.xyz`, `${stagingDir}/components/Animator.xyz`);
+
+                fsExtra.writeFileSync(`${stagingDir}/components/Animator.xml`, [
+                    '<component name="Animator" extends="Node">',
+                    '    <script type="text/brightscript" uri="./Animator.xyz" />',
+                    '</component>'
+                ].join('\n'));
+
+                bpManager.replaceBreakpoints(s`${rootDir}/components/Animator.xyz`, [{ line: 2 }]);
+
+                await bpManager.writeBreakpointsForProject(new Project(<any>{
+                    rootDir: rootDir,
+                    outDir: outDir,
+                    stagingDir: stagingDir
+                }));
+
+                const bp = bpManager['getBreakpointsForFile'](s`${rootDir}/components/Animator.xyz`)[0];
+                expect(bp.verified).to.be.true;
+            });
+
+            it('allows breakpoints in files referenced by parent-relative URI in <script> tags', async () => {
+                // <script uri="../../source/lib.dat" /> traverses up from the XML file
+                const libContent = `sub helper()\n    print "help"\nend sub`;
+                fsExtra.writeFileSync(`${rootDir}/source/lib.dat`, libContent);
+                fsExtra.copyFileSync(`${rootDir}/source/lib.dat`, `${stagingDir}/source/lib.dat`);
+
+                fsExtra.ensureDirSync(`${stagingDir}/components/nested`);
+                fsExtra.writeFileSync(`${stagingDir}/components/nested/Deep.xml`, [
+                    '<component name="Deep" extends="Node">',
+                    '    <script type="text/brightscript" uri="../../source/lib.dat" />',
+                    '</component>'
+                ].join('\n'));
+
+                bpManager.replaceBreakpoints(s`${rootDir}/source/lib.dat`, [{ line: 2 }]);
+
+                await bpManager.writeBreakpointsForProject(new Project(<any>{
+                    rootDir: rootDir,
+                    outDir: outDir,
+                    stagingDir: stagingDir
+                }));
+
+                const bp = bpManager['getBreakpointsForFile'](s`${rootDir}/source/lib.dat`)[0];
+                expect(bp.verified).to.be.true;
+            });
+
+            it('allows breakpoints in files referenced by libpkg:/ URI in <script> tags', async () => {
+                // libpkg:/ is used for component library imports, resolves same as pkg:/
+                const libContent = `sub libFunc()\n    print "lib"\nend sub`;
+                fsExtra.writeFileSync(`${rootDir}/source/libcode.custom`, libContent);
+                fsExtra.copyFileSync(`${rootDir}/source/libcode.custom`, `${stagingDir}/source/libcode.custom`);
+
+                fsExtra.ensureDirSync(`${stagingDir}/components`);
+                fsExtra.writeFileSync(`${stagingDir}/components/LibComp.xml`, [
+                    '<component name="LibComp" extends="Node">',
+                    '    <script type="text/brightscript" uri="libpkg:/source/libcode.custom" />',
+                    '</component>'
+                ].join('\n'));
+
+                bpManager.replaceBreakpoints(s`${rootDir}/source/libcode.custom`, [{ line: 2 }]);
+
+                await bpManager.writeBreakpointsForProject(new Project(<any>{
+                    rootDir: rootDir,
+                    outDir: outDir,
+                    stagingDir: stagingDir
+                }));
+
+                const bp = bpManager['getBreakpointsForFile'](s`${rootDir}/source/libcode.custom`)[0];
+                expect(bp.verified).to.be.true;
+            });
+        });
     });
 
     describe('writeBreakpointsToFile', () => {
@@ -800,6 +1190,7 @@ describe('BreakpointManager', () => {
                 s`${rootDir}/source/main.brs`
             ]);
         });
+
     });
 
     it('properly handles roku-deploy file overriding', async () => {

--- a/src/managers/BreakpointManager.ts
+++ b/src/managers/BreakpointManager.ts
@@ -1,4 +1,6 @@
 import * as fsExtra from 'fs-extra';
+import * as fastGlob from 'fast-glob';
+import * as path from 'path';
 import { orderBy } from 'natural-orderby';
 import type { CodeWithSourceMap } from 'source-map';
 import { SourceNode } from 'source-map';
@@ -23,6 +25,13 @@ export class BreakpointManager {
 
     private logger = logger.createLogger('[bpManager]');
 
+    /**
+     * File extensions that are supported for breakpoints on Roku devices.
+     * Only .brs and .xml files can have breakpoints — other file types (like .js, .ts, etc.)
+     * are not executed by the BrightScript/SceneGraph debugger
+     */
+    public static readonly SUPPORTED_BREAKPOINT_EXTENSIONS = ['.brs', '.xml'];
+
     public launchConfiguration: {
         sourceDirs: string[];
         rootDir: string;
@@ -31,7 +40,7 @@ export class BreakpointManager {
 
     private emitter = new EventEmitter();
 
-    private emit(eventName: 'breakpoints-verified', data: { breakpoints: AugmentedSourceBreakpoint[] });
+    private emit(eventName: 'breakpoints-changed', data: { breakpoints: AugmentedSourceBreakpoint[] });
     private emit(eventName: string, data: any) {
         this.emitter.emit(eventName, data);
     }
@@ -39,7 +48,7 @@ export class BreakpointManager {
     /**
      * Subscribe to an event
      */
-    public on(eventName: 'breakpoints-verified', handler: (data: { breakpoints: AugmentedSourceBreakpoint[] }) => any);
+    public on(eventName: 'breakpoints-changed', handler: (data: { breakpoints: AugmentedSourceBreakpoint[] }) => any);
     public on(eventName: string, handler: (data: any) => any) {
         this.emitter.on(eventName, handler);
         return () => {
@@ -50,10 +59,10 @@ export class BreakpointManager {
     /**
      * Get a promise that resolves the next time the specified event occurs
      */
-    public once(eventName: 'breakpoints-verified'): Promise<{ breakpoints: AugmentedSourceBreakpoint[] }>;
+    public once(eventName: 'breakpoints-changed'): Promise<{ breakpoints: AugmentedSourceBreakpoint[] }>;
     public once(eventName: string): Promise<any> {
         return new Promise((resolve) => {
-            const disconnect = this.on(eventName as 'breakpoints-verified', (data) => {
+            const disconnect = this.on(eventName as 'breakpoints-changed', (data) => {
                 disconnect();
                 resolve(data);
             });
@@ -269,7 +278,7 @@ export class BreakpointManager {
         if (breakpoint) {
             breakpoint.verified = isVerified;
 
-            this.queueEvent('breakpoints-verified', breakpoint.srcHash);
+            this.queueEvent('breakpoints-changed', breakpoint.srcHash);
             return true;
         } else {
             //couldn't find the breakpoint. return false so the caller can handle that properly
@@ -285,7 +294,7 @@ export class BreakpointManager {
      * This queues up a future function that will emit a batch of all the specified breakpoints.
      * @param hash the breakpoint hash that identifies this specific breakpoint based on its features
      */
-    private queueEvent(event: 'breakpoints-verified', ref: BreakpointRef) {
+    private queueEvent(event: 'breakpoints-changed', ref: BreakpointRef) {
         //get the state (or create a new one)
         const state = this.queueEventStates.get(event) ?? (this.queueEventStates.set(event, { pendingRefs: [], isQueued: false }).get(event));
 
@@ -375,10 +384,16 @@ export class BreakpointManager {
 
     /**
      * Get a list of all breakpoint tasks that should be performed.
-     * This will also exclude files with breakpoints that are not in scope.
+     * This will also exclude files with breakpoints that are not in scope,
+     * and filter out breakpoints whose staging file is not a supported Roku file type (.brs, .xml)
+     * unless the file is referenced by a <script> tag in an XML component.
      */
     private async getBreakpointWork(project: Project) {
         let result = {} as Record<string, Array<BreakpointWorkItem>>;
+        let unsupported = [] as BreakpointWorkItem[];
+        // Lazily populated: the set of staging file paths referenced by <script> tags in XML files.
+        // Only built if we encounter a breakpoint in an unsupported file extension.
+        let scriptReferencedFiles: Set<string> | undefined;
 
         //iterate over every file that contains breakpoints
         for (let [sourceFilePath, breakpoints] of this.breakpointsByFilePath) {
@@ -439,6 +454,18 @@ export class BreakpointManager {
                     obj.destHash = this.getBreakpointDestHash(obj);
                     obj.deviceId = this.deviceIdByDestHash.get(obj.destHash)?.deviceId;
 
+                    // Filter out breakpoints that resolve to unsupported file types in staging.
+                    // .brs and .xml are always supported. For other extensions, check if the file
+                    // is referenced by a <script> tag in an XML component (Roku loads those as
+                    // BrightScript regardless of file extension).
+                    if (!this.isSupportedBreakpointExtension(stagingLocation.filePath)) {
+                        scriptReferencedFiles ??= this.getScriptReferencedFiles(project.stagingDir);
+                        if (!scriptReferencedFiles.has(stagingLocation.filePath)) {
+                            unsupported.push(obj);
+                            continue;
+                        }
+                    }
+
                     if (!result[stagingLocation.filePath]) {
                         result[stagingLocation.filePath] = [];
                     }
@@ -451,7 +478,7 @@ export class BreakpointManager {
             result[stagingFilePath] = this.sortAndRemoveDuplicateBreakpoints(result[stagingFilePath]);
         }
 
-        return result;
+        return { work: result, unsupported };
     }
 
     public sortAndRemoveDuplicateBreakpoints<T extends { line: number; column?: number }>(
@@ -472,10 +499,18 @@ export class BreakpointManager {
     }
 
     /**
-     * Write "stop" lines into source code for each breakpoint of each file in the given project
+     * Write "stop" lines into source code for each breakpoint of each file in the given project.
+     * After resolving staging paths, any breakpoints that land in unsupported file types
+     * (i.e. not .brs or .xml) are rejected and a 'breakpoints-unsupported' event is emitted
+     * so the client can mark them as failed.
      */
     public async writeBreakpointsForProject(project: Project) {
-        let breakpointsByStagingFilePath = await this.getBreakpointWork(project);
+        let { work: breakpointsByStagingFilePath, unsupported } = await this.getBreakpointWork(project);
+
+        // Mark any breakpoints that resolved to unsupported file types as failed
+        if (unsupported.length > 0) {
+            this.markBreakpointsUnsupported(unsupported);
+        }
 
         let promises = [] as Promise<any>[];
         for (let stagingFilePath in breakpointsByStagingFilePath) {
@@ -495,6 +530,117 @@ export class BreakpointManager {
         //sort all permanent breakpoints by line and column
         for (const [key, breakpoints] of this.permanentBreakpointsBySrcPath) {
             this.permanentBreakpointsBySrcPath.set(key, orderBy(breakpoints, [x => x.line, x => x.column]));
+        }
+    }
+
+    /**
+     * Check if a file path has a natively supported extension for breakpoints (.brs or .xml).
+     * Returns true if the extension can't be determined as a safety fallback.
+     */
+    private isSupportedBreakpointExtension(filePath: string): boolean {
+        try {
+            const ext = path.extname(filePath).toLowerCase();
+            // No extension (e.g. `manifest`) is not a debuggable file type.
+            // All supported file types (.brs, .xml) always have an extension.
+            if (!ext) {
+                return false;
+            }
+            return BreakpointManager.SUPPORTED_BREAKPOINT_EXTENSIONS.includes(ext);
+        } catch (e) {
+            // Never crash the debugger over extension validation — allow the breakpoint through
+            this.logger.debug('Error checking breakpoint file extension, allowing through', { filePath, error: e });
+            return true;
+        }
+    }
+
+    /**
+     * Cache of script-referenced files per staging directory. This is expensive to compute
+     * (globs + reads all XML files), so we cache the result. The cache is keyed by staging
+     * dir path. Call {@link clearScriptReferencedFilesCache} to invalidate (e.g. on new launch).
+     */
+    private scriptReferencedFilesCache = new Map<string, Set<string>>();
+
+    /**
+     * Clear the cached script-referenced file sets. Should be called when staging
+     * directory contents may have changed (e.g. at the start of a new debug session).
+     */
+    public clearScriptReferencedFilesCache() {
+        this.scriptReferencedFilesCache.clear();
+    }
+
+    /**
+     * Scan all XML files in the staging directory for `<script>` tags and collect
+     * the set of absolute staging file paths they reference. Roku loads any file
+     * referenced by a `<script uri="...">` as BrightScript, regardless of extension,
+     * so these files are valid breakpoint targets even if they don't have a .brs extension.
+     * Results are cached per staging directory.
+     */
+    private getScriptReferencedFiles(stagingDir: string): Set<string> {
+        const cacheKey = s`${stagingDir}`;
+        const cached = this.scriptReferencedFilesCache.get(cacheKey);
+        if (cached) {
+            return cached;
+        }
+        const result = new Set<string>();
+        try {
+            const xmlFiles = fastGlob.sync('**/*.xml', {
+                cwd: stagingDir,
+                absolute: true
+            });
+            // Match <script ... uri="<anything>" ... /> or <script ... uri="<anything>" ...>
+            // URI values can be:
+            //   pkg:/source/file.brs        — absolute from staging root
+            //   libpkg:/source/file.brs     — component library, also absolute from staging root
+            //   ./file.brs                  — relative to the XML file's directory
+            //   ../../source/file.brs       — relative path with parent traversal
+            const scriptUriRegex = /<script\b[^>]*\buri\s*=\s*"([^"]*)"[^>]*\/?>/gi;
+            for (const xmlFile of xmlFiles) {
+                try {
+                    const contents = fsExtra.readFileSync(xmlFile, 'utf-8');
+                    let match: RegExpExecArray;
+                    while ((match = scriptUriRegex.exec(contents))) {
+                        const uri = match[1];
+                        let absolutePath: string;
+                        const protocolIndex = uri.indexOf(':/');
+                        if (protocolIndex >= 0) {
+                            // Has a protocol (pkg:/, libpkg:/, etc.) — strip it and resolve from staging root
+                            const relativePath = uri.substring(protocolIndex + 2).replace(/^\//, '');
+                            absolutePath = s`${stagingDir}/${relativePath}`;
+                        } else {
+                            // Relative path — resolve from the XML file's directory
+                            absolutePath = s`${path.resolve(path.dirname(xmlFile), uri)}`;
+                        }
+                        result.add(absolutePath);
+                    }
+                } catch (e) {
+                    // Don't let a single unreadable XML file break all breakpoints
+                    this.logger.debug('Error reading XML file for script references', { xmlFile, error: e });
+                }
+            }
+        } catch (e) {
+            // If the glob fails entirely, return empty set — breakpoints will be
+            // rejected by extension, which is the safer default
+            this.logger.debug('Error scanning staging dir for XML script references', { stagingDir, error: e });
+        }
+        this.scriptReferencedFilesCache.set(cacheKey, result);
+        return result;
+    }
+
+    /**
+     * Mark breakpoints as unsupported (failed) because their staging file is not a .brs or .xml file.
+     * Uses the existing 'breakpoints-changed' event to notify the client of the state change.
+     */
+    private markBreakpointsUnsupported(breakpoints: BreakpointWorkItem[]) {
+        for (const bp of breakpoints) {
+            const srcBreakpoint = this.getBreakpoint(bp.srcHash);
+            if (srcBreakpoint) {
+                const ext = path.extname(bp.stagingFilePath);
+                srcBreakpoint.verified = false;
+                srcBreakpoint.reason = 'failed';
+                srcBreakpoint.message = `Breakpoint rejected: file resolves to '${ext}' in staging, which is not a supported Roku file type (.brs, .xml)`;
+                // Queue through the standard verification event so the client is notified
+                this.queueEvent('breakpoints-changed', srcBreakpoint.srcHash);
+            }
         }
     }
 
@@ -708,7 +854,7 @@ export class BreakpointManager {
         const workByProject = (await Promise.all(
             projects.map(project => this.getBreakpointWork(project))
         ));
-        for (const projectWork of workByProject) {
+        for (const { work: projectWork } of workByProject) {
             for (let key in projectWork) {
                 const work = projectWork[key];
                 for (const item of work) {
@@ -745,7 +891,7 @@ export class BreakpointManager {
             await Promise.all(
                 projects.map(async (project) => {
                     //get breakpoint data for every project
-                    const work = await this.getBreakpointWork(project);
+                    const { work } = await this.getBreakpointWork(project);
 
                     this.logger.debug('[bpmanager] getDiff breakpointWork', work);
 


### PR DESCRIPTION
Fixes issues around setting breakpoints in files that won't actually be debuggable. Every once in a while this causes issues when using the telnet debugger, as well as just random quirks when setting breakpoints for things that don't work. 