### PR TITLE
Inject breakpoint STOPs after InitializedEvent

### DIFF
--- a/src/debugSession/BrightScriptDebugSession.spec.ts
+++ b/src/debugSession/BrightScriptDebugSession.spec.ts
@@ -62,6 +62,7 @@ describe('BrightScriptDebugSession', () => {
 
         try {
             session = new BrightScriptDebugSession();
+            session['publishTimeout'] = 1_000;
         } catch (e) {
             console.log(e);
         }
@@ -2633,6 +2634,8 @@ describe('BrightScriptDebugSession', () => {
 
     describe('publish', () => {
         it('waits 60 seconds before aborting when the app never becomes ready', async () => {
+            session['publishTimeout'] = 60_000;
+
             const clock = sinon.useFakeTimers();
             const shutdownStub = sinon.stub(session, 'shutdown').resolves() as unknown as SinonStub;
             rokuAdapter.connected = false;

--- a/src/debugSession/BrightScriptDebugSession.spec.ts
+++ b/src/debugSession/BrightScriptDebugSession.spec.ts
@@ -1124,8 +1124,9 @@ describe('BrightScriptDebugSession', () => {
                 verified: false
             });
 
-            //simulate "launch"
+            //simulate "launch" — stage in launchRequest, then write breakpoints + zip in configurationDoneRequest
             await session.prepareMainProject();
+            await session['packageMainProject']();
 
             //remove the breakpoint
             args.breakpoints = [];
@@ -1804,6 +1805,13 @@ describe('BrightScriptDebugSession', () => {
     });
 
     describe('prepareAndHostComponentLibraries', () => {
+        //runs the two-phase complib flow that used to live in a single method, mirroring how the
+        //real launch flow now splits prepare (stage) from package-and-host (write+zip+install+host).
+        async function runPrepareAndHost(componentLibraries: any[], port: number) {
+            await session['prepareComponentLibraries'](componentLibraries);
+            await session['packageAndHostComponentLibraries'](componentLibraries, port);
+        }
+
         function stubDefaults() {
             sinon.stub(rokuDeploy, 'deleteAllComponentLibraries').resolves();
             sinon.stub(session['componentLibraryServer'], 'startStaticFileHosting').resolves();
@@ -1823,7 +1831,7 @@ describe('BrightScriptDebugSession', () => {
                 return { message: 'success', results: [] };
             });
 
-            await session['prepareAndHostComponentLibraries']([
+            await runPrepareAndHost([
                 { rootDir: complib1Dir, outFile: 'lib1.zip', install: true },
                 { rootDir: complib1Dir, outFile: 'lib2.zip', install: true }
             ] as any, 8080);
@@ -1841,7 +1849,7 @@ describe('BrightScriptDebugSession', () => {
                 return { message: 'success', results: [] };
             });
 
-            await session['prepareAndHostComponentLibraries']([
+            await runPrepareAndHost([
                 { rootDir: complib1Dir, outFile: 'lib1.zip', install: true },
                 { rootDir: complib1Dir, outFile: 'lib2.zip', install: false },
                 { rootDir: complib1Dir, outFile: 'lib3.zip', install: undefined },
@@ -1857,7 +1865,7 @@ describe('BrightScriptDebugSession', () => {
             stubDefaults();
             const publishStub = sinon.stub(rokuDeploy, 'publish').resolves({ message: 'success', results: [] });
 
-            await session['prepareAndHostComponentLibraries']([
+            await runPrepareAndHost([
                 { rootDir: complib1Dir, outFile: 'testLib.zip', install: true }
             ] as any, 8080);
 
@@ -1874,7 +1882,7 @@ describe('BrightScriptDebugSession', () => {
             stubDefaults();
             sinon.stub(rokuDeploy, 'publish').rejects(new Error('Network error'));
 
-            await session['prepareAndHostComponentLibraries']([
+            await runPrepareAndHost([
                 { rootDir: complib1Dir, outFile: 'lib1.zip', install: true }
             ] as any, 8080);
 
@@ -1904,7 +1912,7 @@ describe('BrightScriptDebugSession', () => {
                 return Promise.resolve({ message: 'success', results: [] });
             });
 
-            await session['prepareAndHostComponentLibraries']([
+            await runPrepareAndHost([
                 { rootDir: complib1Dir, outFile: 'lib1.zip', install: true },
                 { rootDir: complib1Dir, outFile: 'lib2.zip', install: true }
             ] as any, 8080);
@@ -1926,7 +1934,7 @@ describe('BrightScriptDebugSession', () => {
 
             let errorThrown = false;
             try {
-                await session['prepareAndHostComponentLibraries']([
+                await runPrepareAndHost([
                     { rootDir: complib1Dir, outFile: 'lib1.zip', install: true }
                 ] as any, 8080);
             } catch (e) {
@@ -1943,7 +1951,7 @@ describe('BrightScriptDebugSession', () => {
             sinon.stub(ComponentLibraryProject.prototype, 'postfixFiles').resolves();
             sinon.stub(ComponentLibraryProject.prototype, 'zipPackage').resolves();
 
-            await session['prepareAndHostComponentLibraries']([
+            await runPrepareAndHost([
                 { rootDir: complib1Dir, outFile: 'lib1.zip', install: false },
                 { rootDir: complib1Dir, outFile: 'lib2.zip', install: undefined }
             ] as any, 8080);
@@ -1954,7 +1962,7 @@ describe('BrightScriptDebugSession', () => {
         it('does not start server when no component libraries present', async () => {
             const serverStub = sinon.stub(session['componentLibraryServer'], 'startStaticFileHosting').resolves();
 
-            await session['prepareAndHostComponentLibraries']([], 8080);
+            await runPrepareAndHost([], 8080);
 
             expect(serverStub.called).to.be.false;
         });
@@ -1963,7 +1971,7 @@ describe('BrightScriptDebugSession', () => {
             stubDefaults();
             const sendEventStub = sinon.stub(session as any, 'sendCustomRequest').resolves();
 
-            await session['prepareAndHostComponentLibraries']([
+            await runPrepareAndHost([
                 { rootDir: complib1Dir, outFile: 'lib1.zip', install: true, packageTask: 'build:lib1' },
                 { rootDir: complib1Dir, outFile: 'lib2.zip', install: true, packageTask: 'build:lib2' },
                 { rootDir: complib1Dir, outFile: 'lib3.zip', install: true }
@@ -1995,7 +2003,7 @@ describe('BrightScriptDebugSession', () => {
                 }
             };
 
-            await session['prepareAndHostComponentLibraries']([
+            await runPrepareAndHost([
                 {
                     rootDir: complib1Dir,
                     outFile: 'lib1.zip',
@@ -2526,7 +2534,9 @@ describe('BrightScriptDebugSession', () => {
             sinon.stub(util, 'dnsLookup').callsFake((host) => Promise.resolve(host));
             sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({ developerEnabled: true } as any);
             sinon.stub(session, 'prepareMainProject').resolves();
-            sinon.stub(session as any, 'prepareAndHostComponentLibraries').resolves();
+            sinon.stub(session as any, 'prepareComponentLibraries').resolves();
+            sinon.stub(session as any, 'packageMainProject').resolves();
+            sinon.stub(session as any, 'packageAndHostComponentLibraries').resolves();
             sinon.stub(session, 'initRendezvousTracking').resolves();
             // Prevent createRokuAdapter from replacing the mock rokuAdapter with a real adapter
             sinon.stub(session as any, 'createRokuAdapter').callsFake(() => { });

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -741,6 +741,10 @@ export class BrightScriptDebugSession extends LoggingDebugSession {
             //profiling supports connecting to the socket BEFORE a channel is published, so go ahead and connect now
             await this.tryProfilingConnectOnStart();
 
+            //all setBreakpoints requests have arrived by this point (configurationDone is the DAP signal
+            //that the client has finished sending configuration). Inject the STOPs and seal the zip now.
+            await this.packageMainProject();
+
             this.sendLaunchProgress('update', 'Uploading to Roku');
             await this.publish();
 
@@ -1250,13 +1254,19 @@ export class BrightScriptDebugSession extends LoggingDebugSession {
 
         //add the entry breakpoint if stopOnEntry is true
         await this.handleEntryBreakpoint();
+    }
 
+    /**
+     * Inject breakpoint STOP statements into the staged main project and create the zip package.
+     * Runs after the DAP `InitializedEvent` so client-side `setBreakpoints` requests have landed
+     * before any STOPs are written to the staged .brs files (telnet path) and before the zip is sealed.
+     */
+    private async packageMainProject() {
         //add breakpoint lines to source files and then publish
         util.log('Adding stop statements for active breakpoints');
 
         //write the `stop` statements to every file that has breakpoints (do for telnet, skip for debug protocol)
         if (!this.enableDebugProtocol) {
-
             await this.breakpointManager.writeBreakpointsForProject(this.projectManager.mainProject);
         }
 

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -743,8 +743,10 @@ export class BrightScriptDebugSession extends LoggingDebugSession {
 
             //all setBreakpoints requests have arrived by this point (configurationDone is the DAP signal
             //that the client has finished sending configuration). Inject the STOPs and seal zips now.
-            await this.packageMainProject();
-            await this.packageAndHostComponentLibraries(this.launchConfiguration.componentLibraries, this.launchConfiguration.componentLibrariesPort);
+            await Promise.all([
+                this.packageMainProject(),
+                this.packageAndHostComponentLibraries(this.launchConfiguration.componentLibraries, this.launchConfiguration.componentLibrariesPort)
+            ]);
 
             this.sendLaunchProgress('update', 'Uploading to Roku');
             await this.publish();
@@ -963,6 +965,8 @@ export class BrightScriptDebugSession extends LoggingDebugSession {
         this.sendEvent(new DiagnosticsEvent(diagnostics));
     }
 
+    private publishTimeout = 60_000;
+
     private async publish() {
         const uploadingEnd = this.logger.timeStart('log', 'Uploading zip');
         let packageIsPublished = false;
@@ -1026,7 +1030,7 @@ export class BrightScriptDebugSession extends LoggingDebugSession {
         let didTimeOut = false;
         await Promise.race([
             isConnected,
-            util.sleep(60_000).then(() => {
+            util.sleep(this.publishTimeout).then(() => {
                 didTimeOut = true;
             })
         ]);

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -583,7 +583,7 @@ export class BrightScriptDebugSession extends LoggingDebugSession {
             //build the main project and all component libraries at the same time
             await Promise.all([
                 this.prepareMainProject(),
-                this.prepareAndHostComponentLibraries(this.launchConfiguration.componentLibraries, this.launchConfiguration.componentLibrariesPort)
+                this.prepareComponentLibraries(this.launchConfiguration.componentLibraries)
             ]);
 
             //all of the projects have been successfully staged.
@@ -742,8 +742,9 @@ export class BrightScriptDebugSession extends LoggingDebugSession {
             await this.tryProfilingConnectOnStart();
 
             //all setBreakpoints requests have arrived by this point (configurationDone is the DAP signal
-            //that the client has finished sending configuration). Inject the STOPs and seal the zip now.
+            //that the client has finished sending configuration). Inject the STOPs and seal zips now.
             await this.packageMainProject();
+            await this.packageAndHostComponentLibraries(this.launchConfiguration.componentLibraries, this.launchConfiguration.componentLibrariesPort);
 
             this.sendLaunchProgress('update', 'Uploading to Roku');
             await this.publish();
@@ -1336,110 +1337,120 @@ export class BrightScriptDebugSession extends LoggingDebugSession {
     /**
      * Stores the path to the staging folder for each component library
      */
-    protected async prepareAndHostComponentLibraries(componentLibraries: ComponentLibraryConfiguration[], port: number) {
-        if (componentLibraries && componentLibraries.length > 0) {
-            let componentLibrariesOutDir = s`${this.launchConfiguration.outDir}/component-libraries`;
-            //make sure this folder exists (and is empty)
-            await fsExtra.ensureDir(componentLibrariesOutDir);
-            await fsExtra.emptyDir(componentLibrariesOutDir);
+    protected async prepareComponentLibraries(componentLibraries: ComponentLibraryConfiguration[]) {
+        if (!componentLibraries || componentLibraries.length === 0) {
+            return;
+        }
+        let componentLibrariesOutDir = s`${this.launchConfiguration.outDir}/component-libraries`;
+        //make sure this folder exists (and is empty)
+        await fsExtra.ensureDir(componentLibrariesOutDir);
+        await fsExtra.emptyDir(componentLibrariesOutDir);
 
-            //create a ComponentLibraryProject for each component library
-            for (let libraryIndex = 0; libraryIndex < componentLibraries.length; libraryIndex++) {
-                let componentLibrary = componentLibraries[libraryIndex];
+        //create a ComponentLibraryProject for each component library
+        for (let libraryIndex = 0; libraryIndex < componentLibraries.length; libraryIndex++) {
+            let componentLibrary = componentLibraries[libraryIndex];
 
-                this.projectManager.componentLibraryProjects.push(
-                    new ComponentLibraryProject({
-                        rootDir: componentLibrary.rootDir,
-                        files: componentLibrary.files,
-                        outDir: componentLibrariesOutDir,
-                        outFile: componentLibrary.outFile,
-                        sourceDirs: componentLibrary.sourceDirs,
-                        bsConst: componentLibrary.bsConst,
-                        install: componentLibrary.install,
-                        injectRaleTrackerTask: componentLibrary.injectRaleTrackerTask,
-                        raleTrackerTaskFileLocation: componentLibrary.raleTrackerTaskFileLocation,
-                        libraryIndex: libraryIndex,
-                        enhanceREPLCompletions: this.launchConfiguration.enhanceREPLCompletions
-                    })
-                );
+            this.projectManager.componentLibraryProjects.push(
+                new ComponentLibraryProject({
+                    rootDir: componentLibrary.rootDir,
+                    files: componentLibrary.files,
+                    outDir: componentLibrariesOutDir,
+                    outFile: componentLibrary.outFile,
+                    sourceDirs: componentLibrary.sourceDirs,
+                    bsConst: componentLibrary.bsConst,
+                    install: componentLibrary.install,
+                    injectRaleTrackerTask: componentLibrary.injectRaleTrackerTask,
+                    raleTrackerTaskFileLocation: componentLibrary.raleTrackerTaskFileLocation,
+                    libraryIndex: libraryIndex,
+                    enhanceREPLCompletions: this.launchConfiguration.enhanceREPLCompletions
+                })
+            );
+        }
+
+        //stage all of the libraries in parallel
+        await Promise.all(
+            this.projectManager.componentLibraryProjects.map(compLibProject => compLibProject.stage())
+        );
+    }
+
+    /**
+     * Inject breakpoint STOPs into the staged complibs, seal their zips, install installable ones,
+     * and start static file hosting. Runs in `configurationDoneRequest` (after `InitializedEvent`)
+     * so client-side `setBreakpoints` requests have landed before the staged .brs files are written
+     * and the zips are sealed.
+     */
+    protected async packageAndHostComponentLibraries(componentLibraries: ComponentLibraryConfiguration[], port: number) {
+        if (!componentLibraries || componentLibraries.length === 0) {
+            return;
+        }
+        const componentLibrariesOutDir = s`${this.launchConfiguration.outDir}/component-libraries`;
+
+        // Add breakpoint lines to the staging files and before publishing
+        util.log('Adding stop statements for active breakpoints in Component Libraries');
+
+        //write STOPs (telnet only), postfix, and zip each complib in parallel — each targets distinct files
+        const packagePromises = this.projectManager.componentLibraryProjects.map(async (compLibProject) => {
+            if (!this.enableDebugProtocol) {
+                await this.breakpointManager.writeBreakpointsForProject(compLibProject);
             }
+            await compLibProject.postfixFiles();
+            await compLibProject.zipPackage({ retainStagingFolder: true });
+        });
 
-            //prepare all of the libraries in parallel
-            let compLibPromises = this.projectManager.componentLibraryProjects.map(async (compLibProject) => {
+        const needToDeleteComplibs = this.projectManager.componentLibraryProjects.some(x => x.install);
+        if (needToDeleteComplibs) {
+            await rokuDeploy.deleteAllComponentLibraries({
+                host: this.launchConfiguration.host,
+                password: this.launchConfiguration.password,
+                username: this.launchConfiguration.username || 'rokudev'
+            });
+        }
 
-                await compLibProject.stage();
+        for (let i = 0; i < this.projectManager.componentLibraryProjects.length; i++) {
+            const compLibProject = this.projectManager.componentLibraryProjects[i];
 
-                // Add breakpoint lines to the staging files and before publishing
-                util.log('Adding stop statements for active breakpoints in Component Libraries');
+            if (compLibProject.install === true) {
+                //wait for this complib to finish being packaged
+                await packagePromises[i];
 
-                //write the `stop` statements to every file that has breakpoints (do for telnet, skip for debug protocol)
-                if (!this.enableDebugProtocol) {
-                    await this.breakpointManager.writeBreakpointsForProject(compLibProject);
+                if (componentLibraries[i].packageTask) {
+                    await this.sendCustomRequest('executeTask', { task: componentLibraries[i].packageTask });
                 }
 
-                await compLibProject.postfixFiles();
-
-                await compLibProject.zipPackage({ retainStagingFolder: true });
-            });
-
-            let needToDeleteComplibs = this.projectManager.componentLibraryProjects.some(x => x.install);
-
-            if (needToDeleteComplibs) {
-                await rokuDeploy.deleteAllComponentLibraries({
+                const options: RokuDeployOptions = {
                     host: this.launchConfiguration.host,
                     password: this.launchConfiguration.password,
-                    username: this.launchConfiguration.username || 'rokudev'
-                });
-            }
+                    username: this.launchConfiguration.username || 'rokudev',
+                    logLevel: LogLevelPriority[this.logger.logLevel],
+                    failOnCompileError: true,
+                    outDir: compLibProject.outDir,
+                    outFile: compLibProject.outFile,
+                    appType: 'dcl',
+                    packageUploadOverrides: componentLibraries[i].packageUploadOverrides || {}
+                };
 
-            for (let i = 0; i < this.projectManager.componentLibraryProjects.length; i++) {
-                const compLibProject = this.projectManager.componentLibraryProjects[i];
+                if (componentLibraries[i].packagePath) {
+                    options.outDir = path.dirname(componentLibraries[i].packagePath);
+                    options.outFile = path.basename(componentLibraries[i].packagePath);
+                }
 
-                if (compLibProject.install === true) {
-                    //wait for this complib to finish being staged and zipped
-                    await compLibPromises[i];
-
-                    if (componentLibraries[i].packageTask) {
-                        await this.sendCustomRequest('executeTask', { task: componentLibraries[i].packageTask });
-                    }
-
-                    const options: RokuDeployOptions = {
-                        host: this.launchConfiguration.host,
-                        password: this.launchConfiguration.password,
-                        username: this.launchConfiguration.username || 'rokudev',
-                        logLevel: LogLevelPriority[this.logger.logLevel],
-                        failOnCompileError: true,
-                        outDir: compLibProject.outDir,
-                        outFile: compLibProject.outFile,
-                        appType: 'dcl',
-                        packageUploadOverrides: componentLibraries[i].packageUploadOverrides || {}
-                    };
-
-                    if (componentLibraries[i].packagePath) {
-                        options.outDir = path.dirname(componentLibraries[i].packagePath);
-                        options.outFile = path.basename(componentLibraries[i].packagePath);
-                    }
-
-                    try {
-                        await rokuDeploy.publish(options);
-                    } catch (error) {
-                        this.logger.error(`Error installing component library ${i}`, error);
-                    }
+                try {
+                    await rokuDeploy.publish(options);
+                } catch (error) {
+                    this.logger.error(`Error installing component library ${i}`, error);
                 }
             }
-
-            let hostingPromise: Promise<any>;
-            // prepare static file hosting
-            hostingPromise = this.componentLibraryServer.startStaticFileHosting(componentLibrariesOutDir, port, (message: string) => {
-                util.log(message);
-            });
-
-            //wait for all component libaries to finish building, and the file hosting to start up (if enabled)
-            await Promise.all([
-                ...compLibPromises,
-                hostingPromise
-            ]);
         }
+
+        const hostingPromise = this.componentLibraryServer.startStaticFileHosting(componentLibrariesOutDir, port, (message: string) => {
+            util.log(message);
+        });
+
+        //wait for all complib packaging to finish and the file hosting to start
+        await Promise.all([
+            ...packagePromises,
+            hostingPromise
+        ]);
     }
 
     protected sourceRequest(response: DebugProtocol.SourceResponse, args: DebugProtocol.SourceArguments) {

--- a/src/debugSession/ecpRegistryUtils.spec.ts
+++ b/src/debugSession/ecpRegistryUtils.spec.ts
@@ -14,6 +14,7 @@ describe('ecpRegistryUtils', () => {
 
     beforeEach(() => {
         session = new BrightScriptDebugSession();
+        session['publishTimeout'] = 1_000;
     });
 
     afterEach(() => {
@@ -70,21 +71,23 @@ describe('ecpRegistryUtils', () => {
                         childVariables: []
                     }]
                 });
-                expect(session['variables']).to.eql({ 1: {
-                    name: 'sections',
-                    namedVariables: 1,
-                    type: VariableType.AssociativeArray,
-                    value: VariableType.AssociativeArray,
-                    variablesReference: 1,
-                    childVariables: [{
-                        name: '$count',
-                        presentationHint: { kind: 'virtual' },
-                        type: VariableType.Integer,
-                        value: '0',
-                        variablesReference: 0,
-                        childVariables: []
-                    }]
-                } });
+                expect(session['variables']).to.eql({
+                    1: {
+                        name: 'sections',
+                        namedVariables: 1,
+                        type: VariableType.AssociativeArray,
+                        value: VariableType.AssociativeArray,
+                        variablesReference: 1,
+                        childVariables: [{
+                            name: '$count',
+                            presentationHint: { kind: 'virtual' },
+                            type: VariableType.Integer,
+                            value: '0',
+                            variablesReference: 0,
+                            childVariables: []
+                        }]
+                    }
+                });
             });
 
             it('handles ok response with empty sections', async () => {


### PR DESCRIPTION
## Summary
After [#328](https://github.com/rokucommunity/roku-debug/pull/328) deferred `InitializedEvent` until after `prepareMainProject` + adapter connect, the telnet path stopped injecting client-side breakpoints. VS Code only starts sending `setBreakpoints` after it receives `InitializedEvent`, but by that point the staging files had already been written with STOPs (or not, since no breakpoints were known) and the zip was sealed.

This PR splits the staging from the packaging step for both the main project and component libraries, and runs the packaging step at the start of `configurationDoneRequest`. By DAP spec, all `setBreakpoints` requests have arrived by the time `configurationDone` fires, so STOPs land in the staged `.brs` files before the zip is sealed.

- Main project: new `packageMainProject` helper (breakpoint write + zip), called from `configurationDoneRequest` before `publish`.
- Component libraries: `prepareAndHostComponentLibraries` split into `prepareComponentLibraries` (init + stage, parallel with main) and `packageAndHostComponentLibraries` (write + postfix + zip + install + host, runs in `configurationDoneRequest`).
- also, unrelated, prevents the tests from taking a full 60 seconds before finishing. 