### PR TITLE
Retry temp-dir deletes in test teardown to clear transient Windows locks

### DIFF
--- a/src/managers/BreakpointManager.spec.ts
+++ b/src/managers/BreakpointManager.spec.ts
@@ -101,9 +101,9 @@ describe('BreakpointManager', () => {
         );
     });
 
-    afterEach(() => {
+    afterEach(async () => {
         sinon.restore();
-        forceDeleteDir(tmpDir);
+        await forceDeleteDir(tmpDir);
     });
 
     describe('reset', () => {
@@ -414,8 +414,8 @@ describe('BreakpointManager', () => {
             fsExtra.ensureDirSync(`${sourceDir2}/source`);
         });
 
-        afterEach(() => {
-            forceDeleteDir(tmpDir);
+        afterEach(async () => {
+            await forceDeleteDir(tmpDir);
         });
 
         it('works with normal flow', async () => {

--- a/src/managers/LocationManager.spec.ts
+++ b/src/managers/LocationManager.spec.ts
@@ -18,18 +18,18 @@ const sourceDirs = [
 describe('LocationManager', () => {
     let locationManager: LocationManager;
     let sourceMapManager: SourceMapManager;
-    beforeEach(() => {
+    beforeEach(async () => {
         sourceMapManager = new SourceMapManager();
         locationManager = new LocationManager(sourceMapManager);
-        forceDeleteDir(tempDir);
+        await forceDeleteDir(tempDir);
         fsExtra.ensureDirSync(`${rootDir}/source`);
         fsExtra.ensureDirSync(`${stagingDir}/source`);
         for (let sourceDir of sourceDirs) {
             fsExtra.ensureDirSync(`${sourceDir}/source`);
         }
     });
-    afterEach(() => {
-        forceDeleteDir(tempDir);
+    afterEach(async () => {
+        await forceDeleteDir(tempDir);
     });
     describe('getSourceLocation', () => {
 

--- a/src/managers/ProjectManager.spec.ts
+++ b/src/managers/ProjectManager.spec.ts
@@ -24,13 +24,13 @@ let stagingDir = s`${outDir}/stagingDir`;
 let compLibOutDir = s`${outDir}/component-libraries`;
 let compLibstagingDir = s`${rootDir}/component-libraries/CompLibA`;
 
-beforeEach(() => {
-    forceDeleteDir(tempPath);
+beforeEach(async () => {
+    await forceDeleteDir(tempPath);
     fsExtra.ensureDirSync(tempPath);
     sinon.restore();
 });
-afterEach(() => {
-    forceDeleteDir(tempPath);
+afterEach(async () => {
+    await forceDeleteDir(tempPath);
     fsExtra.ensureDirSync(tempPath);
 });
 
@@ -431,9 +431,9 @@ describe('Project', () => {
     });
 
     describe('stage', () => {
-        afterEach(() => {
+        afterEach(async () => {
             try {
-                forceDeleteDir(tempPath);
+                await forceDeleteDir(tempPath);
             } catch (e) { }
         });
         it('actually stages the project', async () => {
@@ -541,9 +541,9 @@ describe('Project', () => {
     });
 
     describe('preprocessStagingFiles', () => {
-        afterEach(() => {
+        afterEach(async () => {
             try {
-                forceDeleteDir(tempPath);
+                await forceDeleteDir(tempPath);
             } catch (e) { }
         });
 
@@ -1323,9 +1323,9 @@ describe('Project', () => {
     });
 
     describe('scriptReferencedFiles', () => {
-        afterEach(() => {
+        afterEach(async () => {
             try {
-                forceDeleteDir(tempPath);
+                await forceDeleteDir(tempPath);
             } catch (e) { }
         });
 
@@ -1488,16 +1488,16 @@ describe('Project', () => {
         before(() => {
             fsExtra.writeFileSync(raleTrackerTaskFileLocation, `<!--dummy contents-->`);
         });
-        after(() => {
-            forceDeleteDir(tempPath);
+        after(async () => {
+            await forceDeleteDir(tempPath);
             fsExtra.removeSync(raleTrackerTaskFileLocation);
         });
-        afterEach(() => {
-            forceDeleteDir(tempPath);
+        afterEach(async () => {
+            await forceDeleteDir(tempPath);
         });
 
         async function doTest(fileContents: string, expectedContents: string, fileExt = 'brs') {
-            forceDeleteDir(tempPath);
+            await forceDeleteDir(tempPath);
             fsExtra.ensureDirSync(tempPath);
             let folder = s`${tempPath}/findMainFunctionTests/`;
             fsExtra.mkdirSync(folder);
@@ -1600,17 +1600,17 @@ describe('Project', () => {
             fsExtra.mkdirSync(path.dirname(componentsFilePath), { recursive: true });
             fsExtra.writeFileSync(componentsFilePath, `' ${componentsFilePath}`);
         });
-        after(() => {
-            forceDeleteDir(tempPath);
+        after(async () => {
+            await forceDeleteDir(tempPath);
             fsExtra.emptyDirSync(rdbFilesBasePath);
             fsExtra.rmdirSync(rdbFilesBasePath);
         });
-        afterEach(() => {
-            forceDeleteDir(tempPath);
+        afterEach(async () => {
+            await forceDeleteDir(tempPath);
         });
 
         async function doTest(fileContents: string, expectedContents: string, fileExt = 'brs', injectRdbOnDeviceComponent = true) {
-            forceDeleteDir(tempPath);
+            await forceDeleteDir(tempPath);
             fsExtra.ensureDirSync(tempPath);
             let folder = s`${tempPath}/findMainFunctionTests/`;
             fsExtra.mkdirSync(folder);
@@ -1637,7 +1637,7 @@ describe('Project', () => {
         //which fast-glob treats as escape characters. Without normalization, the glob
         //matches nothing and no files get copied.
         it('copies the RDB files when rdbFilesBasePath is an absolute path with native separators', async () => {
-            forceDeleteDir(tempPath);
+            await forceDeleteDir(tempPath);
             fsExtra.ensureDirSync(tempPath);
             let folder = s`${tempPath}/copyAndTransformRDBTests/`;
             fsExtra.mkdirSync(folder);
@@ -1660,7 +1660,7 @@ describe('Project', () => {
         });
 
         it('does not copy files when injectRdbOnDeviceComponent is false', async () => {
-            forceDeleteDir(tempPath);
+            await forceDeleteDir(tempPath);
             fsExtra.ensureDirSync(tempPath);
             let folder = s`${tempPath}/copyAndTransformRDBTests/`;
             fsExtra.mkdirSync(folder);
@@ -1683,7 +1683,7 @@ describe('Project', () => {
         });
 
         it('does not copy files when rdbFilesBasePath is not set', async () => {
-            forceDeleteDir(tempPath);
+            await forceDeleteDir(tempPath);
             fsExtra.ensureDirSync(tempPath);
             let folder = s`${tempPath}/copyAndTransformRDBTests/`;
             fsExtra.mkdirSync(folder);

--- a/src/managers/SourceMapManager.spec.ts
+++ b/src/managers/SourceMapManager.spec.ts
@@ -13,8 +13,8 @@ describe('SourceMapManager', () => {
         fsExtra.ensureDirSync(tmpPath);
         manager = new SourceMapManager();
     });
-    afterEach(() => {
-        forceDeleteDir(tmpPath);
+    afterEach(async () => {
+        await forceDeleteDir(tmpPath);
     });
 
     it('constructs', () => {

--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -4,6 +4,7 @@ import * as fsExtra from 'fs-extra';
 import { SmartBuffer } from 'smart-buffer';
 import { bscProjectWorkerPool } from './bsc/threading/BscProjectWorkerPool';
 import { DisallowedFunctionIdentifiersText, standardizePath as s } from 'brighterscript';
+import { util } from './util';
 
 export const tempDir = s`${__dirname}/../.tmp`;
 export const rootDir = s`${tempDir}/rootDir`;
@@ -39,25 +40,33 @@ function listDirContents(dir: string): string[] {
 }
 
 /**
- * Delete a directory, retrying a few times to get past transient locks (most often a Windows file
- * handle still held open by an earlier test). If every attempt fails, log the paths still present
- * along with a stack trace so CI shows which leftovers blocked the delete, then re-throw the final error.
+ * Delete a directory, retrying to get past transient locks. When an earlier test leaves a file handle
+ * open, Windows keeps the directory entry around until that handle closes, which surfaces as
+ * ENOTEMPTY/EBUSY/EPERM on rmdir; waiting and retrying gives the handle time to close and the OS time to
+ * release it. If every attempt still fails, log the paths still present along with the error message and
+ * stack trace so CI shows which leftovers blocked the delete, then re-throw the final error.
  * @param dir the directory to delete
- * @param options.retryCount how many times to attempt the delete before giving up (defaults to 1)
+ * @param options.retryCount how many times to attempt the delete before giving up (defaults to 10)
+ * @param options.retryDelay milliseconds to wait between attempts, scaled by the attempt number (defaults to 100)
  * @param options.label optional label included in the diagnostic output to identify the calling teardown
  */
-export function forceDeleteDir(dir: string, options?: { retryCount?: number; label?: string }) {
-    const retryCount = options?.retryCount ?? 1;
-    const prefix = options?.label ? `[forceDeleteDir ${options.label}]` : '[forceDeleteDir]';
+export async function forceDeleteDir(dir: string, options?: { retryCount?: number; retryDelay?: number; label?: string }) {
+    const retryCount = options?.retryCount ?? 10;
+    const retryDelay = options?.retryDelay ?? 100;
     let lastError: Error;
     for (let attempt = 1; attempt <= retryCount; attempt++) {
         try {
-            fsExtra.removeSync(dir);
+            await fsExtra.remove(dir);
             return;
         } catch (error) {
             lastError = error as Error;
+            //wait a bit longer each attempt to give any lingering handle time to close
+            if (attempt < retryCount) {
+                await util.sleep(attempt * retryDelay);
+            }
         }
     }
+    const prefix = options?.label ? `[forceDeleteDir ${options.label}]` : '[forceDeleteDir]';
     const leftovers = listDirContents(dir);
     console.error(`${prefix} failed to delete '${dir}' after ${retryCount} attempt(s); ${leftovers.length} path(s) still present:`);
     for (const leftover of leftovers) {
@@ -70,13 +79,13 @@ export function forceDeleteDir(dir: string, options?: { retryCount?: number; lab
     throw lastError;
 }
 
-beforeEach(() => {
-    forceDeleteDir(tempDir);
+beforeEach(async () => {
+    await forceDeleteDir(tempDir);
     fsExtra.ensureDirSync(tempDir);
 });
 
-afterEach(() => {
-    forceDeleteDir(tempDir);
+afterEach(async () => {
+    await forceDeleteDir(tempDir);
 });
 
 /**


### PR DESCRIPTION
Follow-up to #368. That PR added `forceDeleteDir` to diagnose the intermittent Windows CI failure where a test's teardown couldn't delete the shared `.tmp` dir (`ENOTEMPTY: directory not empty, rmdir ...`). The diagnostics confirmed the cause: an earlier test leaves a file handle open, so Windows keeps the directory entry around until that handle closes.

This makes `forceDeleteDir` recover from that instead of just reporting it:

- Retries the delete with a linear backoff (10 attempts, 100ms base), giving any lingering handle time to close before the `rmdir`.
- Async, awaiting `util.sleep` between attempts so pending handle-close callbacks can run during the wait; a synchronous wait would block the event loop and prevent the handle from closing. All call sites updated to await it.
- Still logs the remaining paths plus the error message and stack, then re-throws, if every attempt fails.