### PR TITLE
Fix sourcemap staging bugs when maps are from different depth than staging dir

### DIFF
--- a/src/managers/ProjectManager.spec.ts
+++ b/src/managers/ProjectManager.spec.ts
@@ -224,6 +224,55 @@ describe('ProjectManager', () => {
     });
 
     describe('getSourceLocation', () => {
+        it('resolves a pkg path back to the original rootDir source file via a relative sourcemap', async () => {
+            // Simulate the full flow:
+            // 1. compiler produces MainScene.brs + MainScene.brs.map in srcDir, with sources relative to srcDir
+            // 2. prepublishToStaging copies them to stagingDir (recorded in fileMappings)
+            // 3. fixSourceMapSources rewrites the map's sources to be relative to stagingDir
+            // 4. getSourceLocation('pkg:/source/MainScene.brs', 1) resolves back to rootDir/source/MainScene.bs
+
+            const srcDir = s`${tempPath}/srcDir/source`;
+            const originalBsFile = s`${rootDir}/source/MainScene.bs`;
+            const originalMapPath = s`${srcDir}/MainScene.brs.map`;
+            const stagingBrsPath = s`${stagingDir}/source/MainScene.brs`;
+            const stagingMapPath = s`${stagingDir}/source/MainScene.brs.map`;
+
+            fsExtra.ensureDirSync(srcDir);
+            fsExtra.ensureDirSync(path.dirname(stagingBrsPath));
+            fsExtra.ensureDirSync(path.dirname(originalBsFile));
+            fsExtra.writeFileSync(originalBsFile, `sub main()\n    print "hello"\nend sub`);
+            fsExtra.writeFileSync(stagingBrsPath, `sub main()\n    print "hello"\nend sub`);
+
+            // Source map produced by compiler in srcDir — source is relative from srcDir back to rootDir
+            const { SourceMapGenerator } = await import('source-map');
+            const gen = new SourceMapGenerator({ file: 'MainScene.brs' });
+            gen.addMapping({
+                generated: { line: 1, column: 0 },
+                original: { line: 1, column: 0 },
+                source: path.relative(srcDir, originalBsFile)
+            });
+            fsExtra.writeFileSync(originalMapPath, gen.toString());
+            fsExtra.copySync(originalMapPath, stagingMapPath);
+
+            // fileMappings records the src->dest move that prepublishToStaging performed
+            const fileMappings = [
+                { src: originalBsFile, dest: stagingBrsPath },
+                { src: originalMapPath, dest: stagingMapPath }
+            ];
+
+            // fixSourceMapSources rewrites the on-disk map to use paths relative to stagingDir
+            const project = new Project({ rootDir: rootDir, outDir: outDir, files: [], stagingDir: stagingDir, enhanceREPLCompletions: false });
+            project.fileMappings = fileMappings;
+            await project['fixSourceMapSources']();
+
+            // Point the manager's mainProject at this project
+            manager.mainProject = project as any;
+
+            const sourceLocation = await manager.getSourceLocation('pkg:/source/MainScene.brs', 1);
+            expect(n(sourceLocation.filePath)).to.equal(n(originalBsFile));
+            expect(sourceLocation.lineNumber).to.equal(1);
+        });
+
         it(`does not crash when file is missing`, async () => {
             manager.mainProject.fileMappings = [];
             let sourceLocation = await manager.getSourceLocation('pkg:/source/file-we-dont-know-about.brs', 1);
@@ -524,6 +573,149 @@ describe('Project', () => {
             const expectedRelative = s`${path.relative(path.dirname(stagingMapPath), absoluteSource)}`;
             expect(updated.sources[0]).to.equal(expectedRelative);
             expect(updated.sourceRoot).to.be.undefined;
+        });
+
+        it('rewrites all sources in a map with multiple sources', async () => {
+            const srcDir = s`${tempPath}/srcDir/source`;
+            fsExtra.ensureDirSync(srcDir);
+            fsExtra.ensureDirSync(stagingDir);
+
+            const originalMapPath = s`${srcDir}/main.brs.map`;
+            fsExtra.writeJsonSync(originalMapPath, {
+                version: 3,
+                sources: ['../../rootDir/source/a.bs', '../../rootDir/source/b.bs'],
+                mappings: ''
+            });
+
+            const stagingMapPath = s`${stagingDir}/source/main.brs.map`;
+            fsExtra.ensureDirSync(path.dirname(stagingMapPath));
+            fsExtra.copySync(originalMapPath, stagingMapPath);
+
+            project.fileMappings = [{ src: originalMapPath, dest: stagingMapPath }];
+            await project['fixSourceMapSources']();
+
+            const updated = fsExtra.readJsonSync(stagingMapPath);
+            const stagingMapDir = path.dirname(stagingMapPath);
+            const originalMapDir = path.dirname(originalMapPath);
+            expect(updated.sources[0]).to.equal(s`${path.relative(stagingMapDir, path.resolve(originalMapDir, '../../rootDir/source/a.bs'))}`);
+            expect(updated.sources[1]).to.equal(s`${path.relative(stagingMapDir, path.resolve(originalMapDir, '../../rootDir/source/b.bs'))}`);
+        });
+
+        it('treats an empty string sourceRoot the same as omitted', async () => {
+            const srcDir = s`${tempPath}/srcDir/source`;
+            fsExtra.ensureDirSync(srcDir);
+            fsExtra.ensureDirSync(stagingDir);
+
+            const originalMapPath = s`${srcDir}/main.brs.map`;
+            fsExtra.writeJsonSync(originalMapPath, {
+                version: 3,
+                sourceRoot: '',
+                sources: ['../../rootDir/source/main.bs'],
+                mappings: ''
+            });
+
+            const stagingMapPath = s`${stagingDir}/source/main.brs.map`;
+            fsExtra.ensureDirSync(path.dirname(stagingMapPath));
+            fsExtra.copySync(originalMapPath, stagingMapPath);
+
+            project.fileMappings = [{ src: originalMapPath, dest: stagingMapPath }];
+            await project['fixSourceMapSources']();
+
+            const updated = fsExtra.readJsonSync(stagingMapPath);
+            const absoluteSource = path.resolve(path.dirname(originalMapPath), '../../rootDir/source/main.bs');
+            const expectedRelative = s`${path.relative(path.dirname(stagingMapPath), absoluteSource)}`;
+            expect(updated.sources[0]).to.equal(expectedRelative);
+            expect(updated.sourceRoot).to.be.undefined;
+        });
+
+        it('rewrites sources correctly for a map nested deep in a subdirectory', async () => {
+            const srcDir = s`${tempPath}/srcDir/components/views/details`;
+            fsExtra.ensureDirSync(srcDir);
+            fsExtra.ensureDirSync(stagingDir);
+
+            const originalMapPath = s`${srcDir}/Details.brs.map`;
+            fsExtra.writeJsonSync(originalMapPath, {
+                version: 3,
+                sources: ['../../../../src/components/views/details/Details.bs'],
+                mappings: ''
+            });
+
+            const stagingMapPath = s`${stagingDir}/components/views/details/Details.brs.map`;
+            fsExtra.ensureDirSync(path.dirname(stagingMapPath));
+            fsExtra.copySync(originalMapPath, stagingMapPath);
+
+            project.fileMappings = [{ src: originalMapPath, dest: stagingMapPath }];
+            await project['fixSourceMapSources']();
+
+            const updated = fsExtra.readJsonSync(stagingMapPath);
+            const absoluteSource = path.resolve(path.dirname(originalMapPath), '../../../../src/components/views/details/Details.bs');
+            const expectedRelative = s`${path.relative(path.dirname(stagingMapPath), absoluteSource)}`;
+            expect(updated.sources[0]).to.equal(expectedRelative);
+            expect(updated.sourceRoot).to.be.undefined;
+        });
+
+        it('rewrites multiple map files in a single pass', async () => {
+            const srcDir = s`${tempPath}/srcDir/source`;
+            fsExtra.ensureDirSync(srcDir);
+            fsExtra.ensureDirSync(stagingDir);
+
+            const originalMapPathA = s`${srcDir}/a.brs.map`;
+            const originalMapPathB = s`${srcDir}/b.brs.map`;
+            fsExtra.writeJsonSync(originalMapPathA, { version: 3, sources: ['../../rootDir/a.bs'], mappings: '' });
+            fsExtra.writeJsonSync(originalMapPathB, { version: 3, sources: ['../../rootDir/b.bs'], mappings: '' });
+
+            const stagingMapPathA = s`${stagingDir}/source/a.brs.map`;
+            const stagingMapPathB = s`${stagingDir}/source/b.brs.map`;
+            fsExtra.ensureDirSync(path.dirname(stagingMapPathA));
+            fsExtra.copySync(originalMapPathA, stagingMapPathA);
+            fsExtra.copySync(originalMapPathB, stagingMapPathB);
+
+            project.fileMappings = [
+                { src: originalMapPathA, dest: stagingMapPathA },
+                { src: originalMapPathB, dest: stagingMapPathB }
+            ];
+            await project['fixSourceMapSources']();
+
+            const stagingMapDir = path.dirname(stagingMapPathA);
+            const originalMapDir = path.dirname(originalMapPathA);
+            const updatedA = fsExtra.readJsonSync(stagingMapPathA);
+            const updatedB = fsExtra.readJsonSync(stagingMapPathB);
+            expect(updatedA.sources[0]).to.equal(s`${path.relative(stagingMapDir, path.resolve(originalMapDir, '../../rootDir/a.bs'))}`);
+            expect(updatedB.sources[0]).to.equal(s`${path.relative(stagingMapDir, path.resolve(originalMapDir, '../../rootDir/b.bs'))}`);
+        });
+
+        it('does not crash when map has no sources field', async () => {
+            const srcDir = s`${tempPath}/srcDir/source`;
+            fsExtra.ensureDirSync(srcDir);
+            fsExtra.ensureDirSync(stagingDir);
+
+            const originalMapPath = s`${srcDir}/main.brs.map`;
+            fsExtra.writeJsonSync(originalMapPath, { version: 3, mappings: '' });
+
+            const stagingMapPath = s`${stagingDir}/source/main.brs.map`;
+            fsExtra.ensureDirSync(path.dirname(stagingMapPath));
+            fsExtra.copySync(originalMapPath, stagingMapPath);
+
+            project.fileMappings = [{ src: originalMapPath, dest: stagingMapPath }];
+
+            // should not throw
+            await project['fixSourceMapSources']();
+
+            // file should be unchanged
+            const unchanged = fsExtra.readJsonSync(stagingMapPath);
+            expect(unchanged.sources).to.be.undefined;
+        });
+
+        it('does not crash when map contains invalid JSON', async () => {
+            fsExtra.ensureDirSync(stagingDir);
+            const stagingMapPath = s`${stagingDir}/source/main.brs.map`;
+            fsExtra.ensureDirSync(path.dirname(stagingMapPath));
+            fsExtra.writeFileSync(stagingMapPath, 'not-valid-json');
+
+            project.fileMappings = [{ src: s`${tempPath}/srcDir/main.brs.map`, dest: stagingMapPath }];
+
+            // should not throw
+            await project['fixSourceMapSources']();
         });
     });
 

--- a/src/managers/ProjectManager.spec.ts
+++ b/src/managers/ProjectManager.spec.ts
@@ -354,6 +354,115 @@ describe('Project', () => {
         });
     });
 
