### PR TITLE
Reset connected flag on close so _syncBreakpoints doesn't crash on a missing client

### DIFF
--- a/src/adapters/DebugProtocolAdapter.spec.ts
+++ b/src/adapters/DebugProtocolAdapter.spec.ts
@@ -506,6 +506,105 @@ describe('DebugProtocolAdapter', function() {
             // Should not throw
             await adapter._syncBreakpoints();
         });
+
+        //Regression tests for DAP crash: unhandledRejection - Cannot read properties of undefined (reading 'addBreakpoints').
+        //After the protocol client closes mid-session, this.client becomes undefined but this.connected
+        //is never reset — and even when both flags agree, an await inside _syncBreakpoints can yield
+        //while the close handler nulls the client. Either path crashes at `this.client.addBreakpoints(...)`.
+        //See https://github.com/rokucommunity/vscode-brightscript-language/issues/811 for the full report.
+        it('does not crash when client closes after connect leaves connected flag stale', async () => {
+            await initialize();
+            //force the fallback capabilities to a protocol version that supports breakpoint
+            //registration while running (production crash was on protocol 3.5.0). Without this,
+            //the second guard short-circuits on protocols <3.2.0 and never reaches this.client.addBreakpoints.
+            adapter['fallbackCapabilities'] = new ProtocolCapabilities('3.5.0');
+            //add a breakpoint so the diff has an 'added' entry — forces the function past the early returns into this.client.addBreakpoints
+            breakpointManager.replaceBreakpoints(srcPath, [{ line: 1 }]);
+            //simulate the device disconnecting mid-session: the close handler sets this.client = undefined
+            //but the existing code never resets this.connected, so the entry guard at the top of _syncBreakpoints
+            //still passes
+            adapter['client'] = undefined;
+            //precondition: stale connected flag is the root cause of the production crash
+            expect(adapter.connected).to.be.true;
+
+            //should not throw — currently crashes at `this.client.addBreakpoints(...)`
+            await adapter.syncBreakpoints();
+        });
+
+        it('does not crash when client becomes undefined mid-sync (TOCTOU between guard and addBreakpoints)', async () => {
+            await initialize();
+            breakpointManager.replaceBreakpoints(srcPath, [{ line: 1 }]);
+            //simulate close handler running during the getDiff await — the entry guard already passed, then the client gets nulled
+            sinon.stub(breakpointManager, 'getDiff').callsFake(() => {
+                adapter['client'] = undefined;
+                return Promise.resolve({
+                    added: [{
+                        pkgPath: 'pkg:/source/main.brs',
+                        line: 1,
+                        srcHash: 'a',
+                        destHash: 'a'
+                    } as any],
+                    removed: [],
+                    unchanged: []
+                });
+            });
+
+            //should not throw — currently crashes at `this.client.addBreakpoints(...)`
+            await adapter.syncBreakpoints();
+        });
+
+        it('pushes pending breakpoints to a fresh client after the previous one closed (relaunch/reload recovery)', async () => {
+            await initialize();
+            adapter['fallbackCapabilities'] = new ProtocolCapabilities('3.5.0');
+
+            //user sets a breakpoint while the first client is alive
+            breakpointManager.replaceBreakpoints(srcPath, [{ line: 1 }]);
+            plugin.pushResponse(AddBreakpointsResponse.fromJson({
+                breakpoints: [{ id: 1, errorCode: ErrorCode.OK, ignoreCount: 0 }],
+                requestId: 1
+            }));
+            await adapter.syncBreakpoints();
+
+            //device disconnects: trigger the real close handler so adapter state matches production
+            //(matches the bad window from https://github.com/rokucommunity/vscode-brightscript-language/issues/811 — between close and app-exit firing).
+            adapter['client']['emitter'].emit('close');
+
+            //post-fix invariant: the close handler resets connected so subsequent syncs early-return
+            expect(adapter.connected).to.be.false;
+
+            //user adds another breakpoint while the client is offline
+            breakpointManager.replaceBreakpoints(srcPath, [{ line: 1 }, { line: 2 }]);
+
+            //the no-client sync must not crash; with connected=false it early-returns before getDiff
+            //so the breakpoint baseline is preserved for the next reconnect
+            await adapter.syncBreakpoints();
+
+            //app-exit fires ~200ms after close in production and resets the breakpoint baseline so the
+            //next client sees every breakpoint as a fresh add (BrightScriptDebugSession.resetSessionState)
+            breakpointManager.clearBreakpointLastState();
+
+            //a fresh protocol client comes online (the test server is not designed for reconnects, so
+            //stand up a stub client that captures what sync would send to the new device)
+            const sentBreakpoints: { lineNumber: number }[] = [];
+            adapter['client'] = {
+                capabilities: new ProtocolCapabilities('3.5.0'),
+                isStopped: true,
+                addBreakpoints: (bps: { lineNumber: number }[]) => {
+                    sentBreakpoints.push(...bps);
+                    return Promise.resolve({
+                        data: {
+                            errorCode: ErrorCode.OK,
+                            breakpoints: bps.map((_, i) => ({ id: 100 + i, errorCode: ErrorCode.OK }))
+                        }
+                    });
+                }
+            } as any;
+            adapter['connected'] = true;
+
+            await adapter.syncBreakpoints();
+
+            expect(sentBreakpoints.map(x => x.lineNumber).sort()).to.eql([1, 2]);
+        });
     });
 
     describe('getVariable', () => {

--- a/src/adapters/DebugProtocolAdapter.ts
+++ b/src/adapters/DebugProtocolAdapter.ts
@@ -297,6 +297,10 @@ export class DebugProtocolAdapter {
                 await this.client.destroy()
             ]);
             this.client = undefined;
+            //keep `connected` in sync with `client` so the _syncBreakpoints entry guard
+            //(and similar checks elsewhere) reflects the actual state. Restored to true below
+            //once the new client finishes connecting.
+            this.connected = false;
         }
         this.client = new DebugProtocolClient(this.options);
         try {
@@ -331,6 +335,11 @@ export class DebugProtocolAdapter {
                 this.beginAppExit();
                 void this.client?.destroy();
                 this.client = undefined;
+                //the protocol client is gone — keep `connected` in sync so any subsequent
+                //syncBreakpoints / setExceptionBreakpoints calls during the close→app-exit
+                //window early-return instead of dereferencing the undefined client.
+                //See https://github.com/rokucommunity/vscode-brightscript-language/issues/811
+                this.connected = false;
             });
 
             // Listen for the app exit event
