### PR TITLE
Add per-component-library option to disable file postfixing

### DIFF
--- a/src/LaunchConfiguration.ts
+++ b/src/LaunchConfiguration.ts
@@ -427,6 +427,13 @@ export interface ComponentLibraryConfiguration {
      */
     install: boolean;
     /**
+     * Should this component library's `.brs` files be renamed with a `__lib<index>` postfix during staging?
+     * Postfixing lets the debugger map device-reported file paths back to the component library they came from.
+     * Set to `false` to leave file names untouched (for example, when the library loads files by a fixed name at
+     * runtime); source mapping for this library's files will be degraded while debugging. Defaults to `true`.
+     */
+    enablePostfix?: boolean;
+    /**
      * Task to run instead of roku-deploy to produce the .zip file that will be uploaded to the Roku.
      */
     packageTask?: string;

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -1395,6 +1395,7 @@ export class BrightScriptDebugSession extends LoggingDebugSession {
                     sourceDirs: componentLibrary.sourceDirs,
                     bsConst: componentLibrary.bsConst,
                     install: componentLibrary.install,
+                    enablePostfix: componentLibrary.enablePostfix,
                     injectRaleTrackerTask: componentLibrary.injectRaleTrackerTask,
                     raleTrackerTaskFileLocation: componentLibrary.raleTrackerTaskFileLocation,
                     libraryIndex: libraryIndex,

--- a/src/managers/ProjectManager.spec.ts
+++ b/src/managers/ProjectManager.spec.ts
@@ -341,6 +341,107 @@ describe('ProjectManager', () => {
             expect(info.project).to.equal(manager.mainProject);
             expect(info.absolutePath).to.equal(s`${stagingDir}/source/main.brs`);
         });
+
+        it('when two postfix-disabled component libraries contain the same file, uses component library order', async () => {
+            const disabledLib0 = new ComponentLibraryProject({
+                rootDir: rootDir,
+                outDir: compLibOutDir,
+                files: [],
+                stagingDir: s`${compLibOutDir}/complib0-staging`,
+                libraryIndex: 0,
+                outFile: 'complib0.zip',
+                enablePostfix: false,
+                enhanceREPLCompletions: false
+            });
+            const disabledLib1 = new ComponentLibraryProject({
+                rootDir: rootDir,
+                outDir: compLibOutDir,
+                files: [],
+                stagingDir: s`${compLibOutDir}/complib1-staging`,
+                libraryIndex: 1,
+                outFile: 'complib1.zip',
+                enablePostfix: false,
+                enhanceREPLCompletions: false
+            });
+            manager.componentLibraryProjects = [disabledLib1, disabledLib0];
+            manager.mainProject = <any>{ stagingDir: stagingDir };
+
+            fsExtra.outputFileSync(s`${disabledLib0.stagingDir}/source/shared.brs`, 'sub main()\nend sub');
+            fsExtra.outputFileSync(s`${disabledLib1.stagingDir}/source/shared.brs`, 'sub main()\nend sub');
+
+            const info = await manager.getStagingFileInfo('pkg:/source/shared.brs');
+            expect(info.project).to.equal(disabledLib1);
+            expect(info.absolutePath).to.equal(s`${disabledLib1.stagingDir}/source/shared.brs`);
+        });
+
+        it('when two postfixed component libraries contain the same source file, resolves each postfix to the matching library', async () => {
+            const enabledLib0 = new ComponentLibraryProject({
+                rootDir: rootDir,
+                outDir: compLibOutDir,
+                files: [],
+                stagingDir: s`${compLibOutDir}/complib0-staging`,
+                libraryIndex: 0,
+                outFile: 'complib0.zip',
+                enhanceREPLCompletions: false
+            });
+            const enabledLib1 = new ComponentLibraryProject({
+                rootDir: rootDir,
+                outDir: compLibOutDir,
+                files: [],
+                stagingDir: s`${compLibOutDir}/complib1-staging`,
+                libraryIndex: 1,
+                outFile: 'complib1.zip',
+                enhanceREPLCompletions: false
+            });
+            manager.componentLibraryProjects = [enabledLib1, enabledLib0];
+            manager.mainProject = <any>{ stagingDir: stagingDir };
+
+            fsExtra.outputFileSync(s`${enabledLib0.stagingDir}/source/shared__lib0.brs`, 'sub main()\nend sub');
+            fsExtra.outputFileSync(s`${enabledLib1.stagingDir}/source/shared__lib1.brs`, 'sub main()\nend sub');
+
+            const lib0Info = await manager.getStagingFileInfo('pkg:/source/shared__lib0.brs');
+            expect(lib0Info.project).to.equal(enabledLib0);
+            expect(lib0Info.absolutePath).to.equal(s`${enabledLib0.stagingDir}/source/shared__lib0.brs`);
+
+            const lib1Info = await manager.getStagingFileInfo('pkg:/source/shared__lib1.brs');
+            expect(lib1Info.project).to.equal(enabledLib1);
+            expect(lib1Info.absolutePath).to.equal(s`${enabledLib1.stagingDir}/source/shared__lib1.brs`);
+        });
+
+        it('resolves both mixed postfixed and non-postfixed duplicate filenames', async () => {
+            const disabledLib = new ComponentLibraryProject({
+                rootDir: rootDir,
+                outDir: compLibOutDir,
+                files: [],
+                stagingDir: s`${compLibOutDir}/complib0-staging`,
+                libraryIndex: 0,
+                outFile: 'complib0.zip',
+                enablePostfix: false,
+                enhanceREPLCompletions: false
+            });
+            const enabledLib = new ComponentLibraryProject({
+                rootDir: rootDir,
+                outDir: compLibOutDir,
+                files: [],
+                stagingDir: s`${compLibOutDir}/complib1-staging`,
+                libraryIndex: 1,
+                outFile: 'complib1.zip',
+                enhanceREPLCompletions: false
+            });
+            manager.componentLibraryProjects = [disabledLib, enabledLib];
+            manager.mainProject = <any>{ stagingDir: stagingDir };
+
+            fsExtra.outputFileSync(s`${disabledLib.stagingDir}/source/mixed.brs`, 'sub main()\nend sub');
+            fsExtra.outputFileSync(s`${enabledLib.stagingDir}/source/mixed__lib1.brs`, 'sub main()\nend sub');
+
+            const nonPostfixedInfo = await manager.getStagingFileInfo('pkg:/source/mixed.brs');
+            expect(nonPostfixedInfo.project).to.equal(disabledLib);
+            expect(nonPostfixedInfo.absolutePath).to.equal(s`${disabledLib.stagingDir}/source/mixed.brs`);
+
+            const postfixedInfo = await manager.getStagingFileInfo('pkg:/source/mixed__lib1.brs');
+            expect(postfixedInfo.project).to.equal(enabledLib);
+            expect(postfixedInfo.absolutePath).to.equal(s`${enabledLib.stagingDir}/source/mixed__lib1.brs`);
+        });
     });
 
     describe('getSourceLocation', () => {

--- a/src/managers/ProjectManager.spec.ts
+++ b/src/managers/ProjectManager.spec.ts
@@ -272,6 +272,75 @@ describe('ProjectManager', () => {
 
             expect(stub.called).to.be.true;
         });
+
+        it('falls back to a postfix-disabled component library when the file is not in the main project', async () => {
+            const disabledLib = new ComponentLibraryProject({
+                rootDir: rootDir,
+                outDir: compLibOutDir,
+                files: [],
+                stagingDir: s`${compLibOutDir}/complib0-staging`,
+                libraryIndex: 0,
+                outFile: 'complib0.zip',
+                enablePostfix: false,
+                enhanceREPLCompletions: false
+            });
+            manager.componentLibraryProjects = [disabledLib];
+            manager.mainProject = <any>{ stagingDir: stagingDir };
+
+            //the file exists only in the disabled library's staging dir (not the main project)
+            fsExtra.outputFileSync(s`${disabledLib.stagingDir}/source/main.brs`, 'sub main()\nend sub');
+
+            const info = await manager.getStagingFileInfo('pkg:/source/main.brs');
+            expect(info).to.include({
+                absolutePath: s`${disabledLib.stagingDir}/source/main.brs`,
+                relativePath: s`source/main.brs`
+            });
+            expect(info.project).to.equal(disabledLib);
+        });
+
+        it('prefers the main project over a postfix-disabled component library when both have the file', async () => {
+            const disabledLib = new ComponentLibraryProject({
+                rootDir: rootDir,
+                outDir: compLibOutDir,
+                files: [],
+                stagingDir: s`${compLibOutDir}/complib0-staging`,
+                libraryIndex: 0,
+                outFile: 'complib0.zip',
+                enablePostfix: false,
+                enhanceREPLCompletions: false
+            });
+            manager.componentLibraryProjects = [disabledLib];
+            manager.mainProject = <any>{ stagingDir: stagingDir };
+
+            fsExtra.outputFileSync(s`${stagingDir}/source/main.brs`, 'sub main()\nend sub');
+            fsExtra.outputFileSync(s`${disabledLib.stagingDir}/source/main.brs`, 'sub main()\nend sub');
+
+            const info = await manager.getStagingFileInfo('pkg:/source/main.brs');
+            expect(info.absolutePath).to.equal(s`${stagingDir}/source/main.brs`);
+            expect(info.project).to.equal(manager.mainProject);
+        });
+
+        it('does not fall back to a component library that still has postfixing enabled', async () => {
+            const enabledLib = new ComponentLibraryProject({
+                rootDir: rootDir,
+                outDir: compLibOutDir,
+                files: [],
+                stagingDir: s`${compLibOutDir}/complib0-staging`,
+                libraryIndex: 0,
+                outFile: 'complib0.zip',
+                enhanceREPLCompletions: false
+            });
+            manager.componentLibraryProjects = [enabledLib];
+            manager.mainProject = <any>{ stagingDir: stagingDir };
+
+            //even though an un-postfixed file is present in the enabled library, it must not be used as a fallback
+            fsExtra.outputFileSync(s`${enabledLib.stagingDir}/source/main.brs`, 'sub main()\nend sub');
+
+            const info = await manager.getStagingFileInfo('pkg:/source/main.brs');
+            //resolves to the main project (prior behavior preserved), not the postfix-enabled library
+            expect(info.project).to.equal(manager.mainProject);
+            expect(info.absolutePath).to.equal(s`${stagingDir}/source/main.brs`);
+        });
     });
 
     describe('getSourceLocation', () => {
@@ -1835,6 +1904,42 @@ describe('ComponentLibraryProject', () => {
             expect(project.outFile).to.equal('PrettyComponent.zip');
             (project as any).computeOutFileName();
             expect(project.outFile).to.equal('PrettyComponent.zip');
+        });
+    });
+
+    describe('postfix', () => {
+        it('defaults enablePostfix to true and includes the library index in the postfix', () => {
+            params.libraryIndex = 2;
+            let project = new ComponentLibraryProject(params);
+            expect(project.enablePostfix).to.be.true;
+            expect(project.postfix).to.equal('__lib2');
+        });
+
+        it('returns an empty postfix when postfixing is disabled', () => {
+            params.libraryIndex = 2;
+            params.enablePostfix = false;
+            let project = new ComponentLibraryProject(params);
+            expect(project.enablePostfix).to.be.false;
+            expect(project.postfix).to.equal('');
+        });
+
+        it('leaves files untouched when postfixing is disabled', async () => {
+            params.enablePostfix = false;
+            let project = new ComponentLibraryProject(params);
+            project.fileMappings = [];
+            fsExtra.outputFileSync(`${params.stagingDir}/source/main.brs`, '');
+            fsExtra.outputFileSync(`${params.stagingDir}/components/Component1.xml`, `
+                <component name="CustomComponent" extends="Rectangle">
+                    <script type="text/brightscript" uri="CustomComponent.brs"/>
+                </component>
+            `);
+            await project.postfixFiles();
+            //the file was not renamed
+            expect(fsExtra.pathExistsSync(`${params.stagingDir}/source/main.brs`)).to.be.true;
+            //the uri reference was not rewritten
+            expect(
+                fsExtra.readFileSync(`${params.stagingDir}/components/Component1.xml`).toString()
+            ).to.include('uri="CustomComponent.brs"');
         });
     });
 

