### PR TITLE
Avoid monkey-patching roku-deploy's getFiles function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
                 "postman-request": "^2.88.1-postman.40",
                 "replace-in-file": "^6.3.2",
                 "replace-last": "^1.2.6",
-                "roku-deploy": "^3.16.4",
+                "roku-deploy": "^3.16.5",
                 "semver": "^7.5.4",
                 "serialize-error": "^8.1.0",
                 "smart-buffer": "^4.2.0",
@@ -5532,9 +5532,10 @@
             }
         },
         "node_modules/roku-deploy": {
-            "version": "3.16.4",
-            "resolved": "https://registry.npmjs.org/roku-deploy/-/roku-deploy-3.16.4.tgz",
-            "integrity": "sha512-vw7pfIpTaL21nuBWJBcREG7tL6Bm0fX3LdP+5DZqU9riO0kJZvs6de9u3AnZ78R23E0XcydIM6GAeWmB8zLIEA==",
+            "version": "3.16.5",
+            "resolved": "https://registry.npmjs.org/roku-deploy/-/roku-deploy-3.16.5.tgz",
+            "integrity": "sha512-o6tVquLfmpD+01gDCfsD0of62D4M9d6cq5Wm8AOWKRLRHfSQg+yDGkszwfsqTaO3kr9iXx7W+pgOUXYFUsK8ow==",
+            "license": "MIT",
             "dependencies": {
                 "@types/request": "^2.47.0",
                 "chalk": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
         "postman-request": "^2.88.1-postman.40",
         "replace-in-file": "^6.3.2",
         "replace-last": "^1.2.6",
-        "roku-deploy": "^3.16.4",
+        "roku-deploy": "^3.16.5",
         "semver": "^7.5.4",
         "serialize-error": "^8.1.0",
         "smart-buffer": "^4.2.0",

--- a/src/PerfettoManager.spec.ts
+++ b/src/PerfettoManager.spec.ts
@@ -8,7 +8,7 @@ import { EventEmitter } from 'events';
 import { rootDir, tempDir } from './testHelpers.spec';
 import { createSandbox } from 'sinon';
 import { standardizePath as s } from 'brighterscript';
-import { EcpStatus } from './RokuECP';
+import { EcpStatus, rokuECP } from './RokuECP';
 const sinon = createSandbox();
 
 describe('PerfettoManager', () => {
@@ -154,7 +154,7 @@ describe('PerfettoManager', () => {
         it('creates trace directory if it does not exist', async () => {
             // Stub createWriteStream to prevent actual file operations but still allow directory creation
             sinon.stub(perfettoManager as any, 'createWriteStream').rejects(new Error('Test abort'));
-            
+
             try {
                 await perfettoManager.startTracing();
             } catch {
@@ -226,7 +226,6 @@ describe('PerfettoManager', () => {
 
     describe('enableTracing', () => {
         it('enables tracing and emits enable event', async () => {
-            const { rokuECP } = await import('./RokuECP');
             sinon.stub(rokuECP, 'enablePerfettoTracing').resolves({
                 status: EcpStatus.ok,
                 enabledChannels: ['dev']
@@ -244,7 +243,6 @@ describe('PerfettoManager', () => {
         });
 
         it('throws and emits error when ECP request fails', async () => {
-            const { rokuECP } = await import('./RokuECP');
             sinon.stub(rokuECP, 'enablePerfettoTracing').rejects(new Error('404 Not Found'));
 
             const errorSpy = sinon.spy();
@@ -262,7 +260,6 @@ describe('PerfettoManager', () => {
         });
 
         it('throws error when no host configured', async () => {
-            const { rokuECP } = await import('./RokuECP');
             sinon.stub(rokuECP, 'enablePerfettoTracing').rejects(new Error('No host configured'));
 
             perfettoManager = new PerfettoManager({
@@ -280,7 +277,6 @@ describe('PerfettoManager', () => {
         });
 
         it('propagates network errors', async () => {
-            const { rokuECP } = await import('./RokuECP');
             sinon.stub(rokuECP, 'enablePerfettoTracing').rejects(new Error('Network error'));
 
             try {
@@ -534,7 +530,6 @@ describe('PerfettoManager', () => {
             (perfettoManager as any).socket = mockSocket;
             (perfettoManager as any).filePath = '/tmp/traces/test.perfetto-trace';
 
-            const { rokuECP } = await import('./RokuECP');
             sinon.stub(rokuECP, 'captureHeapSnapshot').resolves({
                 status: EcpStatus.ok,
                 timestamp: Date.now(),
@@ -554,7 +549,6 @@ describe('PerfettoManager', () => {
             mockSocket.readyState = WebSocket.OPEN;
             (perfettoManager as any).socket = mockSocket;
 
-            const { rokuECP } = await import('./RokuECP');
             sinon.stub(rokuECP, 'captureHeapSnapshot').rejects(new Error('500 Internal Server Error'));
 
             const errorSpy = sinon.spy();
@@ -575,7 +569,6 @@ describe('PerfettoManager', () => {
             mockSocket.readyState = WebSocket.OPEN;
             (perfettoManager as any).socket = mockSocket;
 
-            const { rokuECP } = await import('./RokuECP');
             sinon.stub(rokuECP, 'captureHeapSnapshot').rejects(new Error('404 Not Found'));
 
             const stopSpy = sinon.spy();
@@ -801,7 +794,7 @@ describe('PerfettoManager', () => {
 
             // Delay emit to ensure event handlers are registered
             await new Promise<void>(resolve => {
-                setImmediate(resolve); 
+                setImmediate(resolve);
             });
             mockSocket.emit('open');
             await startPromise;
@@ -817,7 +810,7 @@ describe('PerfettoManager', () => {
 
             const startPromise = perfettoManager.startTracing();
             await new Promise<void>(resolve => {
-                setImmediate(resolve); 
+                setImmediate(resolve);
             });
             mockSocket.emit('open');
             await startPromise;
@@ -831,7 +824,7 @@ describe('PerfettoManager', () => {
 
             const startPromise = perfettoManager.startTracing();
             await new Promise<void>(resolve => {
-                setImmediate(resolve); 
+                setImmediate(resolve);
             });
             mockSocket.emit('open');
             await startPromise;
@@ -847,7 +840,7 @@ describe('PerfettoManager', () => {
 
             const startPromise = perfettoManager.startTracing();
             await new Promise<void>(resolve => {
-                setImmediate(resolve); 
+                setImmediate(resolve);
             });
             mockSocket.emit('open');
             await startPromise;
@@ -864,7 +857,7 @@ describe('PerfettoManager', () => {
 
             const startPromise = perfettoManager.startTracing();
             await new Promise<void>(resolve => {
-                setImmediate(resolve); 
+                setImmediate(resolve);
             });
             mockSocket.emit('open');
             await startPromise;
@@ -881,7 +874,7 @@ describe('PerfettoManager', () => {
 
             const startPromise = perfettoManager.startTracing();
             await new Promise<void>(resolve => {
-                setImmediate(resolve); 
+                setImmediate(resolve);
             });
             mockSocket.emit('open');
             await startPromise;
@@ -899,7 +892,7 @@ describe('PerfettoManager', () => {
 
             const startPromise = perfettoManager.startTracing();
             await new Promise<void>(resolve => {
-                setImmediate(resolve); 
+                setImmediate(resolve);
             });
             mockSocket.emit('open');
             await startPromise;
@@ -919,7 +912,7 @@ describe('PerfettoManager', () => {
 
             const startPromise = perfettoManager.startTracing();
             await new Promise<void>(resolve => {
-                setImmediate(resolve); 
+                setImmediate(resolve);
             });
             mockSocket.emit('open');
             await startPromise;
@@ -944,7 +937,7 @@ describe('PerfettoManager', () => {
 
             const startPromise = perfettoManager.startTracing();
             await new Promise<void>(resolve => {
-                setImmediate(resolve); 
+                setImmediate(resolve);
             });
             mockSocket.emit('open');
             await startPromise;
@@ -954,7 +947,7 @@ describe('PerfettoManager', () => {
 
             // Wait for cleanup to complete
             await new Promise(resolve => {
-                setTimeout(resolve, 50); 
+                setTimeout(resolve, 50);
             });
 
             expect(stopSpy.called).to.be.true;
@@ -964,7 +957,6 @@ describe('PerfettoManager', () => {
 
     describe('enableTracing channel validation', () => {
         it('throws when channel is not in enabled channels list', async () => {
-            const { rokuECP } = await import('./RokuECP');
             sinon.stub(rokuECP, 'enablePerfettoTracing').resolves({
                 status: EcpStatus.ok,
                 enabledChannels: ['other-channel', 'another-channel']
@@ -984,7 +976,6 @@ describe('PerfettoManager', () => {
         });
 
         it('succeeds when channel is in enabled channels list (case insensitive)', async () => {
-            const { rokuECP } = await import('./RokuECP');
             sinon.stub(rokuECP, 'enablePerfettoTracing').resolves({
                 status: EcpStatus.ok,
                 enabledChannels: ['DEV', 'prod'] // uppercase 'DEV'
@@ -996,13 +987,14 @@ describe('PerfettoManager', () => {
         });
     });
 
-    describe('captureHeapSnapshot when already tracing', () => {
+    describe('captureHeapSnapshot when already tracing', function() {
+        this.timeout(10_000);
+
         it('does not start new tracing when already tracing', async () => {
             mockSocket.readyState = WebSocket.OPEN;
             (perfettoManager as any).socket = mockSocket;
             (perfettoManager as any).filePath = '/tmp/traces/existing.perfetto-trace';
 
-            const { rokuECP } = await import('./RokuECP');
             sinon.stub(rokuECP, 'captureHeapSnapshot').resolves({
                 status: EcpStatus.ok,
                 timestamp: Date.now(),
@@ -1020,7 +1012,6 @@ describe('PerfettoManager', () => {
             (perfettoManager as any).socket = mockSocket;
             (perfettoManager as any).filePath = '/tmp/traces/test.perfetto-trace';
 
-            const { rokuECP } = await import('./RokuECP');
             sinon.stub(rokuECP, 'captureHeapSnapshot').resolves({
                 status: EcpStatus.ok,
                 timestamp: Date.now(),
@@ -1041,7 +1032,6 @@ describe('PerfettoManager', () => {
             (perfettoManager as any).socket = mockSocket;
             (perfettoManager as any).filePath = '/tmp/traces/test.perfetto-trace';
 
-            const { rokuECP } = await import('./RokuECP');
             sinon.stub(rokuECP, 'captureHeapSnapshot').resolves({
                 status: EcpStatus.ok,
                 timestamp: Date.now(),
@@ -1059,7 +1049,6 @@ describe('PerfettoManager', () => {
             (perfettoManager as any).socket = mockSocket;
             (perfettoManager as any).filePath = '/tmp/traces/test.perfetto-trace';
 
-            const { rokuECP } = await import('./RokuECP');
             sinon.stub(rokuECP, 'captureHeapSnapshot').resolves({
                 status: EcpStatus.ok,
                 timestamp: Date.now(),
@@ -1333,7 +1322,7 @@ describe('PerfettoManager', () => {
             // Start first call
             const promise1 = perfettoManager.startTracing();
             await new Promise<void>(resolve => {
-                setImmediate(resolve); 
+                setImmediate(resolve);
             });
             mockSocket.emit('open');
             await promise1;
@@ -1357,7 +1346,7 @@ describe('PerfettoManager', () => {
 
             const startPromise = perfettoManager.startTracing();
             await new Promise<void>(resolve => {
-                setImmediate(resolve); 
+                setImmediate(resolve);
             });
             mockSocket.emit('open');
             await startPromise;

--- a/src/debugSession/BrightScriptDebugSession.spec.ts
+++ b/src/debugSession/BrightScriptDebugSession.spec.ts
@@ -25,6 +25,9 @@ import type { EvaluateContainer } from '../adapters/DebugProtocolAdapter';
 import { VariableType } from '../debugProtocol/events/responses/VariablesResponse';
 import { PerfettoManager } from '../PerfettoManager';
 
+//DebugSession.shutdown() calls process.exit() after a sleep, so we need to prevent that during tests. This should not be a mock, it needs to be permanent for this flow
+DebugSession.prototype.shutdown = () => { };
+
 const sinon = sinonActual.createSandbox();
 const tempDir = s`${__dirname}/../../.tmp`;
 const rootDir = s`${tempDir}/rootDir`;

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -131,7 +131,7 @@ export class BrightScriptDebugSession extends LoggingDebugSession {
             let debuggerVersion: string;
             let additionalInfo: ProcessCrashEventData['additionalInfo'];
             try {
-                debuggerVersion = (fsExtra.readJsonSync( path.resolve(__dirname, '../../package.json')) as { version: string }).version;
+                debuggerVersion = (fsExtra.readJsonSync(path.resolve(__dirname, '../../package.json')) as { version: string }).version;
 
                 const clientName = this.initRequestArgs?.clientName ?? 'unknown';
 

--- a/src/managers/ProjectManager.spec.ts
+++ b/src/managers/ProjectManager.spec.ts
@@ -1133,10 +1133,12 @@ describe('ComponentLibraryProject', () => {
         it('computes stagingDir before calling getFileMappings', async () => {
             delete params.stagingDir;
             let project = new ComponentLibraryProject(params);
+            // The default stagingDir is resolved at construction time by roku-deploy
+            let defaultStagingDir = project.stagingDir;
 
             sinon.stub(rokuDeploy, 'getFilePaths').returns(Promise.resolve([
-                { src: s`${rootDir}/manifest`, dest: s`manifest` },
-                { src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }
+                { src: s`${rootDir}/manifest`, dest: s`${defaultStagingDir}/manifest` },
+                { src: s`${rootDir}/source/main.brs`, dest: s`${defaultStagingDir}/source/main.brs` }
             ]));
             sinon.stub(Project.prototype, 'stage').returns(Promise.resolve());
             sinon.stub(util, 'convertManifestToObject').returns(Promise.resolve({}));

--- a/src/managers/ProjectManager.ts
+++ b/src/managers/ProjectManager.ts
@@ -343,29 +343,18 @@ export class Project {
     private logger = logger.createLogger(`[${ProjectManager.name}]`);
 
     public async stage() {
-        let rd = new RokuDeploy();
         if (!this.fileMappings) {
             this.fileMappings = await this.getFileMappings();
         }
 
-        //override the getFilePaths function so rokuDeploy doesn't run it again during prepublishToStaging
-        (rd as any).getFilePaths = () => {
-            let relativeFileMappings = [];
-            for (let fileMapping of this.fileMappings) {
-                relativeFileMappings.push({
-                    src: fileMapping.src,
-                    dest: fileUtils.replaceCaseInsensitive(fileMapping.dest, this.stagingDir, '')
-                });
-            }
-            return Promise.resolve(relativeFileMappings);
-        };
-
         //copy all project files to the staging folder
-        await rd.prepublishToStaging({
+        await rokuDeploy.prepublishToStaging({
             rootDir: this.rootDir,
             stagingDir: this.stagingDir,
-            files: this.files,
-            outDir: this.outDir
+            files: this.fileMappings,
+            outDir: this.outDir,
+            //we already fetched the file mappings ourselves, so roku-deploy doesn't need to glob the files again
+            resolveFilesArray: false
         });
 
         await this.fixSourceMapSources();
@@ -686,14 +675,7 @@ export class Project {
      * (`dest` paths are relative in later versions of roku-deploy)
      */
     protected async getFileMappings() {
-        let fileMappings = await rokuDeploy.getFilePaths(this.files, this.rootDir);
-        for (let mapping of fileMappings) {
-            //if the dest path is relative, make it absolute (relative to the staging dir)
-            mapping.dest = path.resolve(this.stagingDir, mapping.dest);
-            //standardize the paths once here, and don't need to do it again anywhere else in this project
-            mapping.src = fileUtils.standardizePath(mapping.src);
-            mapping.dest = fileUtils.standardizePath(mapping.dest);
-        }
+        let fileMappings = await rokuDeploy.getFilePaths(this.files, this.rootDir, true, this.stagingDir);
         return fileMappings;
     }
 


### PR DESCRIPTION
Avoid replacing `rokuDeploy.getFilePaths()` on roku-deploy. Instead. leverage its new  `resolveFilesArray: false` option to pass the raw `{src; dest}` array in to do the copying. 

Depends on https://github.com/rokucommunity/roku-deploy/pull/249