@@ -1068,6 +1077,15 @@ export class DebugProtocolAdapter {
             return;
         }
 
+        //getDiff above can yield to other microtasks. If the protocol client closed while we were
+        //awaiting (mid-sync TOCTOU), bail out before dereferencing this.client. The app-exit handler
+        //resets the breakpoint baseline so the next reconnect re-pushes any pending changes.
+        //See https://github.com/rokucommunity/vscode-brightscript-language/issues/811
+        if (!this.client) {
+            this.logger.info('Skipping breakpoint sync because the protocol client closed mid-sync');
+            return;
+        }
+
         // REMOVE breakpoints (delete these breakpoints from the device)
         if (diff.removed.length > 0) {
             const response = await this.client.removeBreakpoints(
@@ -1081,6 +1099,11 @@ export class DebugProtocolAdapter {
         }
 
         if (diff.added.length > 0) {
+            //the removeBreakpoints await above can also yield; re-check before attempting the add
+            if (!this.client) {
+                this.logger.info('Skipping breakpoint add because the protocol client closed mid-sync');
+                return;
+            }
             const breakpointsToSendToDevice = diff.added.map(breakpoint => {
                 const hitCount = parseInt(breakpoint.hitCondition);
                 return {


### PR DESCRIPTION
After the protocol client closes mid-session, `this.client` was set to `undefined` but `this.connected` stayed `true`, so the entry guard in `_syncBreakpoints` let the function fall through to `this.client.addBreakpoints(...)` and crash with `Cannot read properties of undefined (reading 'addBreakpoints')`. An `await` inside the function could also yield while the close handler nulled the client, hitting the same crash from a second path.

Reset `connected` in the close handler and when destroying the previous client on reconnect, and re-check `this.client` after the awaits in `_syncBreakpoints` so the mid-sync TOCTOU window also fails safe. Recovery via the existing `app-exit → resetSessionState → clearBreakpointLastState` wiring is preserved — covered by the new relaunch test.

Fixes https://github.com/rokucommunity/vscode-brightscript-language/issues/811