### PR TITLE
Add processStagingDir reverse request support

### DIFF
--- a/src/LaunchConfiguration.ts
+++ b/src/LaunchConfiguration.ts
@@ -396,6 +396,25 @@ export interface LaunchConfiguration extends DebugProtocol.LaunchRequestArgument
      * @default true
      */
     emitChannelPublishedEvent?: boolean;
+
+    /**
+     * Optional capabilities advertised by the client (such as the VSCode extension) so the debug adapter
+     * can enable optional features the client supports. This is populated by the client itself, not by the user.
+     */
+    clientCapabilities?: ClientCapabilities;
+}
+
+/**
+ * Optional features the client advertises support for via `LaunchConfiguration.clientCapabilities`.
+ * The debug adapter only enables the matching behavior when the client opts in here.
+ */
+export interface ClientCapabilities {
+    /**
+     * The client supports the `processStagingDir` reverse request. When true, the debug adapter sends that
+     * request after all projects are staged and before they are packaged, giving the client a chance to
+     * inspect or modify each project's staging directory.
+     */
+    supportsProcessStagingDir?: boolean;
 }
 
 export interface ComponentLibraryConfiguration {

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -611,6 +611,13 @@ export class BrightScriptDebugSession extends LoggingDebugSession {
             //all of the projects have been successfully staged.
             this.stagingDefered.tryResolve();
 
+            //if the client supports it, let it process (inspect/modify) each project's staging dir before we package them
+            if (this.launchConfiguration.clientCapabilities?.supportsProcessStagingDir) {
+                await this.sendCustomRequest('processStagingDir', {
+                    projects: this.projectManager.getProjectStagingInfo()
+                });
+            }
+
             packageEnd();
 
             if (this.enableDebugProtocol) {

--- a/src/debugSession/Events.ts
+++ b/src/debugSession/Events.ts
@@ -4,6 +4,7 @@ import type { BSDebugDiagnostic } from '../CompileErrorProcessor';
 import type { LaunchConfiguration } from '../LaunchConfiguration';
 import type { ChanperfData } from '../ChanperfTracker';
 import type { RendezvousHistory } from '../RendezvousTracker';
+import type { ProjectStagingInfo } from '../managers/ProjectManager';
 
 export class CustomEvent<T> {
     public constructor(body: T) {
@@ -241,6 +242,10 @@ export function isExecuteTaskCustomRequest(event: any): event is CustomRequestEv
 
 export function isShowPopupMessageCustomRequest(event: any): event is CustomRequestEvent<{ message: string; severity: 'error' | 'warn' | 'info'; modal: boolean; actions: string[] }> {
     return !!event && event.event === CustomRequestEvent.name && event.body.name === 'showPopupMessage';
+}
+
+export function isProcessStagingDirCustomRequest(event: any): event is CustomRequestEvent<{ projects: ProjectStagingInfo[] }> {
+    return !!event && event.event === CustomRequestEvent.name && event.body.name === 'processStagingDir';
 }
 
 export interface ProcessCrashEventData {

--- a/src/managers/ProjectManager.spec.ts
+++ b/src/managers/ProjectManager.spec.ts
@@ -60,6 +60,56 @@ describe('ProjectManager', () => {
         sinon.restore();
     });
 
+    describe('getProjectStagingInfo', () => {
+        function makeMainProject() {
+            return new Project({ rootDir: rootDir, outDir: outDir, files: [], stagingDir: stagingDir, enhanceREPLCompletions: false });
+        }
+        function makeComponentLibraryProject(libraryIndex: number) {
+            return new ComponentLibraryProject({
+                rootDir: rootDir,
+                outDir: compLibOutDir,
+                files: [],
+                stagingDir: s`${compLibOutDir}/complib${libraryIndex}-staging`,
+                libraryIndex: libraryIndex,
+                outFile: `complib${libraryIndex}.zip`,
+                enhanceREPLCompletions: false
+            });
+        }
+
+        it('always lists the main project first, even when component libraries are assigned first', () => {
+            const mainProject = makeMainProject();
+            const complib0 = makeComponentLibraryProject(0);
+            const complib1 = makeComponentLibraryProject(1);
+
+            //deliberately assign component libraries before the main project to prove the ordering is
+            //enforced by getProjectStagingInfo and not just an artifact of assignment order
+            manager.componentLibraryProjects = [complib0, complib1];
+            manager.mainProject = mainProject;
+
+            const info = manager.getProjectStagingInfo();
+
+            //contract: the main project is always first and typed as 'main'
+            expect(info[0]).to.eql({ type: 'main', stagingDir: mainProject.stagingDir });
+            //component libraries follow, in order, typed as 'componentLibrary'
+            expect(info.map(x => x.type)).to.eql(['main', 'componentLibrary', 'componentLibrary']);
+            expect(info.map(x => x.stagingDir)).to.eql([
+                mainProject.stagingDir,
+                complib0.stagingDir,
+                complib1.stagingDir
+            ]);
+        });
+
+        it('returns only the main project when there are no component libraries', () => {
+            const mainProject = makeMainProject();
+            manager.componentLibraryProjects = [];
+            manager.mainProject = mainProject;
+
+            expect(manager.getProjectStagingInfo()).to.eql([
+                { type: 'main', stagingDir: mainProject.stagingDir }
+            ]);
+        });
+    });
+
     describe('getLineNumberOffsetByBreakpoints', () => {
         let filePath = 'does not matter';
         it('accounts for the entry breakpoint', () => {

--- a/src/managers/ProjectManager.ts
+++ b/src/managers/ProjectManager.ts
@@ -20,6 +20,21 @@ const replaceInFile = require('replace-in-file');
 export const componentLibraryPostfix = '__lib';
 
 /**
+ * Staging info for a single project, used when describing all projects to a client.
+ */
+export interface ProjectStagingInfo {
+    /**
+     * The kind of project. `main` is the application project (always exactly one); `componentLibrary`
+     * is a component library project.
+     */
+    type: 'main' | 'componentLibrary';
+    /**
+     * Absolute path to the project's staging directory.
+     */
+    stagingDir: string;
+}
+
+/**
  * Manages the collection of brightscript projects being used in a debug session.
  * Will contain the main project (in rootDir), as well as component libraries.
  */
@@ -73,6 +88,18 @@ export class ProjectManager {
             ...(this.componentLibraryProjects ?? [])
         ];
         return projects.map(x => x.stagingDir);
+    }
+
+    /**
+     * Get staging-dir info for every project. The main project is always first; component libraries
+     * follow in order. This main-first ordering is a contract that clients rely on, so it is covered
+     * by unit tests to guard against regressions.
+     */
+    public getProjectStagingInfo(): ProjectStagingInfo[] {
+        return this.getAllProjects().map((project) => ({
+            type: project instanceof ComponentLibraryProject ? 'componentLibrary' : 'main',
+            stagingDir: project.stagingDir
+        }));
     }
 
     /**


### PR DESCRIPTION
Adds an optional `clientCapabilities` object to `LaunchConfiguration` so a client can advertise support for optional features. The first one, `supportsProcessStagingDir`, gates a new `processStagingDir` reverse request.

When the client opts in, after all projects are staged and before they are packaged, the debug adapter sends a `processStagingDir` reverse request on the existing custom-request mechanism (awaitable like `executeTask`). Because it blocks until the client responds, the client can inspect or modify each project's staging directory before it is zipped.

- `ProjectManager.getProjectStagingInfo()` returns `{ type, stagingDir }` for every project, with the main project always first. A unit test locks in that main-first ordering.
- New `isProcessStagingDirCustomRequest` guard, mirroring the existing request guards.

The vscode-brightscript-language side (advertising the capability and handling the request) is a separate PR.