--- a/src/managers/ProjectManager.ts
+++ b/src/managers/ProjectManager.ts
@@ -260,25 +260,50 @@ export class ProjectManager {
      * @return a full path to the file in the staging directory
      */
     public async getStagingFileInfo(debuggerPath: string) {
-        let project: Project;
-
         let componentLibraryIndex = fileUtils.getComponentLibraryIndexFromFileName(debuggerPath, componentLibraryPostfix);
-        //component libraries
+
+        //the path carries a `__lib<index>` postfix, so we know exactly which component library it belongs to
         if (componentLibraryIndex !== undefined) {
             let lib = this.componentLibraryProjects.find(x => x.libraryIndex === componentLibraryIndex);
-            if (lib) {
-                project = lib;
-            } else {
+            if (!lib) {
                 throw new Error(`There is no component library with index ${componentLibraryIndex}`);
             }
-            //standard project files
-        } else {
-            project = this.mainProject;
+            return this.buildStagingFileInfo(debuggerPath, lib);
         }
 
+        //No `__lib<index>` postfix on the path. It's either a main-project file, or a file from a
+        //component library that has postfixing disabled (those report device paths that look identical
+        //to the main project's). Try the main project first.
+        let stagingFileInfo = await this.buildStagingFileInfo(debuggerPath, this.mainProject);
+
+        //if the file actually exists in the main project, use it
+        if (stagingFileInfo && await fsExtra.pathExists(stagingFileInfo.absolutePath)) {
+            return stagingFileInfo;
+        }
+
+        //otherwise, fall back to any component library that has postfixing disabled, since those are the
+        //only other source of un-postfixed device paths. Use the first one that has the file on disk.
+        for (const lib of this.componentLibraryProjects) {
+            if (lib.enablePostfix === false) {
+                const libStagingFileInfo = await this.buildStagingFileInfo(debuggerPath, lib);
+                if (libStagingFileInfo && await fsExtra.pathExists(libStagingFileInfo.absolutePath)) {
+                    return libStagingFileInfo;
+                }
+            }
+        }
+
+        //nothing matched on disk; preserve prior behavior by returning the main-project result (if any)
+        return stagingFileInfo;
+    }
+
+    /**
+     * Resolve a debugger-reported path to a staging file within a specific project. Returns undefined if the
+     * path could not be mapped into that project's staging directory.
+     */
+    private async buildStagingFileInfo(debuggerPath: string, project: Project) {
         let relativePath: string;
 
-        //if the path starts with a scheme (i.e. pkg:/ or complib:/, we have an exact match.
+        //if the path starts with a scheme (i.e. pkg:/ or complib:/), we have an exact match.
         if (util.getFileScheme(debuggerPath)) {
             relativePath = util.removeFileScheme(debuggerPath);
         } else {
@@ -286,8 +311,7 @@ export class ProjectManager {
         }
         if (relativePath) {
             relativePath = fileUtils.removeLeadingSlash(
-                fileUtils.standardizePath(relativePath
-                )
+                fileUtils.standardizePath(relativePath)
             );
             return {
                 relativePath: relativePath,
@@ -971,6 +995,7 @@ export interface ComponentLibraryConstructorParams extends AddProjectParams {
     outFile: string;
     libraryIndex: number;
     install?: boolean;
+    enablePostfix?: boolean;
 }
 
 export class ComponentLibraryProject extends Project {
@@ -979,10 +1004,18 @@ export class ComponentLibraryProject extends Project {
         this.outFile = params.outFile;
         this.libraryIndex = params.libraryIndex;
         this.install = params.install ?? false;
+        this.enablePostfix = params.enablePostfix ?? true;
     }
     public outFile: string;
     public libraryIndex: number;
     public install: boolean;
+    /**
+     * Should this component library's `.brs` files be renamed with a `__lib<index>` postfix during staging?
+     * Postfixing is how the debugger maps a device-reported file path back to the component library it came
+     * from. When disabled, file names are left untouched (useful when a library loads files by a fixed name
+     * at runtime), at the cost of degraded source mapping for this library's files while debugging.
+     */
+    public enablePostfix: boolean;
     /**
      * The name of the component library that this project represents. This is loaded during `this.computeOutFileName`
      */
@@ -1057,10 +1090,16 @@ export class ComponentLibraryProject extends Project {
      * back to their original component library whenever the debugger truncates the file path.
      */
     public get postfix() {
-        return `${componentLibraryPostfix}${this.libraryIndex}`;
+        //when postfixing is disabled, return an empty postfix so all postfix-aware logic (file renaming,
+        //breakpoint path matching, source-location resolution) becomes a no-op for this library
+        return this.enablePostfix ? `${componentLibraryPostfix}${this.libraryIndex}` : '';
     }
 
     public async postfixFiles() {
+        //postfixing disabled for this library; leave file names and `uri=` references untouched
+        if (!this.enablePostfix) {
+            return;
+        }
         let pathDetails = {};
         await Promise.all(this.fileMappings.map(async (fileMapping) => {
             let relativePath = fileUtils.removeLeadingSlash(


### PR DESCRIPTION
Component library `.brs` files are renamed with a `__lib<index>` postfix during staging so the debugger can map device-reported paths back to the component library they came from. Some libraries need their file names left intact (for example, when a library loads files by a fixed name at runtime), and this postfixing breaks them.

This adds an `enablePostfix` flag (default `true`) to each component library. When set to `false`, the library's `postfix` resolves to an empty string, so file renaming, the `uri=` rewrite, breakpoint path matching, and source-location resolution all become no-ops together for that library.

Because an un-postfixed library reports device paths that look identical to the main project's, `getStagingFileInfo` now falls back to any postfix-disabled component library when a path isn't found in the main project, using the first one that has the file on disk.

Source mapping for a disabled library is degraded (its device paths can't be attributed by the `__lib` marker), but the library runs unchanged and nothing throws. The launch.json schema entry for this setting will follow in vscode-brightscript-language.