### PR TITLE
Log temp-dir contents when test teardown fails to delete it

### DIFF
--- a/src/managers/BreakpointManager.spec.ts
+++ b/src/managers/BreakpointManager.spec.ts
@@ -10,7 +10,7 @@ let n = fileUtils.standardizePath.bind(fileUtils);
 import type { SourceLocation } from '../managers/LocationManager';
 import { LocationManager } from '../managers/LocationManager';
 import { SourceMapManager } from './SourceMapManager';
-import { expectPickEquals, pickArray, removeTempDir } from '../testHelpers.spec';
+import { expectPickEquals, pickArray, forceDeleteDir } from '../testHelpers.spec';
 import { createSandbox } from 'sinon';
 const sinon = createSandbox();
 
@@ -103,7 +103,7 @@ describe('BreakpointManager', () => {
 
     afterEach(() => {
         sinon.restore();
-        removeTempDir(tmpDir, 'BreakpointManager');
+        forceDeleteDir(tmpDir);
     });
 
     describe('reset', () => {
@@ -415,7 +415,7 @@ describe('BreakpointManager', () => {
         });
 
         afterEach(() => {
-            removeTempDir(tmpDir, 'BreakpointManager');
+            forceDeleteDir(tmpDir);
         });
 
         it('works with normal flow', async () => {

--- a/src/managers/BreakpointManager.spec.ts
+++ b/src/managers/BreakpointManager.spec.ts
@@ -10,7 +10,7 @@ let n = fileUtils.standardizePath.bind(fileUtils);
 import type { SourceLocation } from '../managers/LocationManager';
 import { LocationManager } from '../managers/LocationManager';
 import { SourceMapManager } from './SourceMapManager';
-import { expectPickEquals, pickArray } from '../testHelpers.spec';
+import { expectPickEquals, pickArray, removeTempDir } from '../testHelpers.spec';
 import { createSandbox } from 'sinon';
 const sinon = createSandbox();
 
@@ -103,7 +103,7 @@ describe('BreakpointManager', () => {
 
     afterEach(() => {
         sinon.restore();
-        fsExtra.removeSync(tmpDir);
+        removeTempDir(tmpDir, 'BreakpointManager');
     });
 
     describe('reset', () => {
@@ -415,7 +415,7 @@ describe('BreakpointManager', () => {
         });
 
         afterEach(() => {
-            fsExtra.removeSync(tmpDir);
+            removeTempDir(tmpDir, 'BreakpointManager');
         });
 
         it('works with normal flow', async () => {

--- a/src/managers/LocationManager.spec.ts
+++ b/src/managers/LocationManager.spec.ts
@@ -4,7 +4,7 @@ import { SourceMapConsumer, SourceNode } from 'source-map';
 import { standardizePath as s } from '../FileUtils';
 import { LocationManager } from './LocationManager';
 import { SourceMapManager } from './SourceMapManager';
-import { removeTempDir } from '../testHelpers.spec';
+import { forceDeleteDir } from '../testHelpers.spec';
 
 let tempDir = s`${process.cwd()}/.tmp`;
 const rootDir = s`${tempDir}/rootDir`;
@@ -21,7 +21,7 @@ describe('LocationManager', () => {
     beforeEach(() => {
         sourceMapManager = new SourceMapManager();
         locationManager = new LocationManager(sourceMapManager);
-        removeTempDir(tempDir, 'LocationManager');
+        forceDeleteDir(tempDir);
         fsExtra.ensureDirSync(`${rootDir}/source`);
         fsExtra.ensureDirSync(`${stagingDir}/source`);
         for (let sourceDir of sourceDirs) {
@@ -29,7 +29,7 @@ describe('LocationManager', () => {
         }
     });
     afterEach(() => {
-        removeTempDir(tempDir, 'LocationManager');
+        forceDeleteDir(tempDir);
     });
     describe('getSourceLocation', () => {
 

--- a/src/managers/LocationManager.spec.ts
+++ b/src/managers/LocationManager.spec.ts
@@ -4,6 +4,7 @@ import { SourceMapConsumer, SourceNode } from 'source-map';
 import { standardizePath as s } from '../FileUtils';
 import { LocationManager } from './LocationManager';
 import { SourceMapManager } from './SourceMapManager';
+import { removeTempDir } from '../testHelpers.spec';
 
 let tempDir = s`${process.cwd()}/.tmp`;
 const rootDir = s`${tempDir}/rootDir`;
@@ -20,7 +21,7 @@ describe('LocationManager', () => {
     beforeEach(() => {
         sourceMapManager = new SourceMapManager();
         locationManager = new LocationManager(sourceMapManager);
-        fsExtra.removeSync(tempDir);
+        removeTempDir(tempDir, 'LocationManager');
         fsExtra.ensureDirSync(`${rootDir}/source`);
         fsExtra.ensureDirSync(`${stagingDir}/source`);
         for (let sourceDir of sourceDirs) {
@@ -28,7 +29,7 @@ describe('LocationManager', () => {
         }
     });
     afterEach(() => {
-        fsExtra.removeSync(tempDir);
+        removeTempDir(tempDir, 'LocationManager');
     });
     describe('getSourceLocation', () => {
 

--- a/src/managers/ProjectManager.spec.ts
+++ b/src/managers/ProjectManager.spec.ts
@@ -11,7 +11,7 @@ import { BreakpointManager } from './BreakpointManager';
 import { SourceMapManager } from './SourceMapManager';
 import { LocationManager } from './LocationManager';
 import * as decompress from 'decompress';
-import { removeTempDir, emptyTempDir } from '../testHelpers.spec';
+import { forceDeleteDir } from '../testHelpers.spec';
 
 let sinon = sinonActual.createSandbox();
 let n = fileUtils.standardizePath.bind(fileUtils);
@@ -25,13 +25,13 @@ let compLibOutDir = s`${outDir}/component-libraries`;
 let compLibstagingDir = s`${rootDir}/component-libraries/CompLibA`;
 
 beforeEach(() => {
+    forceDeleteDir(tempPath);
     fsExtra.ensureDirSync(tempPath);
-    emptyTempDir(tempPath, 'ProjectManager');
     sinon.restore();
 });
 afterEach(() => {
+    forceDeleteDir(tempPath);
     fsExtra.ensureDirSync(tempPath);
-    emptyTempDir(tempPath, 'ProjectManager');
 });
 
 describe('ProjectManager', () => {
@@ -433,7 +433,7 @@ describe('Project', () => {
     describe('stage', () => {
         afterEach(() => {
             try {
-                removeTempDir(tempPath, 'ProjectManager');
+                forceDeleteDir(tempPath);
             } catch (e) { }
         });
         it('actually stages the project', async () => {
@@ -543,7 +543,7 @@ describe('Project', () => {
     describe('preprocessStagingFiles', () => {
         afterEach(() => {
             try {
-                removeTempDir(tempPath, 'ProjectManager');
+                forceDeleteDir(tempPath);
             } catch (e) { }
         });
 
@@ -1325,7 +1325,7 @@ describe('Project', () => {
     describe('scriptReferencedFiles', () => {
         afterEach(() => {
             try {
-                removeTempDir(tempPath, 'ProjectManager');
+                forceDeleteDir(tempPath);
             } catch (e) { }
         });
 
@@ -1489,16 +1489,16 @@ describe('Project', () => {
             fsExtra.writeFileSync(raleTrackerTaskFileLocation, `<!--dummy contents-->`);
         });
         after(() => {
-            removeTempDir(tempPath, 'ProjectManager');
+            forceDeleteDir(tempPath);
             fsExtra.removeSync(raleTrackerTaskFileLocation);
         });
         afterEach(() => {
-            emptyTempDir(tempPath, 'ProjectManager');
-            fsExtra.rmdirSync(tempPath);
+            forceDeleteDir(tempPath);
         });
 
         async function doTest(fileContents: string, expectedContents: string, fileExt = 'brs') {
-            emptyTempDir(tempPath, 'ProjectManager');
+            forceDeleteDir(tempPath);
+            fsExtra.ensureDirSync(tempPath);
             let folder = s`${tempPath}/findMainFunctionTests/`;
             fsExtra.mkdirSync(folder);
 
@@ -1601,17 +1601,17 @@ describe('Project', () => {
             fsExtra.writeFileSync(componentsFilePath, `' ${componentsFilePath}`);
         });
         after(() => {
-            removeTempDir(tempPath, 'ProjectManager');
+            forceDeleteDir(tempPath);
             fsExtra.emptyDirSync(rdbFilesBasePath);
             fsExtra.rmdirSync(rdbFilesBasePath);
         });
         afterEach(() => {
-            emptyTempDir(tempPath, 'ProjectManager');
-            fsExtra.rmdirSync(tempPath);
+            forceDeleteDir(tempPath);
         });
 
         async function doTest(fileContents: string, expectedContents: string, fileExt = 'brs', injectRdbOnDeviceComponent = true) {
-            emptyTempDir(tempPath, 'ProjectManager');
+            forceDeleteDir(tempPath);
+            fsExtra.ensureDirSync(tempPath);
             let folder = s`${tempPath}/findMainFunctionTests/`;
             fsExtra.mkdirSync(folder);
 
@@ -1637,7 +1637,8 @@ describe('Project', () => {
         //which fast-glob treats as escape characters. Without normalization, the glob
         //matches nothing and no files get copied.
         it('copies the RDB files when rdbFilesBasePath is an absolute path with native separators', async () => {
-            emptyTempDir(tempPath, 'ProjectManager');
+            forceDeleteDir(tempPath);
+            fsExtra.ensureDirSync(tempPath);
             let folder = s`${tempPath}/copyAndTransformRDBTests/`;
             fsExtra.mkdirSync(folder);
             let filePath = s`${folder}/main.brs`;
@@ -1659,7 +1660,8 @@ describe('Project', () => {
         });
 
         it('does not copy files when injectRdbOnDeviceComponent is false', async () => {
-            emptyTempDir(tempPath, 'ProjectManager');
+            forceDeleteDir(tempPath);
+            fsExtra.ensureDirSync(tempPath);
             let folder = s`${tempPath}/copyAndTransformRDBTests/`;
             fsExtra.mkdirSync(folder);
             let filePath = s`${folder}/main.brs`;
@@ -1681,7 +1683,8 @@ describe('Project', () => {
         });
 
         it('does not copy files when rdbFilesBasePath is not set', async () => {
-            emptyTempDir(tempPath, 'ProjectManager');
+            forceDeleteDir(tempPath);
+            fsExtra.ensureDirSync(tempPath);
             let folder = s`${tempPath}/copyAndTransformRDBTests/`;
             fsExtra.mkdirSync(folder);
             let filePath = s`${folder}/main.brs`;

--- a/src/managers/ProjectManager.spec.ts
+++ b/src/managers/ProjectManager.spec.ts
@@ -11,6 +11,7 @@ import { BreakpointManager } from './BreakpointManager';
 import { SourceMapManager } from './SourceMapManager';
 import { LocationManager } from './LocationManager';
 import * as decompress from 'decompress';
+import { removeTempDir, emptyTempDir } from '../testHelpers.spec';
 
 let sinon = sinonActual.createSandbox();
 let n = fileUtils.standardizePath.bind(fileUtils);
@@ -25,12 +26,12 @@ let compLibstagingDir = s`${rootDir}/component-libraries/CompLibA`;
 
 beforeEach(() => {
     fsExtra.ensureDirSync(tempPath);
-    fsExtra.emptyDirSync(tempPath);
+    emptyTempDir(tempPath, 'ProjectManager');
     sinon.restore();
 });
 afterEach(() => {
     fsExtra.ensureDirSync(tempPath);
-    fsExtra.emptyDirSync(tempPath);
+    emptyTempDir(tempPath, 'ProjectManager');
 });
 
 describe('ProjectManager', () => {
@@ -432,7 +433,7 @@ describe('Project', () => {
     describe('stage', () => {
         afterEach(() => {
             try {
-                fsExtra.removeSync(tempPath);
+                removeTempDir(tempPath, 'ProjectManager');
             } catch (e) { }
         });
         it('actually stages the project', async () => {
@@ -542,7 +543,7 @@ describe('Project', () => {
     describe('preprocessStagingFiles', () => {
         afterEach(() => {
             try {
-                fsExtra.removeSync(tempPath);
+                removeTempDir(tempPath, 'ProjectManager');
             } catch (e) { }
         });
 
@@ -1324,7 +1325,7 @@ describe('Project', () => {
     describe('scriptReferencedFiles', () => {
         afterEach(() => {
             try {
-                fsExtra.removeSync(tempPath);
+                removeTempDir(tempPath, 'ProjectManager');
             } catch (e) { }
         });
 
@@ -1488,16 +1489,16 @@ describe('Project', () => {
             fsExtra.writeFileSync(raleTrackerTaskFileLocation, `<!--dummy contents-->`);
         });
         after(() => {
-            fsExtra.removeSync(tempPath);
+            removeTempDir(tempPath, 'ProjectManager');
             fsExtra.removeSync(raleTrackerTaskFileLocation);
         });
         afterEach(() => {
-            fsExtra.emptyDirSync(tempPath);
+            emptyTempDir(tempPath, 'ProjectManager');
             fsExtra.rmdirSync(tempPath);
         });
 
         async function doTest(fileContents: string, expectedContents: string, fileExt = 'brs') {
-            fsExtra.emptyDirSync(tempPath);
+            emptyTempDir(tempPath, 'ProjectManager');
             let folder = s`${tempPath}/findMainFunctionTests/`;
             fsExtra.mkdirSync(folder);
 
@@ -1600,17 +1601,17 @@ describe('Project', () => {
             fsExtra.writeFileSync(componentsFilePath, `' ${componentsFilePath}`);
         });
         after(() => {
-            fsExtra.removeSync(tempPath);
+            removeTempDir(tempPath, 'ProjectManager');
             fsExtra.emptyDirSync(rdbFilesBasePath);
             fsExtra.rmdirSync(rdbFilesBasePath);
         });
         afterEach(() => {
-            fsExtra.emptyDirSync(tempPath);
+            emptyTempDir(tempPath, 'ProjectManager');
             fsExtra.rmdirSync(tempPath);
         });
 
         async function doTest(fileContents: string, expectedContents: string, fileExt = 'brs', injectRdbOnDeviceComponent = true) {
-            fsExtra.emptyDirSync(tempPath);
+            emptyTempDir(tempPath, 'ProjectManager');
             let folder = s`${tempPath}/findMainFunctionTests/`;
             fsExtra.mkdirSync(folder);
 
@@ -1636,7 +1637,7 @@ describe('Project', () => {
         //which fast-glob treats as escape characters. Without normalization, the glob
         //matches nothing and no files get copied.
         it('copies the RDB files when rdbFilesBasePath is an absolute path with native separators', async () => {
-            fsExtra.emptyDirSync(tempPath);
+            emptyTempDir(tempPath, 'ProjectManager');
             let folder = s`${tempPath}/copyAndTransformRDBTests/`;
             fsExtra.mkdirSync(folder);
             let filePath = s`${folder}/main.brs`;
@@ -1658,7 +1659,7 @@ describe('Project', () => {
         });
 
         it('does not copy files when injectRdbOnDeviceComponent is false', async () => {
-            fsExtra.emptyDirSync(tempPath);
+            emptyTempDir(tempPath, 'ProjectManager');
             let folder = s`${tempPath}/copyAndTransformRDBTests/`;
             fsExtra.mkdirSync(folder);
             let filePath = s`${folder}/main.brs`;
@@ -1680,7 +1681,7 @@ describe('Project', () => {
         });
 
         it('does not copy files when rdbFilesBasePath is not set', async () => {
-            fsExtra.emptyDirSync(tempPath);
+            emptyTempDir(tempPath, 'ProjectManager');
             let folder = s`${tempPath}/copyAndTransformRDBTests/`;
             fsExtra.mkdirSync(folder);
             let filePath = s`${folder}/main.brs`;

--- a/src/managers/SourceMapManager.spec.ts
+++ b/src/managers/SourceMapManager.spec.ts
@@ -3,6 +3,7 @@ import * as fsExtra from 'fs-extra';
 import * as path from 'path';
 import { standardizePath as s } from '../FileUtils';
 import { SourceMapManager } from './SourceMapManager';
+import { removeTempDir } from '../testHelpers.spec';
 let tmpPath = s`${process.cwd()}/.tmp`;
 describe('SourceMapManager', () => {
     let manager: SourceMapManager;
@@ -13,7 +14,7 @@ describe('SourceMapManager', () => {
         manager = new SourceMapManager();
     });
     afterEach(() => {
-        fsExtra.removeSync(tmpPath);
+        removeTempDir(tmpPath, 'SourceMapManager');
     });
 
     it('constructs', () => {

--- a/src/managers/SourceMapManager.spec.ts
+++ b/src/managers/SourceMapManager.spec.ts
@@ -3,7 +3,7 @@ import * as fsExtra from 'fs-extra';
 import * as path from 'path';
 import { standardizePath as s } from '../FileUtils';
 import { SourceMapManager } from './SourceMapManager';
-import { removeTempDir } from '../testHelpers.spec';
+import { forceDeleteDir } from '../testHelpers.spec';
 let tmpPath = s`${process.cwd()}/.tmp`;
 describe('SourceMapManager', () => {
     let manager: SourceMapManager;
@@ -14,7 +14,7 @@ describe('SourceMapManager', () => {
         manager = new SourceMapManager();
     });
     afterEach(() => {
-        removeTempDir(tmpPath, 'SourceMapManager');
+        forceDeleteDir(tmpPath);
     });
 
     it('constructs', () => {

--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -10,9 +10,10 @@ export const rootDir = s`${tempDir}/rootDir`;
 export const stagingDir = s`${tempDir}/stagingDir`;
 
 /**
- * List every path remaining inside `dir` (recursively).
+ * List every path remaining inside `dir` (recursively), sorted. Used to show what is still present
+ * when a directory delete fails.
  */
-function listTempLeftovers(dir: string): string[] {
+function listDirContents(dir: string): string[] {
     const result: string[] = [];
     const walk = (current: string) => {
         let entries: string[];
@@ -38,44 +39,44 @@ function listTempLeftovers(dir: string): string[] {
 }
 
 /**
- * Run a temp-dir cleanup operation. If it throws (most often Windows `ENOTEMPTY`, which happens when an
- * earlier test left a file or handle open in the shared temp dir), log exactly what is still present so CI
- * tells us which leftovers locked the dir, then re-throw. This diagnoses the failure; it does not hide it.
+ * Delete a directory, retrying a few times to get past transient locks (most often a Windows file
+ * handle still held open by an earlier test). If every attempt fails, log the paths still present
+ * along with a stack trace so CI shows which leftovers blocked the delete, then re-throw the final error.
+ * @param dir the directory to delete
+ * @param options.retryCount how many times to attempt the delete before giving up (defaults to 1)
+ * @param options.label optional label included in the diagnostic output to identify the calling teardown
  */
-function cleanupTempDir(label: string, dir: string, action: () => void) {
-    try {
-        action();
-    } catch (error) {
-        const leftovers = listTempLeftovers(dir);
-        console.error(`[temp-teardown] ${label}: ${(error as Error).message}`);
-        console.error(`[temp-teardown] ${label}: ${leftovers.length} path(s) still present under ${dir}:`);
-        for (const leftover of leftovers) {
-            console.error(`[temp-teardown]   ${leftover}`);
+export function forceDeleteDir(dir: string, options?: { retryCount?: number; label?: string }) {
+    const retryCount = options?.retryCount ?? 1;
+    const prefix = options?.label ? `[forceDeleteDir ${options.label}]` : '[forceDeleteDir]';
+    let lastError: Error;
+    for (let attempt = 1; attempt <= retryCount; attempt++) {
+        try {
+            fsExtra.removeSync(dir);
+            return;
+        } catch (error) {
+            lastError = error as Error;
         }
-        throw error;
     }
-}
-
-/**
- * `fsExtra.removeSync` for a temp dir, with diagnostics logged if the removal fails.
- */
-export function removeTempDir(dir: string, label: string) {
-    cleanupTempDir(label, dir, () => fsExtra.removeSync(dir));
-}
-
-/**
- * `fsExtra.emptyDirSync` for a temp dir, with diagnostics logged if the empty fails.
- */
-export function emptyTempDir(dir: string, label: string) {
-    cleanupTempDir(label, dir, () => fsExtra.emptyDirSync(dir));
+    const leftovers = listDirContents(dir);
+    console.error(`${prefix} failed to delete '${dir}' after ${retryCount} attempt(s); ${leftovers.length} path(s) still present:`);
+    for (const leftover of leftovers) {
+        console.error(`${prefix}   ${leftover}`);
+    }
+    console.error(`${prefix} ${lastError.message}`);
+    if (lastError.stack) {
+        console.error(lastError.stack);
+    }
+    throw lastError;
 }
 
 beforeEach(() => {
-    emptyTempDir(tempDir, 'global beforeEach');
+    forceDeleteDir(tempDir);
+    fsExtra.ensureDirSync(tempDir);
 });
 
 afterEach(() => {
-    removeTempDir(tempDir, 'global afterEach');
+    forceDeleteDir(tempDir);
 });
 
 /**

--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -9,12 +9,73 @@ export const tempDir = s`${__dirname}/../.tmp`;
 export const rootDir = s`${tempDir}/rootDir`;
 export const stagingDir = s`${tempDir}/stagingDir`;
 
+/**
+ * List every path remaining inside `dir` (recursively).
+ */
+function listTempLeftovers(dir: string): string[] {
+    const result: string[] = [];
+    const walk = (current: string) => {
+        let entries: string[];
+        try {
+            entries = fsExtra.readdirSync(current);
+        } catch {
+            return;
+        }
+        for (const entry of entries) {
+            const fullPath = `${current}/${entry}`;
+            result.push(fullPath);
+            try {
+                if (fsExtra.statSync(fullPath).isDirectory()) {
+                    walk(fullPath);
+                }
+            } catch {
+                //entry may have been removed concurrently; ignore
+            }
+        }
+    };
+    walk(dir);
+    return result.sort();
+}
+
+/**
+ * Run a temp-dir cleanup operation. If it throws (most often Windows `ENOTEMPTY`, which happens when an
+ * earlier test left a file or handle open in the shared temp dir), log exactly what is still present so CI
+ * tells us which leftovers locked the dir, then re-throw. This diagnoses the failure; it does not hide it.
+ */
+function cleanupTempDir(label: string, dir: string, action: () => void) {
+    try {
+        action();
+    } catch (error) {
+        const leftovers = listTempLeftovers(dir);
+        console.error(`[temp-teardown] ${label}: ${(error as Error).message}`);
+        console.error(`[temp-teardown] ${label}: ${leftovers.length} path(s) still present under ${dir}:`);
+        for (const leftover of leftovers) {
+            console.error(`[temp-teardown]   ${leftover}`);
+        }
+        throw error;
+    }
+}
+
+/**
+ * `fsExtra.removeSync` for a temp dir, with diagnostics logged if the removal fails.
+ */
+export function removeTempDir(dir: string, label: string) {
+    cleanupTempDir(label, dir, () => fsExtra.removeSync(dir));
+}
+
+/**
+ * `fsExtra.emptyDirSync` for a temp dir, with diagnostics logged if the empty fails.
+ */
+export function emptyTempDir(dir: string, label: string) {
+    cleanupTempDir(label, dir, () => fsExtra.emptyDirSync(dir));
+}
+
 beforeEach(() => {
-    fsExtra.emptyDirSync(tempDir);
+    emptyTempDir(tempDir, 'global beforeEach');
 });
 
 afterEach(() => {
-    fsExtra.removeSync(tempDir);
+    removeTempDir(tempDir, 'global afterEach');
 });
 
 /**


### PR DESCRIPTION
Diagnostic for the intermittent Windows CI failure where a test's `afterEach` fails to delete the shared `.tmp` dir:

```
Error: ENOTEMPTY: directory not empty, rmdir '...\.tmp'
```

The victim spec varies (LocationManager, BreakpointManager, ...) and it only happens on Windows, which means an earlier test leaves a file/handle open in the shared `.tmp` and whichever teardown runs while it's held is the one that throws. We can't tell *which* leftovers are locking it from the failure alone.

This wraps the `.tmp` remove/empty calls in the global teardown and the specs that share the dir with a helper that, on failure, logs every path still present under `.tmp` (and which teardown hit it), then re-throws. It diagnoses the failure without masking it.

- No production code changes; test-infra only.
- Silent on success (verified: full suite passes locally with zero diagnostic output).
- Intended to be reverted once the next Windows failure names the offending leftovers.
