### PR TITLE
Accept device-info in the launch config to skip the device-info request

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
                 "postman-request": "^2.88.1-postman.48",
                 "replace-in-file": "^6.3.2",
                 "replace-last": "^1.2.6",
-                "roku-deploy": "^3.17.6",
+                "roku-deploy": "^3.17.7",
                 "semver": "^7.5.4",
                 "serialize-error": "^8.1.0",
                 "smart-buffer": "^4.2.0",
@@ -2076,11 +2076,6 @@
                 "node": "*"
             }
         },
-        "node_modules/dayjs": {
-            "version": "1.11.19",
-            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
-            "integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw=="
-        },
         "node_modules/debounce": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
@@ -3920,12 +3915,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/lodash": {
-            "version": "4.18.1",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-            "license": "MIT"
-        },
         "node_modules/lodash.flattendeep": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
@@ -4159,14 +4148,6 @@
             "license": "ISC",
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/moment": {
-            "version": "2.30.1",
-            "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-            "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/ms": {
@@ -4601,14 +4582,6 @@
             "dependencies": {
                 "callsites": "^3.0.0"
             },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/parse-ms": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
-            "integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==",
             "engines": {
                 "node": ">=6"
             }
@@ -5108,26 +5081,22 @@
             }
         },
         "node_modules/roku-deploy": {
-            "version": "3.17.6",
-            "resolved": "https://registry.npmjs.org/roku-deploy/-/roku-deploy-3.17.6.tgz",
-            "integrity": "sha512-5G28I0eNCpKCv34f6jCNvY8e746RE4uTWisGBZSiUqyKnraN6NIZo5VimNWMBajICCAqzUjpqLmJN9q5KXq8mw==",
+            "version": "3.17.7",
+            "resolved": "https://registry.npmjs.org/roku-deploy/-/roku-deploy-3.17.7.tgz",
+            "integrity": "sha512-aEgi9Vq8/D0NhJzY97CtEUUgUwfR0/F20QR/JIMKXKDxAYt8alfgV217WShTbnFMyYYnJflTMRCHP2bJBbriGQ==",
+            "license": "MIT",
             "dependencies": {
                 "@types/request": "^2.48.13",
                 "chalk": "^2.4.2",
-                "dateformat": "^3.0.3",
-                "dayjs": "^1.11.0",
                 "fast-glob": "^3.2.12",
                 "fs-extra": "^7.0.1",
                 "is-glob": "^4.0.3",
                 "jsonc-parser": "^2.3.0",
                 "jszip": "^3.6.0",
-                "lodash": "^4.17.21",
                 "micromatch": "^4.0.4",
-                "moment": "^2.29.1",
-                "parse-ms": "^2.1.0",
+                "picomatch": "^2.3.2",
                 "postman-request": "^2.88.1-postman.48",
                 "semver": "^7.7.3",
-                "temp-dir": "^2.0.0",
                 "xml2js": "^0.5.0"
             },
             "bin": {
@@ -5170,14 +5139,6 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
             "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
-        },
-        "node_modules/roku-deploy/node_modules/dateformat": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
-            "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
-            "engines": {
-                "node": "*"
-            }
         },
         "node_modules/roku-deploy/node_modules/escape-string-regexp": {
             "version": "1.0.5",
@@ -5794,14 +5755,6 @@
             "version": "3.7.2",
             "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
             "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
-        },
-        "node_modules/temp-dir": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
-            "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
-            "engines": {
-                "node": ">=8"
-            }
         },
         "node_modules/test-exclude": {
             "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
         "postman-request": "^2.88.1-postman.48",
         "replace-in-file": "^6.3.2",
         "replace-last": "^1.2.6",
-        "roku-deploy": "^3.17.6",
+        "roku-deploy": "^3.17.7",
         "semver": "^7.5.4",
         "serialize-error": "^8.1.0",
         "smart-buffer": "^4.2.0",

--- a/src/LaunchConfiguration.ts
+++ b/src/LaunchConfiguration.ts
@@ -1,4 +1,4 @@
-import type { FileEntry } from 'roku-deploy';
+import type { DeviceInfoRaw, FileEntry } from 'roku-deploy';
 import type { DebugProtocol } from '@vscode/debugprotocol';
 import type { LogLevel } from './logging';
 
@@ -14,6 +14,13 @@ export interface LaunchConfiguration extends DebugProtocol.LaunchRequestArgument
      * The host or ip address for the target Roku
      */
     host: string;
+
+    /**
+     * The raw `device-info` for the target Roku. When supplied, the debug session uses this instead of
+     * requesting `device-info` from the device over the network. The client (i.e. the vscode extension)
+     * can populate this from device info it already gathered to avoid a redundant network round-trip.
+     */
+    deviceInfo?: DeviceInfoRaw;
 
     /**
      * The password for the developer page on the target Roku

--- a/src/debugSession/BrightScriptDebugSession.spec.ts
+++ b/src/debugSession/BrightScriptDebugSession.spec.ts
@@ -2948,6 +2948,44 @@ describe('BrightScriptDebugSession', () => {
             rokuAdapter.connected = true;
         }
 
+        describe('device info', () => {
+            it('uses device info supplied in the launch config instead of requesting it from the device', async function() {
+                this.timeout(5000);
+                setupLaunchStubs();
+                const getDeviceInfoStub = rokuDeploy.getDeviceInfo as sinon.SinonStub;
+
+                launchConfiguration.host = '1.2.3.4';
+                launchConfiguration.deviceInfo = {
+                    'developer-enabled': 'true',
+                    'software-version': '11.5.0',
+                    'software-build': '4170'
+                };
+
+                await session.launchRequest({} as any, launchConfiguration);
+
+                //should not have requested device info from the device over the network
+                expect(getDeviceInfoStub.called).to.be.false;
+                //device info should be the normalized (enhanced) form of the supplied raw data
+                expect(session.deviceInfo).to.include({
+                    developerEnabled: true,
+                    softwareVersion: '11.5.0',
+                    softwareBuild: 4170
+                });
+            });
+
+            it('requests device info from the device when none is supplied in the launch config', async function() {
+                this.timeout(5000);
+                setupLaunchStubs();
+                const getDeviceInfoStub = rokuDeploy.getDeviceInfo as sinon.SinonStub;
+
+                launchConfiguration.host = '1.2.3.4';
+
+                await session.launchRequest({} as any, launchConfiguration);
+
+                expect(getDeviceInfoStub.called).to.be.true;
+            });
+        });
+
         describe('progress events', () => {
             let events: any[];
 

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -589,10 +589,9 @@ export class BrightScriptDebugSession extends LoggingDebugSession {
                 return this.shutdown(`Could not resolve ip address for host '${this.launchConfiguration.host}'`);
             }
 
-            // fetches the device info and parses the xml data to JSON object
+            // fetche device info if not supplied via launch config
             try {
                 if (this.launchConfiguration.deviceInfo) {
-                    // device info was supplied in the launch config; enhance it locally instead of requesting it from the device over the network
                     this.deviceInfo = rokuDeploy.enhanceDeviceInfo(this.launchConfiguration.deviceInfo);
                 } else {
                     this.deviceInfo = await rokuDeploy.getDeviceInfo({ host: this.launchConfiguration.host, remotePort: this.launchConfiguration.remotePort, enhance: true, timeout: 4_000 });

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -593,7 +593,7 @@ export class BrightScriptDebugSession extends LoggingDebugSession {
             try {
                 if (this.launchConfiguration.deviceInfo) {
                     // device info was supplied in the launch config; enhance it locally instead of requesting it from the device over the network
-                    this.deviceInfo = rokuDeploy.normalizeDeviceInfo(this.launchConfiguration.deviceInfo);
+                    this.deviceInfo = rokuDeploy.enhanceDeviceInfo(this.launchConfiguration.deviceInfo);
                 } else {
                     this.deviceInfo = await rokuDeploy.getDeviceInfo({ host: this.launchConfiguration.host, remotePort: this.launchConfiguration.remotePort, enhance: true, timeout: 4_000 });
                 }

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -591,7 +591,12 @@ export class BrightScriptDebugSession extends LoggingDebugSession {
 
             // fetches the device info and parses the xml data to JSON object
             try {
-                this.deviceInfo = await rokuDeploy.getDeviceInfo({ host: this.launchConfiguration.host, remotePort: this.launchConfiguration.remotePort, enhance: true, timeout: 4_000 });
+                if (this.launchConfiguration.deviceInfo) {
+                    // device info was supplied in the launch config; enhance it locally instead of requesting it from the device over the network
+                    this.deviceInfo = rokuDeploy.normalizeDeviceInfo(this.launchConfiguration.deviceInfo);
+                } else {
+                    this.deviceInfo = await rokuDeploy.getDeviceInfo({ host: this.launchConfiguration.host, remotePort: this.launchConfiguration.remotePort, enhance: true, timeout: 4_000 });
+                }
                 if (this.deviceInfo.ecpSettingMode === 'limited') {
                     return await this.shutdown(`ECP access is limited on this Roku. Please change it to 'permissive' or 'enabled' and try again. (device: ${this.launchConfiguration.host})`);
                 }

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -589,7 +589,7 @@ export class BrightScriptDebugSession extends LoggingDebugSession {
                 return this.shutdown(`Could not resolve ip address for host '${this.launchConfiguration.host}'`);
             }
 
-            // fetche device info if not supplied via launch config
+            // fetch device info if not supplied via launch config
             try {
                 if (this.launchConfiguration.deviceInfo) {
                     this.deviceInfo = rokuDeploy.enhanceDeviceInfo(this.launchConfiguration.deviceInfo);


### PR DESCRIPTION
Adds an optional `deviceInfo` (`DeviceInfoRaw`) to the launch configuration. When supplied, the debug session enhances it via roku-deploy's `enhanceDeviceInfo` instead of requesting `device-info` from the device over the network. When not supplied, it falls back to the network request as before.

Depends on rokucommunity/roku-deploy#300 for `enhanceDeviceInfo`.

Paired with the vscode extension change that populates this field from device-info it already gathered while probing the host.