### PR TITLE
Cache the staging relative-path list so truncated-path lookups don't re-walk the tree

### DIFF
--- a/src/FileUtils.spec.ts
+++ b/src/FileUtils.spec.ts
@@ -89,6 +89,21 @@ describe('FileUtils', () => {
         it('returns undefined when no results found', async () => {
             expect(await fileUtils.findPartialFileInDirectory('...promise.brs', 'SomeAppDir')).to.be.undefined;
         });
+
+        it('uses the provided relativePaths instead of walking the tree', async () => {
+            //getAllRelativePaths is stubbed in beforeEach; if the provided list is used it should never be called
+            const getAllRelativePaths = fileUtils.getAllRelativePaths as sinonActual.SinonStub;
+            getAllRelativePaths.resetHistory();
+
+            const result = await fileUtils.findPartialFileInDirectory('...other/thing.brs', 'SomeAppDir', [
+                'source/main.brs',
+                'other/thing.brs'
+            ]);
+
+            expect(result).to.equal('other/thing.brs');
+            //it did NOT walk the tree
+            expect(getAllRelativePaths.called).to.be.false;
+        });
     });
 
     describe('getComponentLibraryIndex', () => {

--- a/src/FileUtils.ts
+++ b/src/FileUtils.ts
@@ -69,9 +69,12 @@ export class FileUtils {
      * match the partial file path
      * @param partialFilePath the partial file path to search for
      * @param directoryPath the path to the directory to search through
+     * @param relativePaths the pre-computed list of paths relative to `directoryPath` (from
+     * {@link getAllRelativePaths}). Pass this when resolving many partial paths against the same
+     * directory to avoid re-walking the tree on every call; the tree is walked here when omitted.
      * @returns a relative path to the first match found in the directory
      */
-    public async findPartialFileInDirectory(partialFilePath: string, directoryPath: string) {
+    public async findPartialFileInDirectory(partialFilePath: string, directoryPath: string, relativePaths?: string[]) {
         //the debugger path was truncated, so try and map it to a file in the outdir
         partialFilePath = this.standardizePath(
             this.removeFileTruncation(partialFilePath)
@@ -79,7 +82,7 @@ export class FileUtils {
 
         //find any files from the outDir that end the same as this file
         let results: string[] = [];
-        let relativePaths = await this.getAllRelativePaths(directoryPath);
+        relativePaths ??= await this.getAllRelativePaths(directoryPath);
         for (let relativePath of relativePaths) {
             //if the staging path looks like the debugger path, keep it for now
             if (this.pathEndsWith(relativePath, partialFilePath)) {

--- a/src/managers/ProjectManager.spec.ts
+++ b/src/managers/ProjectManager.spec.ts
@@ -612,6 +612,23 @@ describe('Project', () => {
         expect(project.rdbFilesBasePath).to.eql(rdbFilesBasePath);
     });
 
+    describe('getStagingRelativePaths', () => {
+        it('walks the staging tree only once and caches the result', async () => {
+            const getAllRelativePaths = sinon.stub(fileUtils, 'getAllRelativePaths').returns(Promise.resolve([
+                'source/main.brs',
+                'source/lib.brs'
+            ]));
+
+            const first = await project.getStagingRelativePaths();
+            const second = await project.getStagingRelativePaths();
+
+            expect(first).to.eql(['source/main.brs', 'source/lib.brs']);
+            //the second call returned the cached list without walking the tree again
+            expect(second).to.equal(first);
+            expect(getAllRelativePaths.callCount).to.equal(1);
+        });
+    });
+
     describe('stage', () => {
         afterEach(async () => {
             try {

--- a/src/managers/ProjectManager.ts
+++ b/src/managers/ProjectManager.ts
@@ -307,7 +307,13 @@ export class ProjectManager {
         if (util.getFileScheme(debuggerPath)) {
             relativePath = util.removeFileScheme(debuggerPath);
         } else {
-            relativePath = await fileUtils.findPartialFileInDirectory(debuggerPath, project.stagingDir);
+            //reuse the project's cached staging path list so we don't re-walk the staging tree on every
+            //truncated-path lookup (findPartialFileInDirectory walks the tree itself when the list is omitted)
+            relativePath = await fileUtils.findPartialFileInDirectory(
+                debuggerPath,
+                project.stagingDir,
+                await project.getStagingRelativePaths?.()
+            );
         }
         if (relativePath) {
             relativePath = fileUtils.removeLeadingSlash(
@@ -393,6 +399,23 @@ export class Project {
      * A BrighterScript project for the stagingDir
      */
     private stagingBscProject = new BscProjectThreaded();
+
+    /**
+     * Cached list of every file path in the staging dir, relative to {@link stagingDir}. Lazily computed
+     * on first use and reused for the life of this Project (a new Project is created per debug session, so
+     * this never goes stale within a session). Used to resolve truncated telnet debugger paths without
+     * re-walking the staging tree on every lookup.
+     */
+    private stagingRelativePathsPromise: Promise<string[]> | undefined;
+
+    /**
+     * Get every file path in the staging dir relative to {@link stagingDir}, walking the tree only once
+     * and caching the result for subsequent calls in this session.
+     */
+    public getStagingRelativePaths(): Promise<string[]> {
+        this.stagingRelativePathsPromise ??= fileUtils.getAllRelativePaths(this.stagingDir);
+        return this.stagingRelativePathsPromise;
+    }
 
     //the default project doesn't have a postfix, but component libraries will have a postfix, so just use empty string to standardize the postfix logic
     public get postfix() {


### PR DESCRIPTION
Resolving a truncated telnet debugger path goes through `findPartialFileInDirectory`, which walked the entire staging tree (`glob('**/*')`) on every call. During a session, each distinct truncated path triggered a fresh full walk.

- `findPartialFileInDirectory` now takes an optional pre-computed relative-path list and only walks the tree itself when the list is omitted.
- `Project` computes the staging relative-path list once per session (cached in `getStagingRelativePaths`), and `buildStagingFileInfo` passes it in.

The cache lives on `Project` (created fresh per debug session), so it can't go stale within a session, and a new session gets a fresh walk.
