### PR TITLE
Fix ~30s delay when stopping a Perfetto recording

### DIFF
--- a/src/PerfettoManager.spec.ts
+++ b/src/PerfettoManager.spec.ts
@@ -35,6 +35,10 @@ describe('PerfettoManager', () => {
             // Simulate async close behavior with proper code and reason arguments
             process.nextTick(() => mockSocket.emit('close', 1000, Buffer.from('')));
         });
+        mockSocket.terminate = sinon.stub().callsFake(() => {
+            mockSocket.readyState = WebSocket.CLOSED;
+            process.nextTick(() => mockSocket.emit('close', 1006, Buffer.from('')));
+        });
         mockSocket.ping = sinon.stub();
         mockSocket.pause = sinon.stub();
         mockSocket.resume = sinon.stub();
@@ -221,6 +225,84 @@ describe('PerfettoManager', () => {
             expect(perfettoManager['writeStream']).to.be.null;
             expect(perfettoManager['pingTimer']).to.be.null;
             expect(perfettoManager['filePath']).to.be.undefined;
+        });
+
+        it('terminates after the stream goes quiet when the device never sends a close frame', async () => {
+            const clock = sinon.useFakeTimers();
+            try {
+                // Mimic the real device: close() halts the stream but the device never sends a close frame back,
+                // so 'close' only fires once we terminate. A plain close() would otherwise hang on the ws closeTimeout.
+                const deviceSocket: any = new EventEmitter();
+                deviceSocket.readyState = WebSocket.OPEN;
+                deviceSocket.close = sinon.stub();
+                deviceSocket.pause = sinon.stub();
+                deviceSocket.resume = sinon.stub();
+                deviceSocket.terminate = sinon.stub().callsFake(() => {
+                    deviceSocket.readyState = WebSocket.CLOSED;
+                    deviceSocket.emit('close', 1006, Buffer.from(''));
+                });
+
+                perfettoManager['socket'] = deviceSocket;
+                perfettoManager['writeStream'] = mockWriteStream;
+                perfettoManager['filePath'] = s`${tempDir}/profiling/test.perfetto-trace`;
+                // pretend a trace message just arrived so the quiet window must elapse before we close
+                perfettoManager['lastMessageTime'] = Date.now();
+
+                const stopPromise = perfettoManager.stopTracing();
+
+                // within the quiet window: the close frame is sent but we have not terminated yet
+                await clock.tickAsync(100);
+                expect(deviceSocket.close.called, 'should send the close frame').to.be.true;
+                expect(deviceSocket.terminate.called, 'should not terminate within the quiet window').to.be.false;
+
+                // once the stream has been silent past the quiet window, force-terminate so 'close' fires immediately
+                await clock.tickAsync(500);
+                expect(deviceSocket.terminate.called, 'should terminate after the quiet window').to.be.true;
+
+                await stopPromise;
+                expect(perfettoManager['socket']).to.be.null;
+            } finally {
+                clock.restore();
+            }
+        });
+
+        it('terminates at the ceiling if the device never stops streaming', async () => {
+            const clock = sinon.useFakeTimers();
+            try {
+                const deviceSocket: any = new EventEmitter();
+                deviceSocket.readyState = WebSocket.OPEN;
+                deviceSocket.close = sinon.stub();
+                deviceSocket.pause = sinon.stub();
+                deviceSocket.resume = sinon.stub();
+                deviceSocket.terminate = sinon.stub().callsFake(() => {
+                    deviceSocket.readyState = WebSocket.CLOSED;
+                    deviceSocket.emit('close', 1006, Buffer.from(''));
+                });
+
+                perfettoManager['socket'] = deviceSocket;
+                perfettoManager['writeStream'] = mockWriteStream;
+                perfettoManager['filePath'] = s`${tempDir}/profiling/test.perfetto-trace`;
+
+                const stopPromise = perfettoManager.stopTracing();
+
+                // keep the stream "alive" so the quiet window never elapses
+                const keepAlive = setInterval(() => {
+                    perfettoManager['lastMessageTime'] = Date.now();
+                }, 50);
+
+                // before the ceiling we should still be waiting
+                await clock.tickAsync(2000);
+                expect(deviceSocket.terminate.called, 'should still be waiting before the ceiling').to.be.false;
+
+                // past the 3s ceiling we force-terminate regardless of ongoing data
+                await clock.tickAsync(1100);
+                clearInterval(keepAlive);
+                expect(deviceSocket.terminate.called, 'should terminate at the ceiling').to.be.true;
+
+                await stopPromise;
+            } finally {
+                clock.restore();
+            }
         });
     });
 

