### PR TITLE
Increase app-ready timeout to 60 seconds for slow Roku launches

### DIFF
--- a/src/LaunchConfiguration.ts
+++ b/src/LaunchConfiguration.ts
@@ -329,13 +329,6 @@ export interface LaunchConfiguration extends DebugProtocol.LaunchRequestArgument
     brightScriptConsolePort?: number;
 
     /**
-     * The number of milliseconds to wait after publishing for the app to become ready.
-     * This is mainly useful for slower devices or apps with longer compile/startup times.
-     * @default 60000
-     */
-    appReadyTimeout?: number;
-
-    /**
      * The path used for the staging folder of roku-deploy
      * This should generally be set to "${cwd}/.roku-deploy-staging", but that's ultimately up to the debug client.
      * @deprecated use `stagingDir` instead

--- a/src/LaunchConfiguration.ts
+++ b/src/LaunchConfiguration.ts
@@ -329,6 +329,13 @@ export interface LaunchConfiguration extends DebugProtocol.LaunchRequestArgument
     brightScriptConsolePort?: number;
 
     /**
+     * The number of milliseconds to wait after publishing for the app to become ready.
+     * This is mainly useful for slower devices or apps with longer compile/startup times.
+     * @default 60000
+     */
+    appReadyTimeout?: number;
+
+    /**
      * The path used for the staging folder of roku-deploy
      * This should generally be set to "${cwd}/.roku-deploy-staging", but that's ultimately up to the debug client.
      * @deprecated use `stagingDir` instead

--- a/src/debugSession/BrightScriptDebugSession.spec.ts
+++ b/src/debugSession/BrightScriptDebugSession.spec.ts
@@ -2610,30 +2610,16 @@ describe('BrightScriptDebugSession', () => {
         });
     });
 
-    describe('normalizeLaunchConfig', () => {
-        it('defaults appReadyTimeout to 60000', () => {
-            const config = (session as any).normalizeLaunchConfig({
-                rootDir,
-                outDir,
-                stagingDir,
-                files: DefaultFiles
-            } as LaunchConfiguration);
-
-            expect(config.appReadyTimeout).to.equal(60_000);
-        });
-    });
-
     describe('publish', () => {
-        it('uses appReadyTimeout from the launch configuration', async () => {
+        it('waits 60 seconds before aborting when the app never becomes ready', async () => {
             const clock = sinon.useFakeTimers();
             const shutdownStub = sinon.stub(session, 'shutdown').resolves() as unknown as SinonStub;
-            launchConfiguration.appReadyTimeout = 50;
             rokuAdapter.connected = false;
             sinon.stub(session.rokuDeploy, 'publish').resolves();
 
             const publishPromise = (session as any).publish();
 
-            await clock.tickAsync(49);
+            await clock.tickAsync(59_999);
             expect(shutdownStub.called).to.be.false;
 
             await clock.tickAsync(1);

--- a/src/debugSession/BrightScriptDebugSession.spec.ts
+++ b/src/debugSession/BrightScriptDebugSession.spec.ts
@@ -2610,6 +2610,40 @@ describe('BrightScriptDebugSession', () => {
         });
     });
 
+    describe('normalizeLaunchConfig', () => {
+        it('defaults appReadyTimeout to 60000', () => {
+            const config = (session as any).normalizeLaunchConfig({
+                rootDir,
+                outDir,
+                stagingDir,
+                files: DefaultFiles
+            } as LaunchConfiguration);
+
+            expect(config.appReadyTimeout).to.equal(60_000);
+        });
+    });
+
+    describe('publish', () => {
+        it('uses appReadyTimeout from the launch configuration', async () => {
+            const clock = sinon.useFakeTimers();
+            const shutdownStub = sinon.stub(session, 'shutdown').resolves() as unknown as SinonStub;
+            launchConfiguration.appReadyTimeout = 50;
+            rokuAdapter.connected = false;
+            sinon.stub(session.rokuDeploy, 'publish').resolves();
+
+            const publishPromise = (session as any).publish();
+
+            await clock.tickAsync(49);
+            expect(shutdownStub.called).to.be.false;
+
+            await clock.tickAsync(1);
+            await publishPromise;
+
+            expect(shutdownStub.calledOnceWithExactly('Debug session cancelled: failed to connect to debug protocol control port.')).to.be.true;
+            clock.restore();
+        });
+    });
+
     describe('threadsRequest', () => {
         beforeEach(() => {
             session['rokuAdapterDeferred'].resolve(session['rokuAdapter']);

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -532,6 +532,7 @@ export class BrightScriptDebugSession extends LoggingDebugSession {
         config.sceneGraphDebugCommandsPort ??= 8080;
         config.controlPort ??= 8081;
         config.brightScriptConsolePort ??= 8085;
+        config.appReadyTimeout ??= 60_000;
         config.stagingDir ??= config.stagingFolderPath;
         config.emitChannelPublishedEvent ??= true;
         config.rewriteDevicePathsInLogs ??= true;
@@ -990,11 +991,11 @@ export class BrightScriptDebugSession extends LoggingDebugSession {
         uploadingEnd();
 
         //the channel has been deployed. Wait for the adapter to finish connecting.
-        //if it hasn't connected after 5 seconds, it probably will never connect.
+        //if it hasn't connected after appReadyTimeout, abort the launch.
         let didTimeOut = false;
         await Promise.race([
             isConnected,
-            util.sleep(10_000).then(() => {
+            util.sleep(this.launchConfiguration.appReadyTimeout).then(() => {
                 didTimeOut = true;
             })
         ]);

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -532,7 +532,6 @@ export class BrightScriptDebugSession extends LoggingDebugSession {
         config.sceneGraphDebugCommandsPort ??= 8080;
         config.controlPort ??= 8081;
         config.brightScriptConsolePort ??= 8085;
-        config.appReadyTimeout ??= 60_000;
         config.stagingDir ??= config.stagingFolderPath;
         config.emitChannelPublishedEvent ??= true;
         config.rewriteDevicePathsInLogs ??= true;
@@ -991,11 +990,11 @@ export class BrightScriptDebugSession extends LoggingDebugSession {
         uploadingEnd();
 
         //the channel has been deployed. Wait for the adapter to finish connecting.
-        //if it hasn't connected after appReadyTimeout, abort the launch.
+        //if it hasn't connected after 60 seconds, abort the launch.
         let didTimeOut = false;
         await Promise.race([
             isConnected,
-            util.sleep(this.launchConfiguration.appReadyTimeout).then(() => {
+            util.sleep(60_000).then(() => {
                 didTimeOut = true;
             })
         ]);


### PR DESCRIPTION
This increases the hardcoded post-publish app-ready timeout in `roku-debug` from 10 seconds to 60 seconds.

Some channels take longer to compile and start on slower devices, especially when `run_as_process` increases launch time. In those cases, the current 10-second timeout can abort debugging before the app is actually ready. This change keeps the existing launch flow intact and only gives the app more time to connect.

This will still need to be picked up in a future release of the VS Code BrightScript extension before users get the fix.

Tested:
- `npm test -- --grep "waits 60 seconds before aborting when the app never becomes ready"`
- `npm test -- --grep "BrightScriptDebugSession"`