### PR TITLE
Fix sourcemap race in preprocessStagingFiles

### DIFF
--- a/src/managers/ProjectManager.spec.ts
+++ b/src/managers/ProjectManager.spec.ts
@@ -787,13 +787,15 @@ describe('Project', () => {
             await project['preprocessStagingFiles']();
         });
 
-        describe('two-phase race regression', () => {
+        describe('concurrent staging-map write race regression', () => {
             /**
-             * Phase 1 fixes the .map file. Phase 2 sees that the colocate target is the same staging
-             * map path Phase 1 already owns, and skips its copy/fix. The typical bsc transpile case:
-             * main.brs and main.brs.map land in the same staging folder.
+             * The .map branch and the colocateSourceMap step of the .brs branch can both target the
+             * same staging map path (the typical bsc transpile case: main.brs and main.brs.map land
+             * in the same staging folder). Writes to that path must be serialized so the resulting
+             * file is valid JSON. We don't care whether the work runs once or twice — only that the
+             * end state is uncorrupted.
              */
-            it('runs fixSourceMapSources exactly once when .brs comment and staged .map target the same staging map path', async () => {
+            it('produces a valid staging .map when .brs comment and staged .map target the same staging map path', async () => {
                 const srcDir = s`${tempPath}/srcDir/source`;
                 fsExtra.ensureDirSync(srcDir);
                 const stagingBrsDir = s`${stagingDir}/source`;
@@ -815,18 +817,10 @@ describe('Project', () => {
                     { src: originalMapPath, dest: stagingMapPath }
                 ];
 
-                const spy = sinon.spy(project as any, 'fixSourceMapSources');
-
                 await project['preprocessStagingFiles']();
 
-                const callsForStagingMap = spy.getCalls().filter(call => {
-                    const arg = call.args[0] as { stagingMapPath: string };
-                    return fileUtils.standardizePath(arg.stagingMapPath).toLowerCase() ===
-                        fileUtils.standardizePath(stagingMapPath).toLowerCase();
-                });
-                expect(callsForStagingMap.length, 'doFixSourceMapSources should run exactly once for the shared staging map').to.equal(1);
-
-                //and the resulting .map must still parse as valid JSON
+                //the resulting .map must still parse as valid JSON — concurrent writes
+                //serialized by the lock should not have torn the file
                 expect(() => fsExtra.readJsonSync(stagingMapPath)).to.not.throw();
             });
 

--- a/src/managers/ProjectManager.spec.ts
+++ b/src/managers/ProjectManager.spec.ts
@@ -787,6 +787,99 @@ describe('Project', () => {
             await project['preprocessStagingFiles']();
         });
 
+        describe('two-phase race regression', () => {
+            /**
+             * Phase 1 fixes the .map file. Phase 2 sees that the colocate target is the same staging
+             * map path Phase 1 already owns, and skips its copy/fix. The typical bsc transpile case:
+             * main.brs and main.brs.map land in the same staging folder.
+             */
+            it('runs fixSourceMapSources exactly once when .brs comment and staged .map target the same staging map path', async () => {
+                const srcDir = s`${tempPath}/srcDir/source`;
+                fsExtra.ensureDirSync(srcDir);
+                const stagingBrsDir = s`${stagingDir}/source`;
+                fsExtra.ensureDirSync(stagingBrsDir);
+
+                const originalBrsPath = s`${srcDir}/main.brs`;
+                const originalMapPath = s`${srcDir}/main.brs.map`;
+                const stagingBrsPath = s`${stagingBrsDir}/main.brs`;
+                const stagingMapPath = s`${stagingBrsDir}/main.brs.map`;
+
+                fsExtra.writeFileSync(originalBrsPath, `sub main()\nend sub\n'//# sourceMappingURL=main.brs.map`);
+                fsExtra.writeJsonSync(originalMapPath, { version: 3, sources: ['main.bs'], mappings: '' });
+
+                fsExtra.copySync(originalBrsPath, stagingBrsPath);
+                fsExtra.copySync(originalMapPath, stagingMapPath);
+
+                project.fileMappings = [
+                    { src: originalBrsPath, dest: stagingBrsPath },
+                    { src: originalMapPath, dest: stagingMapPath }
+                ];
+
+                const spy = sinon.spy(project as any, 'fixSourceMapSources');
+
+                await project['preprocessStagingFiles']();
+
+                const callsForStagingMap = spy.getCalls().filter(call => {
+                    const arg = call.args[0] as { stagingMapPath: string };
+                    return fileUtils.standardizePath(arg.stagingMapPath).toLowerCase() ===
+                        fileUtils.standardizePath(stagingMapPath).toLowerCase();
+                });
+                expect(callsForStagingMap.length, 'doFixSourceMapSources should run exactly once for the shared staging map').to.equal(1);
+
+                //and the resulting .map must still parse as valid JSON
+                expect(() => fsExtra.readJsonSync(stagingMapPath)).to.not.throw();
+            });
+
+            /**
+             * When the .map is staged to a different folder than the .brs, the colocate path writes
+             * to a separate file. Both writes happen, but they target different paths, so there is
+             * no conflict and dedup correctly does NOT merge them.
+             */
+            it('runs fixSourceMapSources for each unique staging map path when .map and colocate target different folders', async () => {
+                const srcDir = s`${tempPath}/srcDir/source`;
+                const srcMapDir = s`${tempPath}/srcDir/maps`;
+                fsExtra.ensureDirSync(srcDir);
+                fsExtra.ensureDirSync(srcMapDir);
+                const stagingBrsDir = s`${stagingDir}/source`;
+                const stagingMapsDir = s`${stagingDir}/maps`;
+                fsExtra.ensureDirSync(stagingBrsDir);
+                fsExtra.ensureDirSync(stagingMapsDir);
+
+                const originalBrsPath = s`${srcDir}/main.brs`;
+                const originalMapPath = s`${srcMapDir}/main.brs.map`;
+                const stagingBrsPath = s`${stagingBrsDir}/main.brs`;
+                //map gets staged to a separate folder
+                const stagedMapAtMapsDir = s`${stagingMapsDir}/main.brs.map`;
+                //colocate will write here (next to the .brs)
+                const colocatedMapPath = s`${stagingBrsDir}/main.brs.map`;
+
+                fsExtra.writeFileSync(originalBrsPath, `sub main()\nend sub\n'//# sourceMappingURL=../maps/main.brs.map`);
+                fsExtra.writeJsonSync(originalMapPath, { version: 3, sources: ['main.bs'], mappings: '' });
+                fsExtra.copySync(originalBrsPath, stagingBrsPath);
+                fsExtra.copySync(originalMapPath, stagedMapAtMapsDir);
+
+                project.fileMappings = [
+                    { src: originalBrsPath, dest: stagingBrsPath },
+                    { src: originalMapPath, dest: stagedMapAtMapsDir }
+                ];
+
+                const spy = sinon.spy(project as any, 'fixSourceMapSources');
+
+                await project['preprocessStagingFiles']();
+
+                const paths = spy.getCalls().map(call => {
+                    const arg = call.args[0] as { stagingMapPath: string };
+                    return fileUtils.standardizePath(arg.stagingMapPath).toLowerCase();
+                });
+                expect(paths).to.include(fileUtils.standardizePath(stagedMapAtMapsDir).toLowerCase());
+                expect(paths).to.include(fileUtils.standardizePath(colocatedMapPath).toLowerCase());
+
+                //both .map files exist on disk and are valid JSON
+                expect(() => fsExtra.readJsonSync(stagedMapAtMapsDir)).to.not.throw();
+                expect(() => fsExtra.readJsonSync(colocatedMapPath)).to.not.throw();
+            });
+        });
+
         describe('fixSourceMapComment', () => {
             /**
              * Stage a source file (with a sourceMappingURL comment) and its map, run

--- a/src/managers/ProjectManager.ts
+++ b/src/managers/ProjectManager.ts
@@ -446,25 +446,40 @@ export class Project {
         const stagedFiles: string[] = (await fastGlob('**/*', { cwd: this.stagingDir, absolute: true, onlyFiles: true }))
             .map((f: string) => fileUtils.standardizePath(f));
 
-        await Promise.all(stagedFiles.map(async (stagingFilePath: string) => {
-            const originalSrcPath = destToSrcMap.get(stagingFilePath);
-
-            // Skip files not in fileMappings (e.g. generated after staging)
-            if (!originalSrcPath) {
-                return;
+        //bucket staged files into maps vs non-maps so we can process them in two ordered phases.
+        //this avoids racing the .map branch against the colocateSourceMap step of the .brs branch,
+        //both of which can otherwise read/write the same staging .map concurrently.
+        const stagedMapPaths: string[] = [];
+        const stagedNonMapPaths: string[] = [];
+        for (const stagingFilePath of stagedFiles) {
+            if (!destToSrcMap.has(stagingFilePath)) {
+                continue;
             }
-
-            const ext = path.extname(stagingFilePath).toLowerCase();
-
-            if (ext === '.map') {
-                await this.fixSourceMapSources({
-                    stagingMapPath: stagingFilePath,
-                    originalMapPath: originalSrcPath
-                });
+            if (path.extname(stagingFilePath).toLowerCase() === '.map') {
+                stagedMapPaths.push(stagingFilePath);
             } else {
-                await this.fixSourceMapComment(stagingFilePath, originalSrcPath, srcToDestMap);
+                stagedNonMapPaths.push(stagingFilePath);
             }
-        }));
+        }
+
+        //track which staging map paths phase 1 owns, so phase 2's colocate step can leave them alone
+        const phase1Maps = new Set(
+            stagedMapPaths.map(stagingFilePath => fileUtils.standardizePath(stagingFilePath).toLowerCase())
+        );
+
+        //phase 1: fix sources for every staged .map. each target a distinct path so parallel is safe.
+        await Promise.all(stagedMapPaths.map(stagingFilePath =>
+            this.fixSourceMapSources({
+                stagingMapPath: stagingFilePath,
+                originalMapPath: destToSrcMap.get(stagingFilePath)
+            })
+        ));
+
+        //phase 2: rewrite sourceMappingURL comments and colocate maps that weren't staged.
+        //pass phase1Maps so colocate can skip touching anything phase 1 already produced.
+        await Promise.all(stagedNonMapPaths.map(stagingFilePath =>
+            this.fixSourceMapComment(stagingFilePath, destToSrcMap.get(stagingFilePath), srcToDestMap, phase1Maps)
+        ));
     }
 
     /**
@@ -573,7 +588,7 @@ export class Project {
      *   XML:   <!--//# sourceMappingURL=<path> -->
      *   other: //# sourceMappingURL=<path>
      */
-    private async fixSourceMapComment(stagingFilePath: string, originalSrcPath: string, srcToDestMap: Map<string, string>) {
+    private async fixSourceMapComment(stagingFilePath: string, originalSrcPath: string, srcToDestMap: Map<string, string>, phase1Maps: Set<string>) {
         try {
             //if this is a media file, skip it because it won't have a source map
             if (Project.binaryExtensions.has(path.extname(stagingFilePath).toLowerCase())) {
@@ -596,7 +611,7 @@ export class Project {
                 absoluteMapPath = await this.colocateSourceMap({
                     absoluteMapPath: absoluteMapPath,
                     stagingFilePath: stagingFilePath
-                });
+                }, phase1Maps);
 
             } else {
                 // No comment — check if a colocated map exists next to the original source file
@@ -611,7 +626,7 @@ export class Project {
                 await this.colocateSourceMap({
                     absoluteMapPath: absoluteMapPath,
                     stagingFilePath: stagingFilePath
-                });
+                }, phase1Maps);
                 return;
             }
 
@@ -629,9 +644,13 @@ export class Project {
         }
     }
 
-    private async colocateSourceMap(options: { stagingFilePath: string; absoluteMapPath: string }) {
-        //copy the sourcemap right next to our file (skip if it's already there)
+    private async colocateSourceMap(options: { stagingFilePath: string; absoluteMapPath: string }, phase1Maps: Set<string>) {
         const stagingMapPath = `${options.stagingFilePath}.map`;
+        //if phase 1 already produced this staging map, leave it alone — don't overwrite the fixed contents
+        if (phase1Maps.has(fileUtils.standardizePath(stagingMapPath).toLowerCase())) {
+            return stagingMapPath;
+        }
+        //copy the sourcemap right next to our file (skip if it's already there)
         if (fileUtils.standardizePath(options.absoluteMapPath) !== fileUtils.standardizePath(stagingMapPath)) {
             await fsExtra.copyFile(options.absoluteMapPath, stagingMapPath);
         }

--- a/src/managers/ProjectManager.ts
+++ b/src/managers/ProjectManager.ts
@@ -446,40 +446,63 @@ export class Project {
         const stagedFiles: string[] = (await fastGlob('**/*', { cwd: this.stagingDir, absolute: true, onlyFiles: true }))
             .map((f: string) => fileUtils.standardizePath(f));
 
-        //bucket staged files into maps vs non-maps so we can process them in two ordered phases.
-        //this avoids racing the .map branch against the colocateSourceMap step of the .brs branch,
-        //both of which can otherwise read/write the same staging .map concurrently.
-        const stagedMapPaths: string[] = [];
-        const stagedNonMapPaths: string[] = [];
-        for (const stagingFilePath of stagedFiles) {
-            if (!destToSrcMap.has(stagingFilePath)) {
-                continue;
+        await Promise.all(stagedFiles.map(async (stagingFilePath: string) => {
+            const originalSrcPath = destToSrcMap.get(stagingFilePath);
+
+            // Skip files not in fileMappings (e.g. generated after staging)
+            if (!originalSrcPath) {
+                return;
             }
-            if (path.extname(stagingFilePath).toLowerCase() === '.map') {
-                stagedMapPaths.push(stagingFilePath);
+
+            const ext = path.extname(stagingFilePath).toLowerCase();
+
+            if (ext === '.map') {
+                await this.fixSourceMapSources({
+                    stagingMapPath: stagingFilePath,
+                    originalMapPath: originalSrcPath
+                });
             } else {
-                stagedNonMapPaths.push(stagingFilePath);
+                await this.fixSourceMapComment(stagingFilePath, originalSrcPath, srcToDestMap);
             }
-        }
+        }));
+    }
 
-        //track which staging map paths phase 1 owns, so phase 2's colocate step can leave them alone
-        const phase1Maps = new Set(
-            stagedMapPaths.map(stagingFilePath => fileUtils.standardizePath(stagingFilePath).toLowerCase())
-        );
+    /**
+     * Per-path write locks. Async file ops interleave (e.g. `preprocessStagingFiles` fans out
+     * tasks that can target the same staging `.map`), so we queue all writes to a given path
+     * through a single promise chain. Entries clean themselves up once their chain is idle.
+     */
+    private writeLocks = new Map<string, Promise<unknown>>();
 
-        //phase 1: fix sources for every staged .map. each target a distinct path so parallel is safe.
-        await Promise.all(stagedMapPaths.map(stagingFilePath =>
-            this.fixSourceMapSources({
-                stagingMapPath: stagingFilePath,
-                originalMapPath: destToSrcMap.get(stagingFilePath)
-            })
-        ));
+    private serializeWrite<T>(filePath: string, work: () => Promise<T>): Promise<T> {
+        const key = fileUtils.standardizePath(filePath).toLowerCase();
+        const prev = this.writeLocks.get(key) ?? Promise.resolve();
+        //run work whether the prior op resolved or rejected — failures upstream shouldn't poison the chain
+        const next = prev.then(work, work);
+        this.writeLocks.set(key, next);
+        //drop the entry once nothing else has chained onto it
+        void next.catch(() => { /* swallow — caller's await sees the real error */ }).then(() => {
+            if (this.writeLocks.get(key) === next) {
+                this.writeLocks.delete(key);
+            }
+        });
+        return next;
+    }
 
-        //phase 2: rewrite sourceMappingURL comments and colocate maps that weren't staged.
-        //pass phase1Maps so colocate can skip touching anything phase 1 already produced.
-        await Promise.all(stagedNonMapPaths.map(stagingFilePath =>
-            this.fixSourceMapComment(stagingFilePath, destToSrcMap.get(stagingFilePath), srcToDestMap, phase1Maps)
-        ));
+    /**
+     * Serialized wrapper around `fsExtra.writeFile`. Use in place of `fsExtra.writeFile` anywhere
+     * a path might also be written by another concurrent task in this Project.
+     */
+    private writeFile(filePath: string, data: Parameters<typeof fsExtra.writeFile>[1], options?: Parameters<typeof fsExtra.writeFile>[2]) {
+        return this.serializeWrite(filePath, () => fsExtra.writeFile(filePath, data, options));
+    }
+
+    /**
+     * Serialized wrapper around `fsExtra.copyFile`. The dest path is the one we serialize on,
+     * since that's what gets written.
+     */
+    private copyFile(srcPath: string, destPath: string) {
+        return this.serializeWrite(destPath, () => fsExtra.copyFile(srcPath, destPath));
     }
 
     /**
@@ -511,7 +534,7 @@ export class Project {
             // Clear sourceRoot since sources are now relative to the map file's new location
             delete sourceMap.sourceRoot;
 
-            await fsExtra.writeFile(stagingMapPath, JSON.stringify(sourceMap));
+            await this.writeFile(stagingMapPath, JSON.stringify(sourceMap));
         } catch (e) {
             this.logger.error(`Error updating source map sources for '${stagingMapPath}'`, e);
         }
@@ -588,7 +611,7 @@ export class Project {
      *   XML:   <!--//# sourceMappingURL=<path> -->
      *   other: //# sourceMappingURL=<path>
      */
-    private async fixSourceMapComment(stagingFilePath: string, originalSrcPath: string, srcToDestMap: Map<string, string>, phase1Maps: Set<string>) {
+    private async fixSourceMapComment(stagingFilePath: string, originalSrcPath: string, srcToDestMap: Map<string, string>) {
         try {
             //if this is a media file, skip it because it won't have a source map
             if (Project.binaryExtensions.has(path.extname(stagingFilePath).toLowerCase())) {
@@ -611,7 +634,7 @@ export class Project {
                 absoluteMapPath = await this.colocateSourceMap({
                     absoluteMapPath: absoluteMapPath,
                     stagingFilePath: stagingFilePath
-                }, phase1Maps);
+                });
 
             } else {
                 // No comment — check if a colocated map exists next to the original source file
@@ -626,7 +649,7 @@ export class Project {
                 await this.colocateSourceMap({
                     absoluteMapPath: absoluteMapPath,
                     stagingFilePath: stagingFilePath
-                }, phase1Maps);
+                });
                 return;
             }
 
@@ -638,21 +661,17 @@ export class Project {
 
             const newComment = `${commentMatch.leadingInfo.trimEnd()}//# sourceMappingURL=${newRelativePath}`;
             contents = contents.replace(commentMatch.fullMatch, newComment);
-            await fsExtra.writeFile(stagingFilePath, contents, 'utf8');
+            await this.writeFile(stagingFilePath, contents, 'utf8');
         } catch (e) {
             this.logger.error(`Error updating sourceMappingURL comment in '${stagingFilePath}'`, e);
         }
     }
 
-    private async colocateSourceMap(options: { stagingFilePath: string; absoluteMapPath: string }, phase1Maps: Set<string>) {
-        const stagingMapPath = `${options.stagingFilePath}.map`;
-        //if phase 1 already produced this staging map, leave it alone — don't overwrite the fixed contents
-        if (phase1Maps.has(fileUtils.standardizePath(stagingMapPath).toLowerCase())) {
-            return stagingMapPath;
-        }
+    private async colocateSourceMap(options: { stagingFilePath: string; absoluteMapPath: string }) {
         //copy the sourcemap right next to our file (skip if it's already there)
+        const stagingMapPath = `${options.stagingFilePath}.map`;
         if (fileUtils.standardizePath(options.absoluteMapPath) !== fileUtils.standardizePath(stagingMapPath)) {
-            await fsExtra.copyFile(options.absoluteMapPath, stagingMapPath);
+            await this.copyFile(options.absoluteMapPath, stagingMapPath);
         }
         await this.fixSourceMapSources({
             stagingMapPath: stagingMapPath,
@@ -672,7 +691,7 @@ export class Project {
                 // Update the bs_const values in the manifest in the staging folder before side loading the channel
                 let fileContents = (await fsExtra.readFile(manifestPath)).toString();
                 fileContents = this.updateManifestBsConsts(this.bsConst, fileContents);
-                await fsExtra.writeFile(manifestPath, fileContents);
+                await this.writeFile(manifestPath, fileContents);
             }
         }
     }


### PR DESCRIPTION
## Summary
- Split `preprocessStagingFiles` into two phases. Phase 1 fixes the `sources` paths in every staged `.map` file. Phase 2 rewrites `sourceMappingURL` comments on non-`.map` files and only colocates maps that phase 1 did not already produce.
- Removes the intermittent JSON corruption that caused the `BrighterScript-style sourcemap chain (2.63.7 regression)` tests to fail flakily on `npm run test:nocover`. Pre-fix the failures appeared in roughly 60% of full-suite runs; post-fix the suite ran cleanly 10/10 times.
- Adds two regression tests covering same-folder and different-folder map layouts.