### PR TITLE
Defer initializeProfiling until after InitializedEvent

### DIFF
--- a/src/debugSession/BrightScriptDebugSession.spec.ts
+++ b/src/debugSession/BrightScriptDebugSession.spec.ts
@@ -4,7 +4,7 @@ import * as fsExtra from 'fs-extra';
 import * as path from 'path';
 import * as sinonActual from 'sinon';
 import type { DebugProtocol } from '@vscode/debugprotocol/lib/debugProtocol';
-import { DebugSession, Logger as DapLogger, logger as dapLogger, ProgressEndEvent, ProgressStartEvent, ProgressUpdateEvent } from '@vscode/debugadapter';
+import { DebugSession, InitializedEvent, Logger as DapLogger, logger as dapLogger, ProgressEndEvent, ProgressStartEvent, ProgressUpdateEvent } from '@vscode/debugadapter';
 import { BrightScriptDebugSession } from './BrightScriptDebugSession';
 import type { AugmentedVariable } from './BrightScriptDebugSession';
 import { fileUtils } from '../FileUtils';
@@ -2668,6 +2668,28 @@ describe('BrightScriptDebugSession', () => {
 
                 expect(getProgressEvents()).to.be.empty;
             });
+        });
+
+        it('runs initializeProfiling after InitializedEvent so the extension does not clear profiling context keys on session start', async function() {
+            this.timeout(5000);
+            setupLaunchStubs();
+
+            const calls: string[] = [];
+            sinon.stub(session, 'sendEvent').callsFake((event) => {
+                calls.push(`sendEvent:${event.constructor.name}`);
+            });
+            sinon.stub(session as any, 'initializeProfiling').callsFake(() => {
+                calls.push('initializeProfiling');
+                return Promise.resolve();
+            });
+
+            await session.launchRequest({} as any, launchConfiguration);
+
+            const initializedIdx = calls.indexOf('sendEvent:InitializedEvent');
+            const profilingIdx = calls.indexOf('initializeProfiling');
+            expect(initializedIdx, 'InitializedEvent was not sent').to.be.greaterThan(-1);
+            expect(profilingIdx, 'initializeProfiling was not called').to.be.greaterThan(-1);
+            expect(profilingIdx, 'initializeProfiling must run after InitializedEvent').to.be.greaterThan(initializedIdx);
         });
     });
 

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -588,8 +588,6 @@ export class BrightScriptDebugSession extends LoggingDebugSession {
                 return await this.shutdown(`Developer mode is not enabled for host '${this.launchConfiguration.host}'.`);
             }
 
-            await this.initializeProfiling();
-
             // everything is ready, send the response to the launch request so the UI can update and configuration can begin
             this.sendResponse(response);
 
@@ -656,6 +654,8 @@ export class BrightScriptDebugSession extends LoggingDebugSession {
             // notify VS Code that the adapter is ready to receive configuration (breakpoints, etc.)
             // VS Code will respond with setBreakpoints, setExceptionBreakpoints, then configurationDone
             this.sendEvent(new InitializedEvent());
+
+            await this.initializeProfiling();
 
         } catch (e) {
             //if the message is anything other than compile errors, we want to display the error


### PR DESCRIPTION
## Summary

PR #328 moved `initializeProfiling()` ahead of `sendResponse(response)`. That caused `ProfilingEnabledEvent` to reach the extension before VS Code fired `onDidStartDebugSession`. The extension's session-start handler then cleared `brightscript.tracingEnabled`, hiding the profiling toolbar buttons for the rest of the session.

Move the call to the end of `launchRequest` (after `InitializedEvent`) so the session-start cleanup runs first and the enable event sticks.