### PR TITLE
Handle THREAD_DETACHED gracefully and show [unavailable] for inaccessible threads

### DIFF
--- a/src/adapters/DebugProtocolAdapter.spec.ts
+++ b/src/adapters/DebugProtocolAdapter.spec.ts
@@ -159,6 +159,35 @@ describe('DebugProtocolAdapter', function() {
                 await adapter.getStackTrace(-1)
             ).to.eql([]);
         });
+
+        it('returns empty array when device responds with THREAD_DETACHED', async () => {
+            await initialize();
+            // clear the cache so a new request is sent for thread 0
+            delete adapter['cache']['stack trace for thread 0'];
+            plugin.pushResponse(
+                GenericV3Response.fromJson({
+                    requestId: undefined,
+                    errorCode: ErrorCode.THREAD_DETACHED
+                })
+            );
+            expect(
+                await adapter.getStackTrace(0)
+            ).to.eql([]);
+        });
+
+        it('returns empty array for any non-OK error code', async () => {
+            await initialize();
+            delete adapter['cache']['stack trace for thread 0'];
+            plugin.pushResponse(
+                GenericV3Response.fromJson({
+                    requestId: undefined,
+                    errorCode: ErrorCode.OTHER_ERR
+                })
+            );
+            expect(
+                await adapter.getStackTrace(0)
+            ).to.eql([]);
+        });
     });
 
     describe('syncBreakpoints', () => {

--- a/src/adapters/DebugProtocolAdapter.ts
+++ b/src/adapters/DebugProtocolAdapter.ts
@@ -586,6 +586,12 @@ export class DebugProtocolAdapter {
             let thread = await this.getThreadByThreadId(threadIndex);
             let frames: StackFrame[] = [];
             let stackTraceData = await this.client.getStackTrace(threadIndex);
+
+            // Non-OK error code (e.g. THREAD_DETACHED) means we can not provide the stack trace
+            if (stackTraceData?.data?.errorCode !== undefined && stackTraceData.data.errorCode !== ErrorCode.OK) {
+                this.logger.warn(`getStackTrace for thread ${threadIndex} failed with errorCode ${stackTraceData.data.errorCode}`);
+                return frames;
+            }
             for (let i = 0; i < (stackTraceData?.data?.entries?.length ?? 0); i++) {
                 let frameData = stackTraceData.data.entries[i];
                 let stackFrame: StackFrame = {
@@ -601,7 +607,7 @@ export class DebugProtocolAdapter {
                 this.stackFramesCache[stackFrame.frameId] = stackFrame;
                 frames.push(stackFrame);
             }
-            //if the first frame is missing any data, suppliment with thread information
+            //if the first frame is missing any data, supplement with thread information
             if (frames[0]) {
                 frames[0].filePath ??= thread.filePath;
                 frames[0].lineNumber ??= thread.lineNumber;

--- a/src/debugSession/BrightScriptDebugSession.spec.ts
+++ b/src/debugSession/BrightScriptDebugSession.spec.ts
@@ -2738,5 +2738,109 @@ describe('BrightScriptDebugSession', () => {
             // should not throw even when getSourceLocation returns undefined
             await session['setupSuspendedState']();
         });
+
+        it('does not crash when getStackTrace returns empty and failedDeletions is non-empty', async () => {
+            // Thread has a valid filePath from getThreads() but getStackTrace returns empty.
+            // The original filePath must be preserved (not clobbered with undefined) so the
+            // failedDeletions loop can safely call getSourceLocation.
+            const getSourceLocationStub = sinon.stub(session.projectManager, 'getSourceLocation').resolves(undefined);
+            sinon.stub(rokuAdapter, 'getThreads').resolves([{
+                isSelected: false,
+                isDetached: false,
+                filePath: 'pkg:/source/main.brs',
+                lineNumber: 10,
+                lineContents: '',
+                threadId: 1
+            }]);
+            sinon.stub(rokuAdapter, 'getStackTrace').resolves([]);
+            session.breakpointManager.failedDeletions.push({
+                srcPath: s`${rootDir}/source/main.brs`,
+                line: 10
+            } as any);
+
+            // should not throw — filePath from getThreads() is preserved even when stack trace is empty
+            await session['setupSuspendedState']();
+
+            // getSourceLocation is called with the original filePath, not undefined
+            expect(getSourceLocationStub.args[0][0]).to.equal('pkg:/source/main.brs');
+        });
+
+        it('calls getStackTrace for all threads including those already flagged isDetached by the device', async () => {
+            // Even threads pre-flagged isDetached must go through getStackTrace so the adapter cache
+            // is populated — otherwise stackTraceRequest would make a second round-trip and might
+            // not show the [detached] label if the device returns something unexpected.
+            const getStackTraceStub = sinon.stub(rokuAdapter, 'getStackTrace').resolves([]);
+            sinon.stub(rokuAdapter, 'getThreads').resolves([
+                { isSelected: true, isDetached: true, filePath: 'pkg:/source/main.brs', lineNumber: 1, lineContents: '', threadId: 0 },
+                { isSelected: false, isDetached: false, filePath: 'pkg:/source/main.brs', lineNumber: 2, lineContents: '', threadId: 1 }
+            ]);
+
+            await session['setupSuspendedState']();
+
+            expect(getStackTraceStub.callCount).to.equal(2);
+        });
+
+        it('returns all threads including detached ones so VS Code can display them', async () => {
+            sinon.stub(rokuAdapter, 'getThreads').resolves([
+                { isSelected: true, isDetached: false, filePath: 'pkg:/source/main.brs', lineNumber: 1, lineContents: '', threadId: 0 },
+                { isSelected: false, isDetached: false, filePath: 'pkg:/source/main.brs', lineNumber: 2, lineContents: '', threadId: 1 }
+            ]);
+            sinon.stub(rokuAdapter, 'getStackTrace')
+                .onFirstCall().resolves([{ filePath: 'pkg:/source/main.brs', lineNumber: 1, functionIdentifier: 'main', frameId: 0 }])
+                .onSecondCall().resolves([]);
+
+            const threads = await session['setupSuspendedState']();
+
+            expect(threads).to.have.length(2);
+        });
+
+        it('does not clobber thread.filePath when line correction stack trace returns no frames', async () => {
+            const threads = [{
+                isSelected: true,
+                isDetached: false,
+                filePath: 'pkg:/source/main.brs',
+                lineNumber: 10,
+                lineContents: '',
+                threadId: 0
+            }];
+            sinon.stub(rokuAdapter, 'getThreads').resolves(threads);
+            sinon.stub(rokuAdapter, 'getStackTrace').resolves([]);
+
+            await session['setupSuspendedState']();
+
+            // original filePath must be preserved — never overwritten with undefined
+            expect(threads[0].filePath).to.equal('pkg:/source/main.brs');
+        });
+    });
+
+    describe('stackTraceRequest', () => {
+        beforeEach(() => {
+            session['rokuAdapterDeferred'].resolve(session['rokuAdapter']);
+            rokuAdapter.isAtDebuggerPrompt = true;
+        });
+
+        async function getStackTraceResponse(threadId: number) {
+            const response = { body: undefined } as DebugProtocol.StackTraceResponse;
+            await session['stackTraceRequest'](response, { threadId: threadId, startFrame: 0, levels: 20 });
+            return response;
+        }
+
+        it('returns a label frame when getStackTrace returns empty (detached thread)', async () => {
+            sinon.stub(rokuAdapter, 'getStackTrace').resolves([]);
+
+            const response = await getStackTraceResponse(0);
+
+            expect(response.body.stackFrames).to.have.length(1);
+            expect(response.body.stackFrames[0].presentationHint).to.equal('label');
+            expect(response.body.stackFrames[0].name).to.equal('[unavailable]');
+        });
+
+        it('label frame for detached thread has no source', async () => {
+            sinon.stub(rokuAdapter, 'getStackTrace').resolves([]);
+
+            const response = await getStackTraceResponse(0);
+
+            expect(response.body.stackFrames[0].source).to.be.undefined;
+        });
     });
 });

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -1508,44 +1508,51 @@ export class BrightScriptDebugSession extends LoggingDebugSession {
 
                 if (this.rokuAdapter.isAtDebuggerPrompt) {
                     let stackTrace = await this.rokuAdapter.getStackTrace(args.threadId);
-
-                    for (let debugFrame of stackTrace) {
-                        let sourceLocation = await this.projectManager.getSourceLocation(debugFrame.filePath, debugFrame.lineNumber);
-
-                        //the stacktrace returns function identifiers in all lower case. Try to get the actual case
-                        //load the contents of the file and get the correct casing for the function identifier
-                        try {
-                            let functionName = this.fileManager.getCorrectFunctionNameCase(sourceLocation?.filePath, debugFrame.functionIdentifier);
-                            if (functionName) {
-
-                                //search for original function name if this is an anonymous function.
-                                //anonymous function names are prefixed with $ in the stack trace (i.e. $anon_1 or $functionname_40002)
-                                if (functionName.startsWith('$')) {
-                                    functionName = this.fileManager.getFunctionNameAtPosition(
-                                        sourceLocation.filePath,
-                                        sourceLocation.lineNumber - 1,
-                                        functionName
-                                    );
-                                }
-                                debugFrame.functionIdentifier = functionName;
-                            }
-                        } catch (error) {
-                            this.logger.error('Error correcting function identifier case', { error, sourceLocation, debugFrame });
-                        }
-                        const filePath = sourceLocation?.filePath ?? debugFrame.filePath;
-
-                        const frame: DebugProtocol.StackFrame = new StackFrame(
-                            debugFrame.frameId,
-                            `${debugFrame.functionIdentifier}`,
-                            new Source(path.basename(filePath), filePath),
-                            // lineNumber is 1-based from Roku; toClientLine expects 0-based
-                            this.toClientLine((sourceLocation?.lineNumber ?? debugFrame.lineNumber) - 1),
-                            this.toClientColumn(0)
-                        );
-                        if (!sourceLocation) {
-                            frame.presentationHint = 'subtle';
-                        }
+                    if (stackTrace.length === 0) {
+                        // Thread is detached or encountered an error requesting Stack Trace — show a non-interactive label so VS Code can display
+                        // the thread without letting the user navigate to a source location
+                        const frame = new StackFrame(0, '[unavailable]');
+                        frame.presentationHint = 'label';
                         frames.push(frame);
+                    } else {
+                        for (let debugFrame of stackTrace) {
+                            let sourceLocation = await this.projectManager.getSourceLocation(debugFrame.filePath, debugFrame.lineNumber);
+
+                            //the stacktrace returns function identifiers in all lower case. Try to get the actual case
+                            //load the contents of the file and get the correct casing for the function identifier
+                            try {
+                                let functionName = this.fileManager.getCorrectFunctionNameCase(sourceLocation?.filePath, debugFrame.functionIdentifier);
+                                if (functionName) {
+
+                                    //search for original function name if this is an anonymous function.
+                                    //anonymous function names are prefixed with $ in the stack trace (i.e. $anon_1 or $functionname_40002)
+                                    if (functionName.startsWith('$')) {
+                                        functionName = this.fileManager.getFunctionNameAtPosition(
+                                            sourceLocation.filePath,
+                                            sourceLocation.lineNumber - 1,
+                                            functionName
+                                        );
+                                    }
+                                    debugFrame.functionIdentifier = functionName;
+                                }
+                            } catch (error) {
+                                this.logger.error('Error correcting function identifier case', { error, sourceLocation, debugFrame });
+                            }
+                            const filePath = sourceLocation?.filePath ?? debugFrame.filePath;
+
+                            const frame: DebugProtocol.StackFrame = new StackFrame(
+                                debugFrame.frameId,
+                                `${debugFrame.functionIdentifier}`,
+                                new Source(path.basename(filePath), filePath),
+                                // lineNumber is 1-based from Roku; toClientLine expects 0-based
+                                this.toClientLine((sourceLocation?.lineNumber ?? debugFrame.lineNumber) - 1),
+                                this.toClientColumn(0)
+                            );
+                            if (!sourceLocation) {
+                                frame.presentationHint = 'subtle';
+                            }
+                            frames.push(frame);
+                        }
                     }
                 } else {
                     this.logger.log('Skipped calculating stacktrace because the RokuAdapter is not accepting input at this time');
@@ -2605,10 +2612,12 @@ export class BrightScriptDebugSession extends LoggingDebugSession {
                 const stackTrace = await this.rokuAdapter.getStackTrace(thread.threadId);
                 const stackTraceLineNumber = stackTrace[0]?.lineNumber;
                 const stackTraceFilePath = stackTrace[0]?.filePath;
-                if (stackTraceLineNumber !== thread.lineNumber) {
+                // Only apply the line correction when we actually have valid data — never clobber
+                // thread.filePath with undefined, which would crash getSourceLocation downstream.
+                if (stackTraceLineNumber !== undefined && stackTraceLineNumber !== thread.lineNumber) {
                     this.logger.warn(`Thread ${thread.threadId} reported incorrect line (${thread.lineNumber}). Using line from stack trace instead (${stackTraceLineNumber})`, thread, stackTrace);
                     thread.lineNumber = stackTraceLineNumber;
-                    thread.filePath = stackTraceFilePath;
+                    thread.filePath = stackTraceFilePath ?? thread.filePath;
                 }
             })
         );


### PR DESCRIPTION
## Summary

- When a thread detaches between `getThreads()` and `getStackTrace()`, the device returns `errorCode=6 (THREAD_DETACHED)` with a minimal packet and no stack entries. This previously caused a crash in `setupSuspendedState` where the line-correction workaround blindly overwrote `thread.filePath` with `undefined`, crashing `getSourceLocation` downstream.
- `getStackTrace()` now returns `[]` for any non-OK error code instead of propagating bad data to callers.
- The line-correction workaround in `setupSuspendedState` now guards against `stackTraceLineNumber === undefined` before overwriting thread data.
- `stackTraceRequest` now shows a non-interactive `[unavailable]` label frame (`presentationHint: 'label'`) when `getStackTrace` returns empty, so VS Code displays the thread without allowing navigation to an invalid source location.

Closes #318
Closes rokucommunity/vscode-brightscript-language#732