### PR TITLE
Report empty Perfetto trace files on stop

### DIFF
--- a/src/PerfettoManager.spec.ts
+++ b/src/PerfettoManager.spec.ts
@@ -709,14 +709,7 @@ describe('PerfettoManager', () => {
             expect(result).to.equal('/tmp/traces/test.perfetto-trace');
         });
 
-        it('returns undefined when file is empty and skipEmpty is true', () => {
-            sinon.stub(fs, 'statSync').returns({ size: 0 } as any);
-
-            const result = (perfettoManager as any).getResult('/tmp/traces/test.perfetto-trace', { skipEmpty: true });
-            expect(result).to.be.undefined;
-        });
-
-        it('returns filePath when file is empty but skipEmpty is false', () => {
+        it('returns filePath when file is empty (empty traces are still reported)', () => {
             sinon.stub(fs, 'statSync').returns({ size: 0 } as any);
 
             const result = (perfettoManager as any).getResult('/tmp/traces/test.perfetto-trace');

--- a/src/PerfettoManager.ts
+++ b/src/PerfettoManager.ts
@@ -199,7 +199,7 @@ export class PerfettoManager {
                         type: 'trace',
                         result: options?.excludeResultOnStop
                             ? undefined
-                            : this.getResult(filePath, { skipEmpty: true })
+                            : this.getResult(filePath)
                     });
                 }).catch(e => this.logger.error(e));
             });
@@ -421,17 +421,15 @@ export class PerfettoManager {
     }
 
     /**
-     * Get a file path if it exists, optionally skipping empty files.
+     * Get the file path if it exists on disk, otherwise undefined. Empty trace files are still reported; the
+     * client (VS Code) renders a dedicated empty-state for zero-byte traces.
      */
-    private getResult(filePath: string | undefined, options?: { skipEmpty?: boolean }): string | undefined {
+    private getResult(filePath: string | undefined): string | undefined {
         if (!filePath) {
             return undefined;
         }
         try {
-            const size = fs.statSync(filePath).size;
-            if (options?.skipEmpty && size === 0) {
-                return undefined;
-            }
+            fs.statSync(filePath);
             return filePath;
         } catch {
             return undefined;
@@ -476,7 +474,7 @@ export class PerfettoManager {
             this.emit('stop', {
                 type: 'heapSnapshot',
                 result: thisFunctionStartedTracing
-                    ? this.getResult(filePath, { skipEmpty: true })
+                    ? this.getResult(filePath)
                     : undefined
             });
 


### PR DESCRIPTION
Previously `PerfettoManager` skipped reporting the trace file path when the file was empty, so an empty trace produced no result and never opened. VS Code now renders a dedicated empty-state for zero-byte traces (rokucommunity/vscode-brightscript-language#831), so drop the `skipEmpty` guard and report the file path whenever it exists on disk.