### PR TITLE
Security enhancements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4499,12 +4499,13 @@
             }
         },
         "node_modules/qs": {
-            "version": "6.14.2",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-            "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+            "version": "6.15.3",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+            "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "side-channel": "^1.1.0"
+                "es-define-property": "^1.0.1",
+                "side-channel": "^1.1.1"
             },
             "engines": {
                 "node": ">=0.6"
@@ -5642,11 +5643,16 @@
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
         },
         "node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
             "bin": {
-                "uuid": "dist/bin/uuid"
+                "uuid": "dist/esm/bin/uuid"
             }
         },
         "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -97,7 +97,9 @@
         "undent": "^1.0.1"
     },
     "overrides": {
-        "serialize-javascript": "^7.0.5"
+        "serialize-javascript": "^7.0.5",
+        "qs": "^6.15.3",
+        "uuid": "^11.1.1"
     },
     "dependencies": {
         "@rokucommunity/logger": "^0.4.0",


### PR DESCRIPTION
## Summary
- \`postman-request\` (a direct production dependency) pins \`qs@~6.14.1\` and \`uuid@^8.3.2\`, both flagged: \`qs\` DoS (GHSA-q8mj-m7cp-5q26) and \`uuid\` missing buffer-bounds check (GHSA-w5hq-g745-h8pq)
- No newer \`postman-request\` release exists upstream that fixes either, so patched versions are forced via \`overrides\`
- Verified \`postman-request\` only ever calls \`uuid.v4()\` (auth.js, multipart.js, oauth.js) — unaffected by the v3/v5/v6 buffer-bounds bug the advisory covers, so the \`uuid@11.1.1\` override is safe
- The same \`uuid\` override also clears the dev-only \`nyc > istanbul-lib-processinfo > uuid\` chain

## Test plan
- [x] \`npm run audit\` passes (0 vulnerabilities)
- [x] \`npm run build\` passes
- [x] \`npm run lint\` passes
- [x] \`npm run test\` passes (1170 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)