+    describe('fixSourceMapSources', () => {
+        afterEach(() => {
+            try {
+                fsExtra.removeSync(tempPath);
+            } catch (e) { }
+        });
+
+        it('rewrites sources paths in map files that were moved to staging', async () => {
+            // Simulate a .map file that was compiled in a source dir, then copied to a different stagingDir
+            const srcDir = s`${tempPath}/srcDir/source`;
+            fsExtra.ensureDirSync(srcDir);
+            fsExtra.ensureDirSync(stagingDir);
+
+            // The map's original location is in srcDir
+            const originalMapPath = s`${srcDir}/main.brs.map`;
+            // The original .bs file is one level up from the map file
+            const originalSourceMap = {
+                version: 3,
+                sources: ['../../rootDir/source/main.bs'],
+                mappings: ''
+            };
+            fsExtra.writeJsonSync(originalMapPath, originalSourceMap);
+
+            // Copy to staging (simulating what prepublishToStaging does)
+            const stagingMapPath = s`${stagingDir}/source/main.brs.map`;
+            fsExtra.ensureDirSync(path.dirname(stagingMapPath));
+            fsExtra.copySync(originalMapPath, stagingMapPath);
+
+            // Set up fileMappings to record the move
+            project.fileMappings = [
+                { src: originalMapPath, dest: stagingMapPath }
+            ];
+
+            await project['fixSourceMapSources']();
+
+            const updated = fsExtra.readJsonSync(stagingMapPath);
+            // Resolve what the source path should be after rewriting
+            const absoluteSource = path.resolve(path.dirname(originalMapPath), '../../rootDir/source/main.bs');
+            const expectedRelative = s`${path.relative(path.dirname(stagingMapPath), absoluteSource)}`;
+            expect(updated.sources[0]).to.equal(expectedRelative);
+            expect(updated.sourceRoot).to.be.undefined;
+        });
+
+        it('does not modify a map file that was not moved (src === dest)', async () => {
+            fsExtra.ensureDirSync(stagingDir);
+            const mapPath = s`${stagingDir}/source/main.brs.map`;
+            fsExtra.ensureDirSync(path.dirname(mapPath));
+            const originalSourceMap = { version: 3, sources: ['../source/main.bs'], mappings: '' };
+            fsExtra.writeJsonSync(mapPath, originalSourceMap);
+
+            project.fileMappings = [
+                { src: mapPath, dest: mapPath }
+            ];
+
+            await project['fixSourceMapSources']();
+
+            const unchanged = fsExtra.readJsonSync(mapPath);
+            expect(unchanged.sources[0]).to.equal('../source/main.bs');
+        });
+
+        it('does not modify a map file that is not in fileMappings (generated in staging)', async () => {
+            fsExtra.ensureDirSync(stagingDir);
+            const mapPath = s`${stagingDir}/source/main.brs.map`;
+            fsExtra.ensureDirSync(path.dirname(mapPath));
+            const originalSourceMap = { version: 3, sources: ['../source/main.bs'], mappings: '' };
+            fsExtra.writeJsonSync(mapPath, originalSourceMap);
+
+            // fileMappings does NOT include this map file
+            project.fileMappings = [];
+
+            await project['fixSourceMapSources']();
+
+            const unchanged = fsExtra.readJsonSync(mapPath);
+            expect(unchanged.sources[0]).to.equal('../source/main.bs');
+        });
+
+        it('respects sourceRoot when resolving original source paths', async () => {
+            const srcDir = s`${tempPath}/srcDir/source`;
+            fsExtra.ensureDirSync(srcDir);
+            fsExtra.ensureDirSync(stagingDir);
+
+            const originalMapPath = s`${srcDir}/main.brs.map`;
+            // sourceRoot is a path relative to the map file; sources are relative to sourceRoot
+            const originalSourceMap = {
+                version: 3,
+                sourceRoot: '../rootDir',
+                sources: ['source/main.bs'],
+                mappings: ''
+            };
+            fsExtra.writeJsonSync(originalMapPath, originalSourceMap);
+
+            const stagingMapPath = s`${stagingDir}/source/main.brs.map`;
+            fsExtra.ensureDirSync(path.dirname(stagingMapPath));
+            fsExtra.copySync(originalMapPath, stagingMapPath);
+
+            project.fileMappings = [
+                { src: originalMapPath, dest: stagingMapPath }
+            ];
+
+            await project['fixSourceMapSources']();
+
+            const updated = fsExtra.readJsonSync(stagingMapPath);
+            const absoluteSource = path.resolve(path.dirname(originalMapPath), '../rootDir', 'source/main.bs');
+            const expectedRelative = s`${path.relative(path.dirname(stagingMapPath), absoluteSource)}`;
+            expect(updated.sources[0]).to.equal(expectedRelative);
+            expect(updated.sourceRoot).to.be.undefined;
+        });
+    });
+
     describe('updateManifestBsConsts', () => {
         let constsLine: string;
         let startingFileContents: string;

--- a/src/managers/ProjectManager.spec.ts
+++ b/src/managers/ProjectManager.spec.ts
@@ -430,13 +430,44 @@ describe('Project', () => {
             expect(unchanged.sources[0]).to.equal('../source/main.bs');
         });
 
-        it('respects sourceRoot when resolving original source paths', async () => {
+        it('rewrites sources correctly when sourceRoot is omitted', async () => {
             const srcDir = s`${tempPath}/srcDir/source`;
             fsExtra.ensureDirSync(srcDir);
             fsExtra.ensureDirSync(stagingDir);
 
             const originalMapPath = s`${srcDir}/main.brs.map`;
-            // sourceRoot is a path relative to the map file; sources are relative to sourceRoot
+            // No sourceRoot — sources are relative to the map file's directory
+            const originalSourceMap = {
+                version: 3,
+                sources: ['../../rootDir/source/main.bs'],
+                mappings: ''
+            };
+            fsExtra.writeJsonSync(originalMapPath, originalSourceMap);
+
+            const stagingMapPath = s`${stagingDir}/source/main.brs.map`;
+            fsExtra.ensureDirSync(path.dirname(stagingMapPath));
+            fsExtra.copySync(originalMapPath, stagingMapPath);
+
+            project.fileMappings = [
+                { src: originalMapPath, dest: stagingMapPath }
+            ];
+
+            await project['fixSourceMapSources']();
+
+            const updated = fsExtra.readJsonSync(stagingMapPath);
+            const absoluteSource = path.resolve(path.dirname(originalMapPath), '../../rootDir/source/main.bs');
+            const expectedRelative = s`${path.relative(path.dirname(stagingMapPath), absoluteSource)}`;
+            expect(updated.sources[0]).to.equal(expectedRelative);
+            expect(updated.sourceRoot).to.be.undefined;
+        });
+
+        it('rewrites sources correctly when sourceRoot is a relative path', async () => {
+            const srcDir = s`${tempPath}/srcDir/source`;
+            fsExtra.ensureDirSync(srcDir);
+            fsExtra.ensureDirSync(stagingDir);
+
+            const originalMapPath = s`${srcDir}/main.brs.map`;
+            // sourceRoot is relative to the map file's directory; sources are relative to sourceRoot
             const originalSourceMap = {
                 version: 3,
                 sourceRoot: '../rootDir',
@@ -457,6 +488,39 @@ describe('Project', () => {
 
             const updated = fsExtra.readJsonSync(stagingMapPath);
             const absoluteSource = path.resolve(path.dirname(originalMapPath), '../rootDir', 'source/main.bs');
+            const expectedRelative = s`${path.relative(path.dirname(stagingMapPath), absoluteSource)}`;
+            expect(updated.sources[0]).to.equal(expectedRelative);
+            expect(updated.sourceRoot).to.be.undefined;
+        });
+
+        it('rewrites sources correctly when sourceRoot is an absolute path', async () => {
+            const srcDir = s`${tempPath}/srcDir/source`;
+            fsExtra.ensureDirSync(srcDir);
+            fsExtra.ensureDirSync(stagingDir);
+
+            const originalMapPath = s`${srcDir}/main.brs.map`;
+            const absoluteSourceRoot = s`${tempPath}/rootDir`;
+            // sourceRoot is absolute; sources are relative to sourceRoot
+            const originalSourceMap = {
+                version: 3,
+                sourceRoot: absoluteSourceRoot,
+                sources: ['source/main.bs'],
+                mappings: ''
+            };
+            fsExtra.writeJsonSync(originalMapPath, originalSourceMap);
+
+            const stagingMapPath = s`${stagingDir}/source/main.brs.map`;
+            fsExtra.ensureDirSync(path.dirname(stagingMapPath));
+            fsExtra.copySync(originalMapPath, stagingMapPath);
+
+            project.fileMappings = [
+                { src: originalMapPath, dest: stagingMapPath }
+            ];
+
+            await project['fixSourceMapSources']();
+
+            const updated = fsExtra.readJsonSync(stagingMapPath);
+            const absoluteSource = path.resolve(absoluteSourceRoot, 'source/main.bs');
             const expectedRelative = s`${path.relative(path.dirname(stagingMapPath), absoluteSource)}`;
             expect(updated.sources[0]).to.equal(expectedRelative);
             expect(updated.sourceRoot).to.be.undefined;

--- a/src/managers/ProjectManager.ts
+++ b/src/managers/ProjectManager.ts
@@ -15,7 +15,8 @@ import { Cache } from 'brighterscript/dist/Cache';
 import { BscProjectThreaded } from '../bsc/BscProjectThreaded';
 import type { ScopeFunction } from '../bsc/BscProject';
 import type { Position } from 'brighterscript';
-import { SourceMap, SourceMapPayload } from 'module';
+import type { SourceMapPayload } from 'module';
+import { SourceMap } from 'module';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
 const replaceInFile = require('replace-in-file');

--- a/src/managers/ProjectManager.ts
+++ b/src/managers/ProjectManager.ts
@@ -366,6 +366,8 @@ export class Project {
             outDir: this.outDir
         });
 
+        await this.fixSourceMapSources();
+
         if (this.enhanceREPLCompletions) {
             //activate our background brighterscript ProgramBuilder now that the staging directory contains the final production project
             this.stagingBscProject.activate({
@@ -433,6 +435,61 @@ export class Project {
                 }
             })
         ]);
+    }
+
+    /**
+     * Find all .map files in the staging directory and update their `sources` paths to be
+     * relative to the staging map file location instead of the original source location.
+     * This ensures source maps work correctly when the stagingDir differs from the original
+     * source directory (e.g. when using sourceDirs or a customized stagingDir).
+     */
+    private async fixSourceMapSources() {
+        // Build a lookup from staging dest path -> original src path
+        const stagingToSrcMap = new Map<string, string>();
+        for (const mapping of this.fileMappings) {
+            stagingToSrcMap.set(mapping.dest, mapping.src);
+        }
+
+        // Find all .map files currently in the staging directory
+        const mapFiles = (await globAsync('**/*.map', { cwd: this.stagingDir, absolute: true }))
+            .map(f => fileUtils.standardizePath(f));
+
+        await Promise.all(mapFiles.map(async (stagingMapPath) => {
+            const originalMapPath = stagingToSrcMap.get(stagingMapPath);
+
+            // If not in fileMappings or location is unchanged, no rewriting needed
+            if (!originalMapPath || originalMapPath === stagingMapPath) {
+                return;
+            }
+
+            try {
+                const content = await fsExtra.readFile(stagingMapPath, 'utf-8');
+                const sourceMap = JSON.parse(content);
+
+                if (!Array.isArray(sourceMap.sources) || sourceMap.sources.length === 0) {
+                    return;
+                }
+
+                // Resolve sources relative to original map's base dir (honouring sourceRoot if present)
+                const originalBaseDir = sourceMap.sourceRoot
+                    ? path.resolve(path.dirname(originalMapPath), sourceMap.sourceRoot as string)
+                    : path.dirname(originalMapPath);
+
+                const stagingMapDir = path.dirname(stagingMapPath);
+
+                sourceMap.sources = sourceMap.sources.map((source: string) => {
+                    const absoluteSourcePath = path.resolve(originalBaseDir, source);
+                    return fileUtils.standardizePath(path.relative(stagingMapDir, absoluteSourcePath));
+                });
+
+                // Clear sourceRoot since sources are now relative to the map file's new location
+                delete sourceMap.sourceRoot;
+
+                await fsExtra.writeFile(stagingMapPath, JSON.stringify(sourceMap));
+            } catch (e) {
+                this.logger.error(`Error updating source map sources for '${stagingMapPath}'`, e);
+            }
+        }));
     }
 
     /**

--- a/src/managers/ProjectManager.ts
+++ b/src/managers/ProjectManager.ts
@@ -472,7 +472,9 @@ export class Project {
 
                 // Resolve sources relative to original map's base dir (honoring sourceRoot if present)
                 const originalBaseDir = path.resolve(
-                    sourceMap.sourceRoot ?? path.dirname(originalMapPath)
+                    //sourceRoot should resolve relative to originalMapDir, or keep it as-is if it's an absolute path
+                    path.dirname(originalMapPath),
+                    sourceMap.sourceRoot ?? ''
                 );
 
                 const stagingMapDir = path.dirname(stagingMapPath);

--- a/src/managers/ProjectManager.ts
+++ b/src/managers/ProjectManager.ts
@@ -15,6 +15,7 @@ import { Cache } from 'brighterscript/dist/Cache';
 import { BscProjectThreaded } from '../bsc/BscProjectThreaded';
 import type { ScopeFunction } from '../bsc/BscProject';
 import type { Position } from 'brighterscript';
+import { SourceMap, SourceMapPayload } from 'module';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
 const replaceInFile = require('replace-in-file');
@@ -463,21 +464,20 @@ export class Project {
             }
 
             try {
-                const content = await fsExtra.readFile(stagingMapPath, 'utf-8');
-                const sourceMap = JSON.parse(content);
+                const sourceMap = await fsExtra.readJsonSync(stagingMapPath) as SourceMapPayload;
 
                 if (!Array.isArray(sourceMap.sources) || sourceMap.sources.length === 0) {
                     return;
                 }
 
-                // Resolve sources relative to original map's base dir (honouring sourceRoot if present)
-                const originalBaseDir = sourceMap.sourceRoot
-                    ? path.resolve(path.dirname(originalMapPath), sourceMap.sourceRoot as string)
-                    : path.dirname(originalMapPath);
+                // Resolve sources relative to original map's base dir (honoring sourceRoot if present)
+                const originalBaseDir = path.resolve(
+                    sourceMap.sourceRoot ?? path.dirname(originalMapPath)
+                );
 
                 const stagingMapDir = path.dirname(stagingMapPath);
 
-                sourceMap.sources = sourceMap.sources.map((source: string) => {
+                sourceMap.sources = sourceMap.sources.map((source) => {
                     const absoluteSourcePath = path.resolve(originalBaseDir, source);
                     return fileUtils.standardizePath(path.relative(stagingMapDir, absoluteSourcePath));
                 });


### PR DESCRIPTION
added some logic to handle when we stage maps at a different depth than they where generated for