### PR TITLE
Defer DAP capabilities and InitializedEvent until after adapter connects

### DIFF
--- a/src/debugSession/BrightScriptDebugSession.spec.ts
+++ b/src/debugSession/BrightScriptDebugSession.spec.ts
@@ -245,6 +245,9 @@ describe('BrightScriptDebugSession', () => {
             }
         } as Partial<LaunchConfiguration> as LaunchConfiguration);
 
+        //publish now runs inside configurationDoneRequest, so invoke it to complete the launch flow
+        await (session as any).configurationDoneRequest({} as any, {} as any);
+
         expect(publishStub.getCall(0).args[0].packageUploadOverrides).to.eql({
             route: '1234',
             formData: {
@@ -2555,15 +2558,22 @@ describe('BrightScriptDebugSession', () => {
                 session['initRequestArgs'].supportsProgressReporting = true;
 
                 await session.launchRequest({} as any, launchConfiguration);
+                await (session as any).configurationDoneRequest({} as any, {} as any);
 
                 const progressEvents = getProgressEvents();
-                expect(progressEvents).to.have.lengthOf(3);
+                expect(progressEvents).to.have.lengthOf(6);
                 expect(progressEvents[0]).to.be.instanceOf(ProgressStartEvent);
-                expect((progressEvents[0].body as any).message).to.equal('Packaging...');
+                expect((progressEvents[0].body as any).message).to.equal('Finding device on network...');
                 expect(progressEvents[1]).to.be.instanceOf(ProgressUpdateEvent);
-                expect((progressEvents[1].body as any).message).to.equal('Uploading to Roku...');
+                expect((progressEvents[1].body as any).message).to.equal('Packaging Project...');
                 expect(progressEvents[2]).to.be.instanceOf(ProgressUpdateEvent);
-                expect((progressEvents[2].body as any).message).to.equal('Waiting on application...');
+                expect((progressEvents[2].body as any).message).to.equal('Connecting to debug server...');
+                expect(progressEvents[3]).to.be.instanceOf(ProgressUpdateEvent);
+                expect((progressEvents[3].body as any).message).to.equal('Configuring breakpoints...');
+                expect(progressEvents[4]).to.be.instanceOf(ProgressUpdateEvent);
+                expect((progressEvents[4].body as any).message).to.equal('Uploading to Roku...');
+                expect(progressEvents[5]).to.be.instanceOf(ProgressUpdateEvent);
+                expect((progressEvents[5].body as any).message).to.equal('Waiting on application...');
             });
 
             it('all progress events share the same progressId', async function() {
@@ -2591,6 +2601,7 @@ describe('BrightScriptDebugSession', () => {
                 session['initRequestArgs'].supportsProgressReporting = true;
 
                 await session.launchRequest({} as any, launchConfiguration);
+                await (session as any).configurationDoneRequest({} as any, {} as any);
 
                 const progressUpdateEvents = events.filter(e => e instanceof ProgressUpdateEvent);
                 const abortEvent = progressUpdateEvents.find(e => (e.body as any).message === 'Aborted (compile error)');

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -9,6 +9,7 @@ import {
     LoggingDebugSession,
     Logger as DapLogger,
     logger as dapLogger,
+    CapabilitiesEvent,
     InitializedEvent,
     InvalidatedEvent,
     OutputEvent,
@@ -365,37 +366,11 @@ export class BrightScriptDebugSession extends LoggingDebugSession {
         // make VS Code to use 'evaluate' when hovering over source
         response.body.supportsEvaluateForHovers = true;
 
-        // make VS Code to show a 'step back' button
-        response.body.supportsStepBack = false;
-
         // This debug adapter supports conditional breakpoints
         response.body.supportsConditionalBreakpoints = true;
 
-        response.body.supportsExceptionFilterOptions = true;
-        response.body.supportsExceptionOptions = true;
-
-        //the list of exception breakpoints (we have to send them all the time, even if the device doesn't support them)
-        response.body.exceptionBreakpointFilters = [{
-            filter: 'caught',
-            supportsCondition: true,
-            conditionDescription: '__brs_err__.rethrown = true',
-            label: 'Caught Exceptions',
-            description: `Breaks on all errors, even if they're caught later.`,
-            default: false
-        }, {
-            filter: 'uncaught',
-            supportsCondition: true,
-            conditionDescription: '__brs_err__.rethrown = true',
-            label: 'Uncaught Exceptions',
-            description: 'Breaks only on errors that are not handled.',
-            default: true
-        }];
-
         // This debug adapter supports breakpoints that break execution after a specified number of hits
         response.body.supportsHitConditionalBreakpoints = true;
-
-        // This debug adapter supports log points by interpreting the 'logMessage' attribute of the SourceBreakpoint
-        response.body.supportsLogPoints = true;
 
         response.body.supportsCompletionsRequest = true;
         response.body.completionTriggerCharacters = ['.', '(', '{', ',', ' '];
@@ -410,11 +385,6 @@ export class BrightScriptDebugSession extends LoggingDebugSession {
                 )
             );
         });
-
-        // since this debug adapter can accept configuration requests like 'setBreakpoint' at any time,
-        // we request them early by sending an 'initializeRequest' to the frontend.
-        // The frontend will end the configuration sequence by calling 'configurationDone' request.
-        this.sendEvent(new InitializedEvent());
 
         this.logger.log('initializeRequest finished');
     }
@@ -598,7 +568,6 @@ export class BrightScriptDebugSession extends LoggingDebugSession {
 
         this.sendEvent(new LaunchStartEvent(this.launchConfiguration));
 
-        let error: Error;
         this.logger.log('[launchRequest] Packaging and deploying to roku');
         try {
             const packageEnd = this.logger.timeStart('log', 'Packaging');
@@ -630,6 +599,58 @@ export class BrightScriptDebugSession extends LoggingDebugSession {
             await this.connectRokuAdapter();
             connectAdapterEnd();
 
+            // some capabilities depend on adapter type and are sent now that we know which adapter is in use
+            const supportsExceptionBreakpoints = this.rokuAdapter.supportsExceptionBreakpoints;
+            this.sendEvent(new CapabilitiesEvent({
+                // log points are only supported by the telnet adapter
+                supportsLogPoints: !this.enableDebugProtocol,
+                supportsExceptionFilterOptions: supportsExceptionBreakpoints,
+                supportsExceptionOptions: supportsExceptionBreakpoints,
+                exceptionBreakpointFilters: supportsExceptionBreakpoints ? [{
+                    filter: 'caught',
+                    supportsCondition: true,
+                    conditionDescription: '__brs_err__.rethrown = true',
+                    label: 'Caught Exceptions',
+                    description: `Breaks on all errors, even if they're caught later.`,
+                    default: false
+                }, {
+                    filter: 'uncaught',
+                    supportsCondition: true,
+                    conditionDescription: '__brs_err__.rethrown = true',
+                    label: 'Uncaught Exceptions',
+                    description: 'Breaks only on errors that are not handled.',
+                    default: true
+                }] : []
+            }));
+
+            // notify VS Code that the adapter is ready to receive configuration (breakpoints, etc.)
+            // VS Code will respond with setBreakpoints, setExceptionBreakpoints, then configurationDone
+            this.sendEvent(new InitializedEvent());
+
+        } catch (e) {
+            //if the message is anything other than compile errors, we want to display the error
+            if (!(e instanceof CompileError)) {
+                util.log('Encountered an issue during the launch process');
+                util.log((e as Error)?.stack);
+
+                //send any compile errors to the client
+                await this.rokuAdapter?.sendErrors();
+
+                const message = (e instanceof SocketConnectionInUseError) ? e.message : (e?.stack ?? e);
+                await this.shutdown(message as string, true);
+            } else {
+                this.sendLaunchProgress('end', 'Aborted (compile error)');
+            }
+        }
+        logEnd();
+    }
+
+    protected async configurationDoneRequest(response: DebugProtocol.ConfigurationDoneResponse, args: DebugProtocol.ConfigurationDoneArguments) {
+        this.logger.log('configurationDoneRequest');
+        super.configurationDoneRequest(response, args);
+
+        let error: Error;
+        try {
             await this.runAutomaticSceneGraphCommands(this.launchConfiguration.autoRunSgDebugCommands);
 
             //press the home button to ensure we're at the home screen
@@ -693,7 +714,7 @@ export class BrightScriptDebugSession extends LoggingDebugSession {
                     await this.shutdown();
                 } else {
                     const message = 'App exit detected; but launchConfiguration.stopDebuggerOnAppExit is set to false, so keeping debug session running.';
-                    this.logger.log('[launchRequest]', message);
+                    this.logger.log('[configurationDoneRequest]', message);
                     this.sendEvent(new LogOutputEvent(message));
                     this.rokuAdapter.once('connected').then(async () => {
                         await this.rokuAdapter.setExceptionBreakpoints(this.exceptionBreakpoints);
@@ -764,7 +785,6 @@ export class BrightScriptDebugSession extends LoggingDebugSession {
                 this.sendLaunchProgress('end', 'Aborted (compile error)');
             }
         }
-        logEnd();
     }
 
     /**
@@ -1403,10 +1423,6 @@ export class BrightScriptDebugSession extends LoggingDebugSession {
             this.sendResponse = old;
         };
         super.sourceRequest(response, args);
-    }
-
-    protected configurationDoneRequest(response: DebugProtocol.ConfigurationDoneResponse, args: DebugProtocol.ConfigurationDoneArguments) {
-        this.logger.log('configurationDoneRequest');
     }
 
     /**

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -565,6 +565,10 @@ export class BrightScriptDebugSession extends LoggingDebugSession {
             }
 
             await this.initializeProfiling();
+
+            // everything is ready, send the response to the launch request so the UI can update and configuration can begin
+            this.sendResponse(response);
+
             //initialize all file logging (rokuDevice, debugger, etc)
             this.fileLoggingManager.activate(this.launchConfiguration?.fileLogging, this.cwd);
 
@@ -633,8 +637,8 @@ export class BrightScriptDebugSession extends LoggingDebugSession {
             }));
 
             this.sendLaunchProgress('update', 'Configuring breakpoints');
-            // everything is ready, send the response to the launch request so the UI can update and configuration can begin
-            this.sendResponse(response);
+
+            util.log('Done initializing');
 
             // notify VS Code that the adapter is ready to receive configuration (breakpoints, etc.)
             // VS Code will respond with setBreakpoints, setExceptionBreakpoints, then configurationDone

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -519,59 +519,57 @@ export class BrightScriptDebugSession extends LoggingDebugSession {
     public async launchRequest(response: DebugProtocol.LaunchResponse, config: LaunchConfiguration) {
         const logEnd = this.logger.timeStart('log', '[launchRequest] launch');
 
-        this.resetSessionState();
-
-        //send the response right away so the UI immediately shows the debugger toolbar
-        this.sendResponse(response);
-
-        this.launchConfiguration = this.normalizeLaunchConfig(config);
-        this.setupProcessErrorHandlers();
-
-        //prebake some threads for our ProjectManager to use later on (1 for the main project, and 1 for every complib)
-        bscProjectWorkerPool.preload(1 + (this.launchConfiguration?.componentLibraries?.length ?? 0));
-
-        //set the logLevel provided by the launch config
-        if (this.launchConfiguration.logLevel) {
-            logger.logLevel = this.launchConfiguration.logLevel;
-        }
-
-        //do a DNS lookup for the host to fix issues with roku rejecting ECP
         try {
-            this.launchConfiguration.host = await util.dnsLookup(this.launchConfiguration.host);
-        } catch (e) {
-            return this.shutdown(`Could not resolve ip address for host '${this.launchConfiguration.host}'`);
-        }
+            this.resetSessionState();
+            this.launchConfiguration = this.normalizeLaunchConfig(config);
+            this.setupProcessErrorHandlers();
 
-        // fetches the device info and parses the xml data to JSON object
-        try {
-            this.deviceInfo = await rokuDeploy.getDeviceInfo({ host: this.launchConfiguration.host, remotePort: this.launchConfiguration.remotePort, enhance: true, timeout: 4_000 });
-            if (this.deviceInfo.ecpSettingMode === 'limited') {
-                return await this.shutdown(`ECP access is limited on this Roku. Please change it to 'permissive' or 'enabled' and try again. (device: ${this.launchConfiguration.host})`);
+            //prebake some threads for our ProjectManager to use later on (1 for the main project, and 1 for every complib)
+            bscProjectWorkerPool.preload(1 + (this.launchConfiguration?.componentLibraries?.length ?? 0));
+
+            //set the logLevel provided by the launch config
+            if (this.launchConfiguration.logLevel) {
+                logger.logLevel = this.launchConfiguration.logLevel;
             }
-        } catch (e) {
-            if (e instanceof EcpNetworkAccessModeDisabledError) {
-                return this.shutdown(`ECP access is disabled on this Roku. Please change it to 'permissive' or 'enabled' and try again. (device: ${this.launchConfiguration.host})`);
+
+            this.sendLaunchProgress('start', 'Finding device on network');
+
+            //do a DNS lookup for the host to fix issues with roku rejecting ECP
+            try {
+                this.launchConfiguration.host = await util.dnsLookup(this.launchConfiguration.host);
+            } catch (e) {
+                return this.shutdown(`Could not resolve ip address for host '${this.launchConfiguration.host}'`);
             }
-            return this.shutdown(`Unable to connect to roku at '${this.launchConfiguration.host}'. Verify the IP address is correct and that the device is powered on and connected to same network as this computer.`);
-        }
 
-        if (this.deviceInfo && !this.deviceInfo.developerEnabled) {
-            return this.shutdown(`Developer mode is not enabled for host '${this.launchConfiguration.host}'.`);
-        }
+            // fetches the device info and parses the xml data to JSON object
+            try {
+                this.deviceInfo = await rokuDeploy.getDeviceInfo({ host: this.launchConfiguration.host, remotePort: this.launchConfiguration.remotePort, enhance: true, timeout: 4_000 });
+                if (this.deviceInfo.ecpSettingMode === 'limited') {
+                    return await this.shutdown(`ECP access is limited on this Roku. Please change it to 'permissive' or 'enabled' and try again. (device: ${this.launchConfiguration.host})`);
+                }
+            } catch (e) {
+                if (e instanceof EcpNetworkAccessModeDisabledError) {
+                    return this.shutdown(`ECP access is disabled on this Roku. Please change it to 'permissive' or 'enabled' and try again. (device: ${this.launchConfiguration.host})`);
+                }
+                return this.shutdown(`Unable to connect to roku at '${this.launchConfiguration.host}'. Verify the IP address is correct and that the device is powered on and connected to same network as this computer.`);
+            }
 
-        await this.initializeProfiling();
-        //initialize all file logging (rokuDevice, debugger, etc)
-        this.fileLoggingManager.activate(this.launchConfiguration?.fileLogging, this.cwd);
+            if (this.deviceInfo && !this.deviceInfo.developerEnabled) {
+                return await this.shutdown(`Developer mode is not enabled for host '${this.launchConfiguration.host}'.`);
+            }
 
-        this.projectManager.launchConfiguration = this.launchConfiguration;
-        this.breakpointManager.launchConfiguration = this.launchConfiguration;
+            await this.initializeProfiling();
+            //initialize all file logging (rokuDevice, debugger, etc)
+            this.fileLoggingManager.activate(this.launchConfiguration?.fileLogging, this.cwd);
 
-        this.sendEvent(new LaunchStartEvent(this.launchConfiguration));
+            this.projectManager.launchConfiguration = this.launchConfiguration;
+            this.breakpointManager.launchConfiguration = this.launchConfiguration;
 
-        this.logger.log('[launchRequest] Packaging and deploying to roku');
-        try {
+            this.sendEvent(new LaunchStartEvent(this.launchConfiguration));
+
+            this.logger.log('[launchRequest] Packaging and deploying to roku');
             const packageEnd = this.logger.timeStart('log', 'Packaging');
-            this.sendLaunchProgress('start', 'Packaging');
+            this.sendLaunchProgress('update', `Packaging Project${(this.launchConfiguration?.componentLibraries?.length ?? 0) > 0 ? 's' : ''}`);
             //build the main project and all component libraries at the same time
             await Promise.all([
                 this.prepareMainProject(),
@@ -594,6 +592,7 @@ export class BrightScriptDebugSession extends LoggingDebugSession {
                 this.logger.error('Failed to initialize rendezvous tracking', e);
             }
 
+            this.sendLaunchProgress('update', 'Connecting to debug server');
             const connectAdapterEnd = this.logger.timeStart('log', 'Connect adapter');
             this.createRokuAdapter(this.rendezvousTracker);
             await this.connectRokuAdapter();
@@ -622,6 +621,10 @@ export class BrightScriptDebugSession extends LoggingDebugSession {
                     default: true
                 }] : []
             }));
+
+            this.sendLaunchProgress('update', 'Configuring breakpoints');
+            // everything is ready, send the response to the launch request so the UI can update and configuration can begin
+            this.sendResponse(response);
 
             // notify VS Code that the adapter is ready to receive configuration (breakpoints, etc.)
             // VS Code will respond with setBreakpoints, setExceptionBreakpoints, then configurationDone


### PR DESCRIPTION
## Summary

- Move `InitializedEvent` from `initializeRequest` to `launchRequest`, sent after the Roku adapter connects — so VS Code's configuration phase (`setBreakpoints`, `setExceptionBreakpoints`, `configurationDone`) happens with a live connection
- Move post-configuration work (sg commands, home button, publish, activate, deep link) into `configurationDoneRequest` so it runs only after VS Code has finished sending breakpoint config
- Send a `CapabilitiesEvent` just before `InitializedEvent` to advertise adapter-specific capabilities:
  - `supportsLogPoints` only for telnet (not debug protocol)
  - Exception breakpoint support (`supportsExceptionFilterOptions`, `supportsExceptionOptions`, `exceptionBreakpointFilters`) conditional on `rokuAdapter.supportsExceptionBreakpoints`
- Remove `supportsStepBack = false` (redundant default) and stale comments

## Test plan

- [ ] Launch a debug session using the **telnet** adapter — verify log points UI appears and exception breakpoint filters show in the Breakpoints panel
- [ ] Launch a debug session using the **debug protocol** adapter — verify log points UI does NOT appear and exception breakpoints are hidden if not supported
- [ ] Verify breakpoints set before launch are correctly registered (sent during configuration phase)
- [ ] Verify `configurationDone` triggers the publish/activate flow as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)