### PR TITLE
Fix deferred capability handling for exception breakpoints

### DIFF
--- a/src/adapters/DebugProtocolAdapter.spec.ts
+++ b/src/adapters/DebugProtocolAdapter.spec.ts
@@ -2,6 +2,7 @@
 
 import { expect } from 'chai';
 import type { DebugProtocolClient } from '../debugProtocol/client/DebugProtocolClient';
+import { ProtocolCapabilities } from '../debugProtocol/client/ProtocolCapabilities';
 import { DebugProtocolAdapter, KeyType } from './DebugProtocolAdapter';
 import { createSandbox } from 'sinon';
 import { VariableType, VariablesResponse } from '../debugProtocol/events/responses/VariablesResponse';
@@ -194,7 +195,7 @@ describe('DebugProtocolAdapter', function() {
         it('retries at next sync() to delete breakpoints if first request failed', async () => {
             await initialize();
             //disable auto breakpoint verification
-            client.protocolVersion = '3.2.0';
+            client.capabilities = new ProtocolCapabilities('3.2.0');
 
             //add a single breakpoint first and do a diff to lock in the diff
             const bp2 = breakpointManager.setBreakpoint(srcPath, { line: 2 });
@@ -327,7 +328,7 @@ describe('DebugProtocolAdapter', function() {
             await initialize();
 
             //force the client to expect the device to verify breakpoints (instead of auto-verifying them as soon as seen)
-            client.protocolVersion = '3.2.0';
+            client.capabilities = new ProtocolCapabilities('3.2.0');
 
             breakpointManager.setBreakpoint(srcPath, {
                 line: bpLine

--- a/src/adapters/DebugProtocolAdapter.ts
+++ b/src/adapters/DebugProtocolAdapter.ts
@@ -43,7 +43,7 @@ export class DebugProtocolAdapter {
         this.connected = false;
         //capabilities derived from device-info; used to answer questions before the debug
         //protocol client has connected and completed its handshake
-        this.fallbackCapabilities = new ProtocolCapabilities(this.deviceInfo?.brightscriptDebuggerVersion);
+        this.fallbackCapabilities = new ProtocolCapabilities(this.deviceInfo?.brightscriptDebuggerVersion, this.deviceInfo?.softwareVersion);
 
         // watch for chanperf events
         this.chanperfTracker.on('chanperf', (output) => {

--- a/src/adapters/DebugProtocolAdapter.ts
+++ b/src/adapters/DebugProtocolAdapter.ts
@@ -9,12 +9,12 @@ import { ChanperfTracker } from '../ChanperfTracker';
 import { ErrorCode, PROTOCOL_ERROR_CODES, UpdateType } from '../debugProtocol/Constants';
 import { defer, util } from '../util';
 import { logger } from '../logging';
-import * as semver from 'semver';
 import type { AdapterOptions, HighLevelType, RokuAdapterEvaluateResponse } from '../interfaces';
 import type { BreakpointManager } from '../managers/BreakpointManager';
 import type { ProjectManager } from '../managers/ProjectManager';
 import type { BreakpointsVerifiedEvent, ConstructorOptions, ProtocolVersionDetails } from '../debugProtocol/client/DebugProtocolClient';
 import { DebugProtocolClient } from '../debugProtocol/client/DebugProtocolClient';
+import { ProtocolCapabilities } from '../debugProtocol/client/ProtocolCapabilities';
 import type { Variable } from '../debugProtocol/events/responses/VariablesResponse';
 import { VariableType } from '../debugProtocol/events/responses/VariablesResponse';
 import type { TelnetAdapter } from './TelnetAdapter';
@@ -41,6 +41,9 @@ export class DebugProtocolAdapter {
         this.chanperfTracker = new ChanperfTracker();
         this.compileErrorProcessor = new CompileErrorProcessor();
         this.connected = false;
+        //capabilities derived from device-info; used to answer questions before the debug
+        //protocol client has connected and completed its handshake
+        this.fallbackCapabilities = new ProtocolCapabilities(this.deviceInfo?.brightscriptDebuggerVersion);
 
         // watch for chanperf events
         this.chanperfTracker.on('chanperf', (output) => {
@@ -51,16 +54,25 @@ export class DebugProtocolAdapter {
     private logger = logger.createLogger(`[padapter]`);
 
     /**
+     * Capabilities seeded from the device-info `brightscript-debugger-version`. Used as the
+     * source of truth for protocol capability questions before the debug protocol client has
+     * connected and completed its handshake.
+     */
+    private fallbackCapabilities: ProtocolCapabilities;
+
+    /**
+     * The current authoritative capabilities for protocol-version-driven questions: the live
+     * client's capabilities once it exists, otherwise the device-info-seeded fallback.
+     */
+    private get capabilities(): ProtocolCapabilities {
+        return this.client?.capabilities ?? this.fallbackCapabilities;
+    }
+
+    /**
      * Indicates whether the adapter has successfully established a connection with the device
      */
     public connected: boolean;
 
-    /**
-     *  Due to casing issues with the variables request on some versions of the debug protocol, we first need to try the request in the supplied case.
-     * If that fails we retry in lower case. This flag is used to drive that logic switching
-     */
-    private enableVariablesLowerCaseRetry = true;
-    private supportsExecuteCommand: boolean;
     private compileClient: Socket;
     private compileErrorProcessor: CompileErrorProcessor;
     private emitter: EventEmitter;
@@ -150,10 +162,26 @@ export class DebugProtocolAdapter {
     }
 
     /**
-     * Does the current client support exception breakpoints? This value will be undefined if the client has not yet connected
+     * Does the current client support exception breakpoints? Resolved via the live client's
+     * capabilities when connected, otherwise the device-info-seeded fallback.
      */
-    public get supportsExceptionBreakpoints(): boolean | undefined {
-        return this.client?.supportsExceptionBreakpoints;
+    public get supportsExceptionBreakpoints(): boolean {
+        return this.capabilities.supportsExceptionBreakpoints;
+    }
+
+    /**
+     * Does the current client support conditional breakpoints? Same fallback semantics as
+     * `supportsExceptionBreakpoints`.
+     */
+    public get supportsConditionalBreakpoints(): boolean {
+        return this.capabilities.supportsConditionalBreakpoints;
+    }
+
+    /**
+     * Does the current client support hit-count breakpoints?
+     */
+    public get supportsHitConditionalBreakpoints(): boolean {
+        return this.capabilities.supportsHitConditionalBreakpoints;
     }
 
     /**
@@ -295,13 +323,6 @@ export class DebugProtocolAdapter {
                     this.emit('console-output', data.message);
                 }
 
-                // TODO: Update once we know the exact version of the debug protocol this issue was fixed in.
-                // Due to casing issues with variables on protocol version <FUTURE_VERSION> and under we first need to try the request in the supplied case.
-                // If that fails we retry in lower case.
-                this.enableVariablesLowerCaseRetry = semver.satisfies(this.activeProtocolVersion, '<3.1.0');
-                // While execute was added as a command in 2.1.0. It has shortcoming that prevented us for leveraging the command.
-                // This was mostly addressed in the 3.0.0 release to the point where we were comfortable adding support for the command.
-                this.supportsExecuteCommand = semver.satisfies(this.activeProtocolVersion, '>=3.0.0');
             });
 
             // Listen for the close event
@@ -375,6 +396,16 @@ export class DebugProtocolAdapter {
             this.handleStartupIfReady();
             this.emit('connected', this.connected);
             this.emit('app-ready');
+            //flush any breakpoints that were queued while we were waiting for the client to connect.
+            //setBreakpointsRequest is called by VS Code before the channel is uploaded, so the initial
+            //sync bails out (no client yet); this re-sync pushes those queued breakpoints to the device.
+            void this.syncBreakpoints();
+            //also replay any queued exception breakpoint filters
+            if (this.pendingExceptionBreakpointFilters) {
+                const queuedFilters = this.pendingExceptionBreakpointFilters;
+                this.pendingExceptionBreakpointFilters = undefined;
+                void this.client.setExceptionBreakpoints(queuedFilters);
+            }
 
             //the adapter is connected and running smoothly. resolve the promise
             deferred.resolve();
@@ -395,7 +426,7 @@ export class DebugProtocolAdapter {
      * Determines if the current version of the debug protocol supports emitting compile error updates.
      */
     public get supportsCompileErrorReporting() {
-        return semver.satisfies(this.deviceInfo.brightscriptDebuggerVersion, '>=3.1.0');
+        return this.capabilities.supportsCompileErrorReporting;
     }
 
     /**
@@ -541,7 +572,7 @@ export class DebugProtocolAdapter {
      * @returns the output of the command (if possible)
      */
     public async evaluate(command: string, frameId: number = this.client.primaryThread): Promise<RokuAdapterEvaluateResponse> {
-        if (this.supportsExecuteCommand) {
+        if (this.capabilities.supportsExecuteCommand) {
             if (!this.isAtDebuggerPrompt) {
                 throw new Error('Cannot run evaluate: debugger is not paused');
             }
@@ -645,13 +676,13 @@ export class DebugProtocolAdapter {
         let variablePath = expression === '' ? [] : util.getVariablePath(expression);
 
         // Temporary workaround related to casing issues over the protocol
-        if (this.enableVariablesLowerCaseRetry && variablePath?.length > 0) {
+        if (this.capabilities.enableVariablesLowerCaseRetry && variablePath?.length > 0) {
             variablePath[0] = variablePath[0].toLowerCase();
         }
 
         let response = await this.client.getVariables(variablePath, frame.frameIndex, frame.threadIndex);
 
-        if (this.enableVariablesLowerCaseRetry && response.data.errorCode !== ErrorCode.OK) {
+        if (this.capabilities.enableVariablesLowerCaseRetry && response.data.errorCode !== ErrorCode.OK) {
             // Temporary workaround related to casing issues over the protocol
             logger.log(`Retrying expression as lower case:`, expression);
             variablePath = expression === '' ? [] : util.getVariablePath(expression?.toLowerCase());
@@ -981,13 +1012,23 @@ export class DebugProtocolAdapter {
         this.chanperfTracker.clearHistory();
     }
 
+    /**
+     * The most recently requested exception breakpoint filters. Stored so we can replay them
+     * to the debug protocol client once it connects (the session can send these before the
+     * device has launched and the client has finished its handshake).
+     */
+    private pendingExceptionBreakpointFilters: ExceptionBreakpoint[] | undefined;
+
     public async setExceptionBreakpoints(filters: ExceptionBreakpoint[]) {
-        if (this.client?.supportsExceptionBreakpoints) {
-            //tell the client to set the exception breakpoints
-            const response = await this.client?.setExceptionBreakpoints(filters);
-            return response;
+        if (!this.capabilities.supportsExceptionBreakpoints) {
+            return undefined;
         }
-        return undefined;
+        //if the client isn't connected yet, queue the filters for replay on connect
+        if (!this.connected) {
+            this.pendingExceptionBreakpointFilters = filters;
+            return undefined;
+        }
+        return this.client.setExceptionBreakpoints(filters);
     }
 
     private syncBreakpointsPromise = Promise.resolve();
@@ -1005,10 +1046,16 @@ export class DebugProtocolAdapter {
     }
 
     public async _syncBreakpoints() {
+        //we need to actually be connected to the device before we can push breakpoints. We'll get
+        //called again once the debug protocol client has connected.
+        if (!this.connected) {
+            this.logger.info('Cannot sync breakpoints because the debug protocol client has not connected yet');
+            return;
+        }
         //we can't send breakpoints unless we're stopped (or in a protocol version that supports sending them while running).
         //So...if we're not stopped, quit now. (we'll get called again when the stop event happens)
-        if (!this.client?.supportsBreakpointRegistrationWhileRunning && !this.isAtDebuggerPrompt) {
-            this.logger.info('Cannot sync breakpoints because the debugger', this.client?.supportsBreakpointRegistrationWhileRunning ? 'does not support sending breakpoints while running' : 'is not paused');
+        if (!this.capabilities.supportsBreakpointRegistrationWhileRunning && !this.isAtDebuggerPrompt) {
+            this.logger.info('Cannot sync breakpoints because the debugger', this.capabilities.supportsBreakpointRegistrationWhileRunning ? 'does not support sending breakpoints while running' : 'is not paused');
             return;
         }
 

--- a/src/adapters/TelnetAdapter.ts
+++ b/src/adapters/TelnetAdapter.ts
@@ -74,6 +74,11 @@ export class TelnetAdapter {
 
     public supportsExceptionBreakpoints = false;
 
+    //BreakpointManager rewrites `stop` statements as `if <cond> then : STOP : end if` and
+    //`if hits >= N then STOP`, so both forms work in telnet mode regardless of firmware.
+    public supportsConditionalBreakpoints = true;
+    public supportsHitConditionalBreakpoints = true;
+
     public once(eventName: 'app-ready'): Promise<void>;
     public once(eventName: 'connected'): Promise<boolean>;
     public once(eventName: string) {

--- a/src/debugProtocol/client/DebugProtocolClient.spec.ts
+++ b/src/debugProtocol/client/DebugProtocolClient.spec.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-bitwise */
 import { DebugProtocolClient } from './DebugProtocolClient';
+import { ProtocolCapabilities } from './ProtocolCapabilities';
 import { expect } from 'chai';
 import { createSandbox } from 'sinon';
 import { Command, ErrorCode, StepType, StopReason } from '../Constants';
@@ -96,24 +97,24 @@ describe('DebugProtocolClient', () => {
 
     it('knows when to enable the thread hopping workaround', () => {
         //only supported below version 3.1.0
-        client.protocolVersion = '1.0.0';
+        client.capabilities = new ProtocolCapabilities('1.0.0');
         expect(
-            client['enableThreadHoppingWorkaround']
+            client.capabilities.enableThreadHoppingWorkaround
         ).to.be.true;
 
-        client.protocolVersion = '3.0.0';
+        client.capabilities = new ProtocolCapabilities('3.0.0');
         expect(
-            client['enableThreadHoppingWorkaround']
+            client.capabilities.enableThreadHoppingWorkaround
         ).to.be.true;
 
-        client.protocolVersion = '3.1.0';
+        client.capabilities = new ProtocolCapabilities('3.1.0');
         expect(
-            client['enableThreadHoppingWorkaround']
+            client.capabilities.enableThreadHoppingWorkaround
         ).to.be.false;
 
-        client.protocolVersion = '4.0.0';
+        client.capabilities = new ProtocolCapabilities('4.0.0');
         expect(
-            client['enableThreadHoppingWorkaround']
+            client.capabilities.enableThreadHoppingWorkaround
         ).to.be.false;
     });
 
@@ -272,7 +273,7 @@ describe('DebugProtocolClient', () => {
 
         it('ignores the `isPrimary` flag when threadHoppingWorkaround is enabled', async () => {
             await connect();
-            client.protocolVersion = '2.0.0';
+            client.capabilities = new ProtocolCapabilities('2.0.0');
             client.primaryThread = 0;
             plugin.pushResponse(ThreadsResponse.fromJson({
                 requestId: 1,
@@ -292,7 +293,7 @@ describe('DebugProtocolClient', () => {
 
         it('honors the `isPrimary` flag when threadHoppingWorkaround is disabled', async () => {
             await connect();
-            client.protocolVersion = '3.1.0';
+            client.capabilities = new ProtocolCapabilities('3.1.0');
             client.primaryThread = 0;
             plugin.pushResponse(ThreadsResponse.fromJson({
                 requestId: 1,
@@ -378,7 +379,7 @@ describe('DebugProtocolClient', () => {
 
         it('sends AddBreakpointsRequest when conditional breakpoints are NOT supported', async () => {
             await connect();
-            client.protocolVersion = '2.0.0';
+            client.capabilities = new ProtocolCapabilities('2.0.0');
 
             //response structure doesn't matter, we're verifying that the request was properly built
             plugin.pushResponse(AddBreakpointsResponse.fromJson({} as any));
@@ -394,7 +395,7 @@ describe('DebugProtocolClient', () => {
 
         it('sends AddConditionalBreakpointsRequest when conditional breakpoints ARE supported', async () => {
             await connect();
-            client.protocolVersion = '3.1.0';
+            client.capabilities = new ProtocolCapabilities('3.1.0');
 
             //response structure doesn't matter, we're verifying that the request was properly built
             plugin.pushResponse(AddConditionalBreakpointsResponse.fromJson({} as any));
@@ -410,7 +411,7 @@ describe('DebugProtocolClient', () => {
 
         it('includes complib prefix when supported', async () => {
             await connect();
-            client.protocolVersion = '3.1.0';
+            client.capabilities = new ProtocolCapabilities('3.1.0');
 
             //response structure doesn't matter, we're verifying that the request was properly built
             plugin.pushResponse(AddConditionalBreakpointsResponse.fromJson({} as any));
@@ -425,7 +426,7 @@ describe('DebugProtocolClient', () => {
 
         it('excludes complib prefix when not supported', async () => {
             await connect();
-            client.protocolVersion = '2.0.0';
+            client.capabilities = new ProtocolCapabilities('2.0.0');
 
             //response structure doesn't matter, we're verifying that the request was properly built
             plugin.pushResponse(AddConditionalBreakpointsResponse.fromJson({} as any));
@@ -480,70 +481,70 @@ describe('DebugProtocolClient', () => {
 
     it('knows when to enable complib specific breakpoints', () => {
         //only supported on version 3.1.0 and above
-        client.protocolVersion = '1.0.0';
+        client.capabilities = new ProtocolCapabilities('1.0.0');
         expect(
-            client['enableComponentLibrarySpecificBreakpoints']
+            client.capabilities.enableComponentLibrarySpecificBreakpoints
         ).to.be.false;
 
-        client.protocolVersion = '3.0.0';
+        client.capabilities = new ProtocolCapabilities('3.0.0');
         expect(
-            client['enableComponentLibrarySpecificBreakpoints']
+            client.capabilities.enableComponentLibrarySpecificBreakpoints
         ).to.be.false;
 
-        client.protocolVersion = '3.1.0';
+        client.capabilities = new ProtocolCapabilities('3.1.0');
         expect(
-            client['enableComponentLibrarySpecificBreakpoints']
+            client.capabilities.enableComponentLibrarySpecificBreakpoints
         ).to.be.true;
 
-        client.protocolVersion = '4.0.0';
+        client.capabilities = new ProtocolCapabilities('4.0.0');
         expect(
-            client['enableComponentLibrarySpecificBreakpoints']
+            client.capabilities.enableComponentLibrarySpecificBreakpoints
         ).to.be.true;
     });
 
     it('knows when to enable conditional breakpoints', () => {
         //only supported on version 3.1.0 and above
-        client.protocolVersion = '1.0.0';
+        client.capabilities = new ProtocolCapabilities('1.0.0');
         expect(
-            client['supportsConditionalBreakpoints']
+            client.capabilities.supportsConditionalBreakpoints
         ).to.be.false;
 
-        client.protocolVersion = '3.0.0';
+        client.capabilities = new ProtocolCapabilities('3.0.0');
         expect(
-            client['supportsConditionalBreakpoints']
+            client.capabilities.supportsConditionalBreakpoints
         ).to.be.false;
 
-        client.protocolVersion = '3.1.0';
+        client.capabilities = new ProtocolCapabilities('3.1.0');
         expect(
-            client['supportsConditionalBreakpoints']
+            client.capabilities.supportsConditionalBreakpoints
         ).to.be.true;
 
-        client.protocolVersion = '4.0.0';
+        client.capabilities = new ProtocolCapabilities('4.0.0');
         expect(
-            client['supportsConditionalBreakpoints']
+            client.capabilities.supportsConditionalBreakpoints
         ).to.be.true;
     });
 
     it('knows when to enable exception breakpoint filters', () => {
         //only supported on version 3.3.0 and above
-        client.protocolVersion = '1.0.0';
+        client.capabilities = new ProtocolCapabilities('1.0.0');
         expect(
-            client['supportsExceptionBreakpoints']
+            client.capabilities.supportsExceptionBreakpoints
         ).to.be.false;
 
-        client.protocolVersion = '3.0.0';
+        client.capabilities = new ProtocolCapabilities('3.0.0');
         expect(
-            client['supportsExceptionBreakpoints']
+            client.capabilities.supportsExceptionBreakpoints
         ).to.be.false;
 
-        client.protocolVersion = '3.3.0';
+        client.capabilities = new ProtocolCapabilities('3.3.0');
         expect(
-            client['supportsExceptionBreakpoints']
+            client.capabilities.supportsExceptionBreakpoints
         ).to.be.true;
 
-        client.protocolVersion = '4.0.0';
+        client.capabilities = new ProtocolCapabilities('4.0.0');
         expect(
-            client['supportsExceptionBreakpoints']
+            client.capabilities.supportsExceptionBreakpoints
         ).to.be.true;
     });
 
@@ -1019,7 +1020,7 @@ describe('DebugProtocolClient', () => {
             ]);
 
             // force the protocolVersion to 2.0.0 for this test
-            client.protocolVersion = '2.0.0';
+            client.capabilities = new ProtocolCapabilities('2.0.0');
 
             plugin.pushResponse(VariablesResponse.fromJson({
                 requestId: -1, // overridden in the plugin
@@ -1051,7 +1052,7 @@ describe('DebugProtocolClient', () => {
             } as VariablesRequest['data']);
 
             // force the protocolVersion to 3.1.0 for this test
-            client.protocolVersion = '3.1.0';
+            client.capabilities = new ProtocolCapabilities('3.1.0');
 
             plugin.pushResponse(VariablesResponse.fromJson({
                 requestId: -1, // overridden in the plugin

--- a/src/debugProtocol/client/DebugProtocolClient.ts
+++ b/src/debugProtocol/client/DebugProtocolClient.ts
@@ -9,6 +9,7 @@ import { ListBreakpointsResponse } from '../events/responses/ListBreakpointsResp
 import { AddBreakpointsResponse } from '../events/responses/AddBreakpointsResponse';
 import { RemoveBreakpointsResponse } from '../events/responses/RemoveBreakpointsResponse';
 import { defer, util } from '../../util';
+import { ProtocolCapabilities } from './ProtocolCapabilities';
 import { BreakpointErrorUpdate } from '../events/updates/BreakpointErrorUpdate';
 import { ContinueRequest } from '../events/requests/ContinueRequest';
 import { StopRequest } from '../events/requests/StopRequest';
@@ -53,7 +54,7 @@ export class DebugProtocolClient {
     public logger = logger.createLogger(`[dpclient]`);
 
     // The highest tested version of the protocol we support.
-    public supportedVersionRange = '<=3.2.0';
+    public supportedVersionRange = '<=3.5.0';
 
     constructor(
         options?: ConstructorOptions
@@ -87,7 +88,19 @@ export class DebugProtocolClient {
      * This field indicates whether we should be looking for packet_length or not in the responses we get from the device
      */
     public watchPacketLength = false;
-    public protocolVersion: string;
+    /**
+     * Capability flags derived from the negotiated protocol version. Undefined until the
+     * handshake completes, then assigned a fresh `ProtocolCapabilities` keyed off the version
+     * the device reported.
+     */
+    public capabilities: ProtocolCapabilities | undefined;
+    /**
+     * The protocol version negotiated with the device during the handshake. Undefined until
+     * the handshake has completed.
+     */
+    public get protocolVersion(): string | undefined {
+        return this.capabilities?.protocolVersion;
+    }
     public primaryThread: number;
     public stackFrameIndex: number;
 
@@ -124,45 +137,6 @@ export class DebugProtocolClient {
     private requestIdSequence = 1;
     private activeRequests = new Map<number, ProtocolRequest>();
     private options: ConstructorOptions;
-
-    /**
-     * Prior to protocol v3.1.0, the Roku device would regularly set the wrong thread as "active",
-     * so this flag lets us know if we should use our better-than-nothing workaround
-     */
-    private get enableThreadHoppingWorkaround() {
-        return semver.satisfies(this.protocolVersion, '<3.1.0');
-    }
-
-    /**
-     * Starting in protocol v3.1.0, component libary breakpoints must be added in the format `lib:/<library_name>/<filepath>`, but prior they didn't require this.
-     * So this flag tells us which format to support
-     */
-    private get enableComponentLibrarySpecificBreakpoints() {
-        return semver.satisfies(this.protocolVersion, '>=3.1.0');
-    }
-
-    /**
-     * Starting in protocol v3.1.0, breakpoints can support conditional expressions. This flag indicates whether the current sessuion supports that functionality.
-     */
-    private get supportsConditionalBreakpoints() {
-        return semver.satisfies(this.protocolVersion, '>=3.1.0');
-    }
-
-    public get supportsBreakpointRegistrationWhileRunning() {
-        return semver.satisfies(this.protocolVersion, '>=3.2.0');
-    }
-
-    public get supportsBreakpointVerification() {
-        return semver.satisfies(this.protocolVersion, '>=3.2.0');
-    }
-
-    public get supportsVirtualVariables() {
-        return semver.satisfies(this.protocolVersion, '>=3.3.0');
-    }
-
-    public get supportsExceptionBreakpoints() {
-        return semver.satisfies(this.protocolVersion, '>=3.3.0');
-    }
 
     /**
      * Get a promise that resolves after an event occurs exactly once
@@ -425,7 +399,7 @@ export class DebugProtocolClient {
 
             if (result.data.errorCode === ErrorCode.OK) {
                 //older versions of the debug protocol had issues with maintaining the active thread, so our workaround is to keep track of it elsewhere
-                if (this.enableThreadHoppingWorkaround) {
+                if (this.capabilities?.enableThreadHoppingWorkaround) {
                     //ignore the `isPrimary` flag on threads
                     this.logger.debug(`Ignoring the 'isPrimary' flag from threads because protocol version 3.0.0 and lower has a bug`);
                 } else {
@@ -494,7 +468,7 @@ export class DebugProtocolClient {
                 threadIndex: threadIndex,
                 stackFrameIndex: stackFrameIndex,
                 getChildKeys: true,
-                getVirtualKeys: this.supportsVirtualVariables,
+                getVirtualKeys: this.capabilities?.supportsVirtualVariables,
                 variablePathEntries: variablePathEntries.map(x => ({
                     //remove leading and trailing quotes
                     name: x.replace(/^"/, '').replace(/"$/, ''),
@@ -643,7 +617,7 @@ export class DebugProtocolClient {
     }
 
     public async addBreakpoints(breakpoints: Array<BreakpointSpec & { componentLibraryName?: string }>): Promise<AddBreakpointsResponse> {
-        const { enableComponentLibrarySpecificBreakpoints } = this;
+        const enableComponentLibrarySpecificBreakpoints = this.capabilities?.enableComponentLibrarySpecificBreakpoints;
         if (breakpoints?.length > 0) {
             const json = {
                 requestId: this.requestIdSequence++,
@@ -661,7 +635,7 @@ export class DebugProtocolClient {
 
             const useConditionalBreakpoints = (
                 //does this protocol version support conditional breakpoints?
-                this.supportsConditionalBreakpoints &&
+                this.capabilities?.supportsConditionalBreakpoints &&
                 //is there at least one conditional breakpoint present?
                 !!breakpoints.find(x => !!x?.conditionalExpression?.trim())
             );
@@ -678,7 +652,7 @@ export class DebugProtocolClient {
             }
 
             //if the device does not support breakpoint verification, then auto-mark all of these as verified
-            if (!this.supportsBreakpointVerification) {
+            if (!this.capabilities?.supportsBreakpointVerification) {
                 this.emit('breakpoints-verified', {
                     breakpoints: response.data.breakpoints
                 });
@@ -1054,7 +1028,7 @@ export class DebugProtocolClient {
         if (DebugProtocolClient.DEBUGGER_MAGIC === response.data.magic) {
             this.logger.log('Magic is valid.');
 
-            this.protocolVersion = response.data.protocolVersion;
+            this.capabilities = new ProtocolCapabilities(response.data.protocolVersion);
             this.logger.log('Protocol Version:', this.protocolVersion);
 
             this.watchPacketLength = semver.satisfies(this.protocolVersion, '>=3.0.0');

--- a/src/debugProtocol/client/ProtocolCapabilities.spec.ts
+++ b/src/debugProtocol/client/ProtocolCapabilities.spec.ts
@@ -1,0 +1,73 @@
+import { expect } from 'chai';
+import { ProtocolCapabilities } from './ProtocolCapabilities';
+
+describe('ProtocolCapabilities', () => {
+    describe('protocolVersion resolution', () => {
+        it('uses the supplied protocol version when it is valid', () => {
+            expect(new ProtocolCapabilities('3.2.0', '11.0.0').protocolVersion).to.equal('3.2.0');
+        });
+
+        it('resolves every OS range to its introduced protocol version', () => {
+            const cases: Array<[string, string]> = [
+                //>= 14.1 → 3.3.0
+                ['14.1.0', '3.3.0'],
+                ['14.5.0', '3.3.0'],
+                ['15.0.0', '3.3.0'],
+                ['99.99.99', '3.3.0'],
+                //12.0 - 14.0 → 3.2.0
+                ['12.0.0', '3.2.0'],
+                ['12.5.7', '3.2.0'],
+                ['13.0.0', '3.2.0'],
+                ['14.0.99', '3.2.0'],
+                //11.5 - 11.x → 3.1.0
+                ['11.5.0', '3.1.0'],
+                ['11.5.5', '3.1.0'],
+                ['11.9.99', '3.1.0'],
+                //11.0 - 11.4 → 3.0.0
+                ['11.0.0', '3.0.0'],
+                ['11.2.3', '3.0.0'],
+                ['11.4.99', '3.0.0'],
+                //9.3 - 10.x → 2.0.0
+                ['9.3.0', '2.0.0'],
+                ['9.4.0', '2.0.0'],
+                ['10.0.0', '2.0.0'],
+                ['10.5.0', '2.0.0'],
+                ['10.99.99', '2.0.0'],
+                //9.2 - 9.2.x → 1.0.1
+                ['9.2.0', '1.0.1'],
+                ['9.2.99', '1.0.1']
+            ];
+            for (const [osVersion, expected] of cases) {
+                expect(new ProtocolCapabilities(undefined, osVersion).protocolVersion, `osVersion=${osVersion}`).to.equal(expected);
+            }
+        });
+
+        it('derives the protocol version when protocol version is an empty string', () => {
+            expect(new ProtocolCapabilities('', '14.1.0').protocolVersion).to.equal('3.3.0');
+        });
+
+        it('returns the original value when osVersion is missing and protocol version is invalid', () => {
+            expect(new ProtocolCapabilities(undefined).protocolVersion).to.be.undefined;
+            expect(new ProtocolCapabilities('').protocolVersion).to.equal('');
+        });
+
+        it('returns the original value when osVersion is too old to map', () => {
+            expect(new ProtocolCapabilities(undefined, '9.1.0').protocolVersion).to.be.undefined;
+        });
+
+        it('coerces a non-strict os version string', () => {
+            expect(new ProtocolCapabilities(undefined, '11.5').protocolVersion).to.equal('3.1.0');
+            expect(new ProtocolCapabilities(undefined, '12').protocolVersion).to.equal('3.2.0');
+        });
+    });
+
+    describe('capability flags', () => {
+        it('reports capabilities based on the resolved protocol version', () => {
+            const caps = new ProtocolCapabilities(undefined, '12.0.0');
+            expect(caps.protocolVersion).to.equal('3.2.0');
+            expect(caps.supportsBreakpointVerification).to.be.true;
+            expect(caps.supportsVirtualVariables).to.be.false;
+            expect(caps.enableThreadHoppingWorkaround).to.be.false;
+        });
+    });
+});

--- a/src/debugProtocol/client/ProtocolCapabilities.ts
+++ b/src/debugProtocol/client/ProtocolCapabilities.ts
@@ -7,7 +7,45 @@ import * as semver from 'semver';
  * `brightscript-debugger-version` when no client has connected yet.
  */
 export class ProtocolCapabilities {
-    constructor(public readonly protocolVersion: string) { }
+    constructor(protocolVersion: string | undefined, osVersion?: string) {
+        this.protocolVersion = ProtocolCapabilities.resolveProtocolVersion(protocolVersion, osVersion);
+    }
+
+    public readonly protocolVersion: string;
+
+    /**
+     * Roku OS versions that introduced each debug protocol version, ordered newest-first so
+     * we can pick the highest protocol whose OS floor the device meets.
+     */
+    private static readonly osToProtocolVersions: ReadonlyArray<{ os: string; protocol: string }> = [
+        { os: '14.1.0', protocol: '3.3.0' },
+        { os: '12.0.0', protocol: '3.2.0' },
+        { os: '11.5.0', protocol: '3.1.0' },
+        { os: '11.0.0', protocol: '3.0.0' },
+        { os: '9.3.0', protocol: '2.0.0' },
+        { os: '9.2.0', protocol: '1.0.1' }
+    ];
+
+    /**
+     * Some Roku firmware versions support the debug protocol but omit `brightscript-debugger-version`
+     * from device-info, so fall back to deriving the protocol version from the OS version when the
+     * caller didn't get one from the device.
+     */
+    private static resolveProtocolVersion(protocolVersion: string | undefined, osVersion: string | undefined): string {
+        if (semver.valid(protocolVersion)) {
+            return protocolVersion;
+        }
+        const coercedOs = osVersion ? semver.coerce(osVersion) : null;
+        if (!coercedOs) {
+            return protocolVersion;
+        }
+        for (const entry of ProtocolCapabilities.osToProtocolVersions) {
+            if (semver.gte(coercedOs, entry.os)) {
+                return entry.protocol;
+            }
+        }
+        return protocolVersion;
+    }
 
     /**
      * Prior to protocol v3.1.0, the Roku device would regularly set the wrong thread as "active",

--- a/src/debugProtocol/client/ProtocolCapabilities.ts
+++ b/src/debugProtocol/client/ProtocolCapabilities.ts
@@ -1,0 +1,79 @@
+import * as semver from 'semver';
+
+/**
+ * Encapsulates the version-based capability checks for the BrightScript debug protocol.
+ * Used by `DebugProtocolClient` for the live session (version set during the handshake),
+ * and by `DebugProtocolAdapter` as a standalone fallback seeded from the device-info
+ * `brightscript-debugger-version` when no client has connected yet.
+ */
+export class ProtocolCapabilities {
+    constructor(public readonly protocolVersion: string) { }
+
+    /**
+     * Prior to protocol v3.1.0, the Roku device would regularly set the wrong thread as "active",
+     * so this flag lets us know if we should use our better-than-nothing workaround
+     */
+    public get enableThreadHoppingWorkaround() {
+        return semver.satisfies(this.protocolVersion, '<3.1.0');
+    }
+
+    /**
+     * Starting in protocol v3.1.0, component library breakpoints must be added in the format
+     * `lib:/<library_name>/<filepath>`, but prior they didn't require this.
+     */
+    public get enableComponentLibrarySpecificBreakpoints() {
+        return semver.satisfies(this.protocolVersion, '>=3.1.0');
+    }
+
+    /**
+     * Starting in protocol v3.1.0, breakpoints can support conditional expressions.
+     */
+    public get supportsConditionalBreakpoints() {
+        return semver.satisfies(this.protocolVersion, '>=3.1.0');
+    }
+
+    /**
+     * Starting in protocol v3.1.0, breakpoints can carry a hit count (ignoreCount).
+     */
+    public get supportsHitConditionalBreakpoints() {
+        return semver.satisfies(this.protocolVersion, '>=3.1.0');
+    }
+
+    public get supportsBreakpointRegistrationWhileRunning() {
+        return semver.satisfies(this.protocolVersion, '>=3.2.0');
+    }
+
+    public get supportsBreakpointVerification() {
+        return semver.satisfies(this.protocolVersion, '>=3.2.0');
+    }
+
+    public get supportsVirtualVariables() {
+        return semver.satisfies(this.protocolVersion, '>=3.3.0');
+    }
+
+    public get supportsExceptionBreakpoints() {
+        return semver.satisfies(this.protocolVersion, '>=3.3.0');
+    }
+
+    /**
+     * Due to casing issues with the variables request on older protocols, we first try the
+     * request in the supplied case and retry in lower case on failure.
+     */
+    public get enableVariablesLowerCaseRetry() {
+        return semver.satisfies(this.protocolVersion, '<3.1.0');
+    }
+
+    /**
+     * The `execute` command was unreliable before protocol v3.0.0.
+     */
+    public get supportsExecuteCommand() {
+        return semver.satisfies(this.protocolVersion, '>=3.0.0');
+    }
+
+    /**
+     * The device emits compile-error update events starting in protocol v3.1.0.
+     */
+    public get supportsCompileErrorReporting() {
+        return semver.satisfies(this.protocolVersion, '>=3.1.0');
+    }
+}

--- a/src/debugSession/BrightScriptDebugSession.spec.ts
+++ b/src/debugSession/BrightScriptDebugSession.spec.ts
@@ -687,6 +687,9 @@ describe('BrightScriptDebugSession', () => {
                 filters: undefined,
                 filterOptions: undefined
             };
+            //the request now waits on `rokuAdapterDeferred` directly (instead of `getRokuAdapter`),
+            //so resolve it up front for these tests
+            session['rokuAdapterDeferred'].resolve(rokuAdapter as any);
         });
 
         it('both caught and uncaught filters', async () => {

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -372,11 +372,32 @@ export class BrightScriptDebugSession extends LoggingDebugSession {
         // make VS Code to use 'evaluate' when hovering over source
         response.body.supportsEvaluateForHovers = true;
 
-        // This debug adapter supports conditional breakpoints
-        response.body.supportsConditionalBreakpoints = true;
+        //NOTE: `supportsConditionalBreakpoints` and `supportsHitConditionalBreakpoints` are
+        //sent later in the post-connect CapabilitiesEvent once we know which adapter is in use
+        //(telnet always supports them via stop-statement rewrites; debug protocol requires v3.1.0+).
+        //VS Code reads these caps per-render in the BREAKPOINTS view, so CapabilitiesEvent updates
+        //take effect immediately - unlike `exceptionBreakpointFilters` / `breakpointModes` which
+        //must be in the initialize response.
 
-        // This debug adapter supports breakpoints that break execution after a specified number of hits
-        response.body.supportsHitConditionalBreakpoints = true;
+        //surface the filter list here so VS Code's BREAKPOINTS panel renders the checkboxes - the
+        //panel only reads this list from the initialize response, not from later CapabilitiesEvents.
+        //The `supportsExceptionFilterOptions` / `supportsExceptionOptions` booleans are deferred and
+        //sent via CapabilitiesEvent once we know the connected device's protocol version.
+        response.body.exceptionBreakpointFilters = [{
+            filter: 'caught',
+            supportsCondition: true,
+            conditionDescription: '__brs_err__.rethrown = true',
+            label: 'Caught Exceptions',
+            description: `Breaks on all errors, even if they're caught later.`,
+            default: false
+        }, {
+            filter: 'uncaught',
+            supportsCondition: true,
+            conditionDescription: '__brs_err__.rethrown = true',
+            label: 'Uncaught Exceptions',
+            description: 'Breaks only on errors that are not handled.',
+            default: true
+        }];
 
         response.body.supportsCompletionsRequest = true;
         response.body.completionTriggerCharacters = ['.', '(', '{', ',', ' '];
@@ -412,12 +433,15 @@ export class BrightScriptDebugSession extends LoggingDebugSession {
             }
             this.exceptionBreakpoints = filterOptions;
 
-            //ensure the rokuAdapter is loaded
-            await this.getRokuAdapter();
+            //wait until the adapter object exists, but don't wait for the device to come online —
+            //VS Code will not send configurationDone (and we cannot launch the channel) until we
+            //respond to this request.
+            await this.rokuAdapterDeferred.promise;
 
             if (this.rokuAdapter.supportsExceptionBreakpoints) {
+                //the adapter queues these filters internally if the debug protocol client hasn't
+                //connected yet, and replays them once it does
                 await this.rokuAdapter.setExceptionBreakpoints(filterOptions);
-                //if success
                 response.body.breakpoints = [
                     { verified: true },
                     { verified: true }
@@ -612,28 +636,17 @@ export class BrightScriptDebugSession extends LoggingDebugSession {
             await this.connectRokuAdapter();
             connectAdapterEnd();
 
-            // some capabilities depend on adapter type and are sent now that we know which adapter is in use
+            // Capabilities that depend on the adapter or device version. The exception-breakpoint
+            // FILTER LIST was surfaced in initializeRequest (VS Code only reads it from there).
+            // Everything below is read per-action in VS Code, so a CapabilitiesEvent update takes
+            // effect dynamically.
             const supportsExceptionBreakpoints = this.rokuAdapter.supportsExceptionBreakpoints;
             this.sendEvent(new CapabilitiesEvent({
-                // log points are only supported by the telnet adapter
                 supportsLogPoints: !this.enableDebugProtocol,
                 supportsExceptionFilterOptions: supportsExceptionBreakpoints,
                 supportsExceptionOptions: supportsExceptionBreakpoints,
-                exceptionBreakpointFilters: supportsExceptionBreakpoints ? [{
-                    filter: 'caught',
-                    supportsCondition: true,
-                    conditionDescription: '__brs_err__.rethrown = true',
-                    label: 'Caught Exceptions',
-                    description: `Breaks on all errors, even if they're caught later.`,
-                    default: false
-                }, {
-                    filter: 'uncaught',
-                    supportsCondition: true,
-                    conditionDescription: '__brs_err__.rethrown = true',
-                    label: 'Uncaught Exceptions',
-                    description: 'Breaks only on errors that are not handled.',
-                    default: true
-                }] : []
+                supportsConditionalBreakpoints: this.rokuAdapter.supportsConditionalBreakpoints,
+                supportsHitConditionalBreakpoints: this.rokuAdapter.supportsHitConditionalBreakpoints
             }));
 
             this.sendLaunchProgress('update', 'Configuring breakpoints');


### PR DESCRIPTION
## Summary

PR #328 deferred the entire DAP capabilities payload to a post-connect `CapabilitiesEvent`, but VS Code reads `exceptionBreakpointFilters` exactly once from the initialize response — so the filters never appeared in the BREAKPOINTS panel.

Split the responsibilities:
- `initializeRequest` surfaces the filter list (UI-driving, must be early)
- post-connect `CapabilitiesEvent` carries the device-dependent booleans (`supportsExceptionFilterOptions` / `supportsExceptionOptions`, `supportsConditionalBreakpoints`, `supportsHitConditionalBreakpoints`, `supportsLogPoints`), which VS Code reads per-render so `CapabilitiesEvent` updates take effect

## Adjacent fixes uncovered while testing

- **`ProtocolCapabilities` class** — extract version-based capability checks from `DebugProtocolClient`. The adapter holds a fallback instance seeded from device-info `brightscriptDebuggerVersion` so we can answer capability questions before the protocol handshake completes. Some firmware versions support the debug protocol but omit `brightscript-debugger-version` from device-info, so the class also takes an optional `softwareVersion` and derives the protocol version from the Roku OS → protocol mapping when the device-info value is missing.
- **`setExceptionBreakPointsRequest` deadlock** — was awaiting `getRokuAdapter()` which waits for the device to come online; that waits for `publish()`, which waits for `configurationDone`, which VS Code holds until we respond to this request. Switched to awaiting `rokuAdapterDeferred.promise`.
- **Exception breakpoint queue/replay** — adapter queues filters when the debug protocol client hasn't connected yet, replays on connect.
- **`_syncBreakpoints` gating** — now gates on `this.connected` and a proactive `syncBreakpoints()` runs on connect to flush queued breakpoints.