--- a/src/PerfettoManager.ts
+++ b/src/PerfettoManager.ts
@@ -25,6 +25,17 @@ interface PerfettoConfig {
 
 export class PerfettoManager {
 
+    /**
+     * How long the trace stream must be silent before we consider the device finished and close the socket.
+     * Must comfortably exceed the device's counter cadence (~250ms) so a normal gap between samples isn't mistaken for "done".
+     */
+    private static readonly stopQuietWindowMs = 500;
+
+    /**
+     * Hard ceiling on how long we'll wait for the stream to go quiet after initiating close, in case a device never stops streaming.
+     */
+    private static readonly stopCeilingMs = 3000;
+
     public constructor(config?: PerfettoConfig) {
         this.config = config ?? {} as any;
         this.config.remotePort ??= 8060;
@@ -39,6 +50,12 @@ export class PerfettoManager {
     private writeStream: fs.WriteStream | null = null;
     private pingTimer: NodeJS.Timeout | null = null;
     private emitter = new EventEmitter();
+
+    /**
+     * Timestamp (ms) of the most recent trace message written to disk. Used when stopping to detect when the
+     * device has gone quiet so we can close without waiting on the WebSocket closing handshake.
+     */
+    private lastMessageTime = 0;
 
     /**
      * When tracing is active, this is the file we're currently writing to. Cleaned up whenever tracing stops or errors.
@@ -148,23 +165,27 @@ export class PerfettoManager {
             //register our general error handler next (so it'll be called second, and we can disconnect it if we get a connect error
             const onError = (error: Error) => {
                 this.emitError(error);
-                // Force-close the socket so the 'close' handler fires cleanup + stop event
-                this.socket?.close();
+                // Force-terminate the socket so the 'close' handler fires cleanup + stop event immediately
+                this.socket?.terminate();
             };
             this.socket.on('error', onError);
 
-            let backpressured = false;
+            // `write` returns false when the write stream's buffer is full, i.e. the device is sending trace data
+            // faster than we can persist it to disk. When that happens we pause the socket (applying backpressure so
+            // the device stops sending) until the buffer drains, then resume. The `awaitingDrain` latch means we attach
+            // only a single 'drain' listener no matter how many messages arrive in the same batch while the buffer is full.
+            let awaitingDrain = false;
             this.socket.on('message', (data: any, isBinary: boolean) => {
                 if (!isBinary || !this.writeStream) {
                     return;
                 }
-                // Write the binary data to the file, handling backpressure by pausing the socket if the internal buffer is full
-                //only the FIRST message that causes backpressure should subscribe to the 'drain' event, to avoid multiple listeners
-                if (!this.writeStream.write(data) && !backpressured) {
-                    backpressured = true;
+                this.lastMessageTime = Date.now();
+                const bufferHasRoom = this.writeStream.write(data);
+                if (!bufferHasRoom && !awaitingDrain) {
+                    awaitingDrain = true;
                     this.socket?.pause();
                     this.writeStream.once('drain', () => {
-                        backpressured = false;
+                        awaitingDrain = false;
                         this.socket?.resume();
                     });
                 }
@@ -337,6 +358,38 @@ export class PerfettoManager {
     }
 
     /**
+     * Close the trace socket without hanging on the WebSocket closing handshake.
+     *
+     * The Roku `/perfetto-session` server stops streaming the instant it receives our close frame, but it never sends
+     * a close frame back, so a plain `socket.close()` would block for the full `ws` close timeout (~30s) before the
+     * socket is force-destroyed. Instead we send the close frame, wait for the trace stream to go quiet (capturing any
+     * final flush from the device), then terminate the socket so the 'close' event fires immediately. A hard ceiling
+     * guards against a device that never stops streaming.
+     */
+    private closeSocket(socket: WebSocket): Promise<void> {
+        return new Promise<void>(resolve => {
+            const startTime = Date.now();
+            const timer = setInterval(() => {
+                const now = Date.now();
+                //the device has finished sending once no trace message has arrived for the quiet window
+                const streamWentQuiet = now - this.lastMessageTime >= PerfettoManager.stopQuietWindowMs;
+                //backstop: give up waiting if a device keeps streaming and never goes quiet
+                const hitCeiling = now - startTime >= PerfettoManager.stopCeilingMs;
+                if (streamWentQuiet || hitCeiling) {
+                    clearInterval(timer);
+                    socket.terminate();
+                }
+            }, 50);
+            socket.once('close', () => {
+                clearInterval(timer);
+                resolve();
+            });
+            //send the close frame; the device reacts by halting the trace stream
+            socket.close();
+        });
+    }
+
+    /**
      * Clean up all resources. Safe to call multiple times.
      * When isCrash is true, destroys the write stream immediately instead of flushing it.
      */
@@ -350,10 +403,7 @@ export class PerfettoManager {
             const socket = this.socket;
             this.socket = null;
             if (socket.readyState !== WebSocket.CLOSED) {
-                await new Promise<void>(resolve => {
-                    socket.once('close', resolve);
-                    socket.close();
-                });
+                await this.closeSocket(socket);
             }
             socket.removeAllListeners();
         }

--- a/src/PerfettoManagerIntegration.spec.ts
+++ b/src/PerfettoManagerIntegration.spec.ts
@@ -35,6 +35,10 @@ describe('Profiling/Tracing Integration Tests', () => {
         mockSocket.close = sinon.stub().callsFake(() => {
             process.nextTick(() => mockSocket.emit('close'));
         });
+        mockSocket.terminate = sinon.stub().callsFake(() => {
+            mockSocket.readyState = WebSocket.CLOSED;
+            process.nextTick(() => mockSocket.emit('close'));
+        });
         mockSocket.ping = sinon.stub();
         mockSocket.pause = sinon.stub();
         mockSocket.resume = sinon.stub();


### PR DESCRIPTION
## Problem

Stopping a Perfetto recording takes ~30s before the trace becomes available, regardless of trace size.

The Roku `/perfetto-session` WebSocket server stops streaming the moment it receives the client's close frame, but it never sends a close frame back to complete the closing handshake. As a result, `socket.close()` blocks for the full `ws` `closeTimeout` (30,000ms) before the socket is force-destroyed and the `'close'` event fires. Verified on firmware 15.3.4: 0 bytes arrive after the client close, and the socket finally closes 30,007ms later with code 1006.

## Fix

`PerfettoManager` now closes the trace socket without waiting on the handshake: send the close frame, wait for the trace stream to go quiet (so any final flush is captured), then `terminate()` the socket so `'close'` fires immediately. A hard ceiling guards against a device that never goes quiet, and the error path terminates rather than closing. Stop now completes in ~0.5s (validated on hardware, no data lost, device accepts a new trace session right after).

## Tests

Adds regression coverage for the device-never-sends-a-close-frame case and the never-goes-quiet ceiling case. The previous integration mock auto-emitted `'close'` on `close()`, which masked the bug.

## Note

This addresses the close-handshake delay only. The separate buffer-flush-on-stop data-loss issue is being left to a device-side fix.