### PR TITLE
Drop stale suspend/runtime-error events when debugger is no longer paused

### DIFF
--- a/src/adapters/DebugProtocolAdapter.spec.ts
+++ b/src/adapters/DebugProtocolAdapter.spec.ts
@@ -693,4 +693,38 @@ describe('DebugProtocolAdapter', function() {
         });
     });
 
+    describe('getThreads', () => {
+        //Regression test for DAP crash: unhandledRejection - Cannot get threads: debugger is not paused.
+        //adapter.emit('suspend') defers the actual event delivery via setTimeout(0). If isStopped
+        //flips from true to false during that window (auto-continue on entry breakpoint, rapid
+        //step, etc.), the suspend handler — which calls getThreads — throws an unhandled rejection.
+        //See https://github.com/rokucommunity/vscode-brightscript-language/issues/798
+        it('does not throw "Cannot get threads" when isStopped flips false between emit and the suspend handler running', async () => {
+            await initialize();
+
+            //mirror what BrightScriptDebugSession.onSuspend does: call getThreads from the suspend handler
+            let handlerError: Error | undefined;
+            adapter.on('suspend', async () => {
+                try {
+                    await adapter.getThreads();
+                } catch (e) {
+                    handlerError = e as Error;
+                }
+            });
+
+            //synchronously trigger the adapter's internal 'suspend' listener — this schedules adapter.emit('suspend') via setTimeout(0)
+            adapter['client']['emitter'].emit('suspend', {});
+            //before the setTimeout fires, the debugger transitions back to running (e.g. auto-continue
+            //on entry breakpoint kicked off by a previous suspend, or a rapid step request)
+            adapter['client'].isStopped = false;
+
+            //let the setTimeout(0) fire and the async suspend handler complete
+            await util.sleep(50);
+
+            expect(
+                handlerError?.message ?? ''
+            ).to.not.include('Cannot get threads: debugger is not paused');
+        });
+    });
+
 });

--- a/src/adapters/DebugProtocolAdapter.ts
+++ b/src/adapters/DebugProtocolAdapter.ts
@@ -155,9 +155,18 @@ export class DebugProtocolAdapter {
         //emit these events on next tick, otherwise they will be processed immediately which could cause issues
         setTimeout(() => {
             //in rare cases, this event is fired after the debugger has closed, so make sure the event emitter still exists
-            if (this.emitter) {
-                this.emitter.emit(eventName, data);
+            if (!this.emitter) {
+                return;
             }
+            //drop stale 'suspend'/'runtime-error' events when the debugger has already resumed.
+            //emit() defers via setTimeout, so isStopped can flip false between queue and fire (e.g. auto-continue on entry breakpoint),
+            //causing downstream handlers to call getThreads() against a running debugger.
+            //See https://github.com/rokucommunity/vscode-brightscript-language/issues/798
+            if ((eventName === 'suspend' || eventName === 'runtime-error') && !this.isAtDebuggerPrompt) {
+                this.logger.warn(`Dropping stale "${eventName}" event because debugger is no longer paused`);
+                return;
+            }
+            this.emitter.emit(eventName, data);
         }, 0);
     }
 


### PR DESCRIPTION
`DebugProtocolAdapter.emit` defers every event with `setTimeout(0)`. When `'suspend'` is queued while paused, `isStopped` can flip back to `false` before the timer fires (auto-continue on entry breakpoint, rapid step, etc.). The deferred suspend listener in `BrightScriptDebugSession` then calls `setupSuspendedState → getThreads`, which throws `Cannot get threads: debugger is not paused` as an unhandled rejection.

Re-check `isAtDebuggerPrompt` inside the deferred dispatch and drop the event if the debugger has already resumed. Same guard applies to `'runtime-error'`, which routes through the same handler path.

Fixes https://github.com/rokucommunity/vscode-brightscript-language/issues/798