### PR TITLE
Fail breakpoints only when unplaceable in every project

### DIFF
--- a/src/debugSession/BrightScriptDebugSession.spec.ts
+++ b/src/debugSession/BrightScriptDebugSession.spec.ts
@@ -1134,7 +1134,7 @@ describe('BrightScriptDebugSession', () => {
 
             //simulate "launch" — stage in launchRequest, then write breakpoints + zip in configurationDoneRequest
             await session.prepareMainProject();
-            await session['writeMainProjectBreakpoints']();
+            await session['writeBreakpoints']();
             await session['zipMainProject']();
 
             //remove the breakpoint
@@ -1860,12 +1860,13 @@ describe('BrightScriptDebugSession', () => {
         });
     });
 
-    describe('prepareComponentLibraries / packageAndHostComponentLibraries', () => {
-        //runs the full complib flow in the same order launchRequest does: stage, then write+postfix,
-        //then the cross-project `Library` rewrite, then zip+install+host.
+    describe('prepareComponentLibraries / zipServeAndInstallComponentLibraries', () => {
+        //runs the full complib flow in the same order launchRequest does: stage, then write breakpoints,
+        //then postfix, then the cross-project `Library` rewrite, then zip+install+host.
         async function runPrepareAndHost(componentLibraries: any[], port: number) {
             await session['prepareComponentLibraries'](componentLibraries);
-            await session['writeAndPostfixComponentLibraries'](componentLibraries);
+            await session['writeBreakpoints']();
+            await session['postfixComponentLibraries'](componentLibraries);
             await session.projectManager.applyLibraryReferencePostfixes();
             await session['zipServeAndInstallComponentLibraries'](componentLibraries, port);
         }
@@ -3162,8 +3163,8 @@ describe('BrightScriptDebugSession', () => {
             sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({ developerEnabled: true } as any);
             sinon.stub(session, 'prepareMainProject').resolves();
             sinon.stub(session as any, 'prepareComponentLibraries').resolves();
-            sinon.stub(session as any, 'writeMainProjectBreakpoints').resolves();
-            sinon.stub(session as any, 'writeAndPostfixComponentLibraries').resolves();
+            sinon.stub(session as any, 'writeBreakpoints').resolves();
+            sinon.stub(session as any, 'postfixComponentLibraries').resolves();
             sinon.stub(session.projectManager, 'applyLibraryReferencePostfixes').resolves();
             sinon.stub(session as any, 'zipMainProject').resolves();
             sinon.stub(session as any, 'zipServeAndInstallComponentLibraries').resolves();
@@ -3300,10 +3301,10 @@ describe('BrightScriptDebugSession', () => {
 
         describe('library reference postfixing lifecycle', () => {
             /**
-             * Stub the postfixing and zipping phases so each records a marker when it runs, then run the launch
-             * flow (launchRequest stages; the package phase runs in configurationDoneRequest) and return the
-             * recorded order. The write/postfix phases resolve on a later tick so the test proves the `Library`
-             * rewrite truly waits for BOTH write/postfix branches to finish.
+             * Stub the breakpoint-write, postfixing, and zipping phases so each records a marker when it runs,
+             * then run the launch flow (launchRequest stages; the package phase runs in configurationDoneRequest)
+             * and return the recorded order. The write/postfix phases resolve on a later tick so the test proves
+             * each downstream phase truly waits for the previous one to finish.
              */
             async function recordPhaseOrder() {
                 const order: string[] = [];
@@ -3321,12 +3322,12 @@ describe('BrightScriptDebugSession', () => {
                 sinon.stub(session as any, 'prepareComponentLibraries').resolves();
                 rokuAdapter.connected = true;
 
-                //write+postfix phases: resolve on a later tick so a missing barrier would let the rewrite sneak in early
-                sinon.stub(session as any, 'writeMainProjectBreakpoints').callsFake(async () => {
+                //write+postfix phases: resolve on a later tick so a missing barrier would let the next phase sneak in early
+                sinon.stub(session as any, 'writeBreakpoints').callsFake(async () => {
                     await util.sleep(20);
-                    order.push('postfix:main');
+                    order.push('write');
                 });
-                sinon.stub(session as any, 'writeAndPostfixComponentLibraries').callsFake(async () => {
+                sinon.stub(session as any, 'postfixComponentLibraries').callsFake(async () => {
                     await util.sleep(10);
                     order.push('postfix:complibs');
                 });
@@ -3357,8 +3358,10 @@ describe('BrightScriptDebugSession', () => {
                 const order = await recordPhaseOrder();
 
                 const rewriteIndex = order.indexOf('rewrite');
-                //both write/postfix phases complete before the rewrite starts
-                expect(order.indexOf('postfix:main')).to.be.lessThan(rewriteIndex);
+                //breakpoints are written (telnet STOPs) before any complib file is renamed with its postfix
+                expect(order.indexOf('write')).to.be.lessThan(order.indexOf('postfix:complibs'));
+                //the write and postfix phases complete before the rewrite starts
+                expect(order.indexOf('write')).to.be.lessThan(rewriteIndex);
                 expect(order.indexOf('postfix:complibs')).to.be.lessThan(rewriteIndex);
                 //all zipping/uploading happens after the rewrite
                 expect(order.indexOf('zip:main')).to.be.greaterThan(rewriteIndex);

--- a/src/debugSession/BrightScriptDebugSession.ts
+++ b/src/debugSession/BrightScriptDebugSession.ts
@@ -857,12 +857,14 @@ export class BrightScriptDebugSession extends LoggingDebugSession {
             await this.tryProfilingConnectOnStart();
 
             //all setBreakpoints requests have arrived by this point (configurationDone is the DAP signal
-            //that the client has finished sending configuration). Inject the STOPs and postfix each project's
-            //own files now (still no zips. those are sealed after cross-project references are rewritten).
-            await Promise.all([
-                this.writeMainProjectBreakpoints(),
-                this.writeAndPostfixComponentLibraries(this.launchConfiguration.componentLibraries)
-            ]);
+            //that the client has finished sending configuration). Validate breakpoints across every project
+            //in one pass (and inject the STOPs for telnet) - validating per project would fail every other
+            //project's breakpoints. Must finish before postfixing renames the complib files.
+            await this.writeBreakpoints();
+
+            //postfix each complib's own files now (still no zips. those are sealed after cross-project
+            //references are rewritten).
+            await this.postfixComponentLibraries(this.launchConfiguration.componentLibraries);
 
             //now that EVERY project (main + all complibs) is postfixed, rewrite cross-project `Library`
             //references to point at the postfixed file names. Must run before any project zip is sealed.
@@ -1402,17 +1404,19 @@ export class BrightScriptDebugSession extends LoggingDebugSession {
     }
 
     /**
-     * Inject breakpoint STOP statements into the staged main project. Runs after the DAP `InitializedEvent`
-     * so client-side `setBreakpoints` requests have landed before any STOPs are written to the staged .brs
-     * files (telnet path). Kept separate from zipping so the cross-project `Library` reference rewrite can
-     * run in between (after every project is postfixed, before any zip is sealed).
+     * Validate every breakpoint against the staged projects and (telnet only) write STOP statements into the
+     * staged .brs files. Runs after the DAP `InitializedEvent` so client-side `setBreakpoints` requests have
+     * landed before any STOPs are written. Validates the main project and every component library in ONE pass:
+     * a breakpoint is only failed when it can't be placed in any project, so validating per project would fail
+     * every other project's breakpoints. Must complete before `postfixComponentLibraries` renames the complib
+     * files so telnet STOPs are written to the original file names.
      */
-    private async writeMainProjectBreakpoints() {
+    private async writeBreakpoints() {
         //add breakpoint lines to source files and then publish
         util.log('Adding stop statements for active breakpoints');
 
         //validate breakpoints for all debugger types (and write `stop` statements for telnet — decided internally)
-        await this.breakpointManager.validateAndWriteBreakpointsForProject(this.projectManager.mainProject);
+        await this.breakpointManager.validateAndWriteBreakpointsForProjects(this.projectManager.getAllProjects());
     }
 
     /**
@@ -1524,25 +1528,20 @@ export class BrightScriptDebugSession extends LoggingDebugSession {
     }
 
     /**
-     * Inject breakpoint STOPs into the staged complibs and postfix each library's own files. Runs in
-     * `configurationDoneRequest` (after `InitializedEvent`) so client-side `setBreakpoints` requests have
-     * landed before the staged .brs files are written. Kept separate from zipping so the cross-project
-     * `Library` reference rewrite can run after EVERY project is postfixed but before any zip is sealed.
+     * Postfix each staged complib's own files (rename its `.brs` files with the `__lib<index>` postfix and
+     * rewrite its `uri=` references). Runs in `configurationDoneRequest` AFTER `writeBreakpoints` so any
+     * telnet STOPs have already been written to the original file names. Kept separate from zipping so the
+     * cross-project `Library` reference rewrite can run after EVERY project is postfixed but before any zip
+     * is sealed.
      */
-    protected async writeAndPostfixComponentLibraries(componentLibraries: ComponentLibraryConfiguration[]) {
+    protected async postfixComponentLibraries(componentLibraries: ComponentLibraryConfiguration[]) {
         if (!componentLibraries || componentLibraries.length === 0) {
             return;
         }
 
-        // Add breakpoint lines to the staging files and before publishing
-        util.log('Adding stop statements for active breakpoints in Component Libraries');
-
-        //validate breakpoints (and write STOPs for telnet) and postfix each complib's own files in parallel
+        //postfix each complib's own files in parallel
         await Promise.all(
-            this.projectManager.componentLibraryProjects.map(async (compLibProject) => {
-                await this.breakpointManager.validateAndWriteBreakpointsForProject(compLibProject);
-                await compLibProject.postfixFiles();
-            })
+            this.projectManager.componentLibraryProjects.map(compLibProject => compLibProject.postfixFiles())
         );
     }
 

--- a/src/managers/BreakpointManager.spec.ts
+++ b/src/managers/BreakpointManager.spec.ts
@@ -34,7 +34,7 @@ describe('BreakpointManager', () => {
     let sourceMapManager: SourceMapManager;
     let projectManager: ProjectManager;
 
-    //There is now a single public entry point (validateAndWriteBreakpointsForProject) that decides
+    //There is now a single public entry point (validateAndWriteBreakpointsForProjects) that decides
     //whether to write STOPs from launchConfiguration.enableDebugProtocol. These helpers preserve the
     //intent of the old two-method API in the tests: "inject" = telnet (writes STOPs), "resolve" = DAP
     //(validate only). They set the flag and delegate to the unified method.
@@ -47,12 +47,12 @@ describe('BreakpointManager', () => {
     /** telnet path — validates AND writes STOP statements into the staged files */
     function injectBreakpointsForProject(project: Project) {
         setDebuggerType(false);
-        return bpManager.validateAndWriteBreakpointsForProject(project);
+        return bpManager.validateAndWriteBreakpointsForProjects([project]);
     }
     /** DebugProtocol path — validates only, never writes STOPs */
     function resolveBreakpointsForProject(project: Project) {
         setDebuggerType(true);
-        return bpManager.validateAndWriteBreakpointsForProject(project);
+        return bpManager.validateAndWriteBreakpointsForProjects([project]);
     }
 
     beforeEach(() => {
@@ -398,7 +398,104 @@ describe('BreakpointManager', () => {
         });
     });
 
-    describe('validateAndWriteBreakpointsForProject', () => {
+    describe('validateAndWriteBreakpointsForProjects with multiple projects', () => {
+        let tmpDir = s`${cwd}/.tmp`;
+        let mainRootDir = s`${tmpDir}/mainProject/rootDir`;
+        let mainStagingDir = s`${tmpDir}/mainProject/staging`;
+        let libRootDir = s`${tmpDir}/library/rootDir`;
+        let libStagingDir = s`${tmpDir}/library/staging`;
+        const mainSrcPath = s`${mainRootDir}/source/main.brs`;
+        const libSrcPath = s`${libRootDir}/components/Task.brs`;
+
+        let mainProject: Project;
+        let libProject: ComponentLibraryProject;
+
+        beforeEach(() => {
+            const code = `sub main()\n    print 1\n    print 2\nend sub`;
+            fsExtra.outputFileSync(mainSrcPath, code);
+            fsExtra.outputFileSync(libSrcPath, code);
+            //copy the files to staging (this is what the extension would normally do automatically)
+            fsExtra.outputFileSync(s`${mainStagingDir}/source/main.brs`, code);
+            fsExtra.outputFileSync(s`${libStagingDir}/components/Task.brs`, code);
+
+            mainProject = new Project(<any>{
+                rootDir: mainRootDir,
+                outDir: s`${tmpDir}/mainProject/out`,
+                stagingDir: mainStagingDir
+            });
+            libProject = new ComponentLibraryProject(<any>{
+                rootDir: libRootDir,
+                outDir: s`${tmpDir}/library/out`,
+                stagingDir: libStagingDir,
+                outFile: 'complib.zip',
+                libraryIndex: 0
+            });
+        });
+
+        afterEach(async () => {
+            await forceDeleteDir(tmpDir);
+        });
+
+        it('keeps a component library breakpoint placeable when validating all projects together', async () => {
+            setDebuggerType(true);
+            const [breakpoint] = bpManager.replaceBreakpoints(libSrcPath, [{ line: 2 }]);
+
+            await bpManager.validateAndWriteBreakpointsForProjects([mainProject, libProject]);
+
+            //the main project's pass must not fail the complib breakpoint
+            expect(breakpoint.reason).to.not.equal('failed');
+
+            //the breakpoint makes it into the diff (this is what gets sent to the device)
+            const diff = await bpManager.getDiff([mainProject, libProject]);
+            expect(
+                diff.added.map(x => ({ pkgPath: x.pkgPath, line: x.line }))
+            ).to.eql([{
+                pkgPath: 'pkg:/components/Task__lib0.brs',
+                line: 2
+            }]);
+        });
+
+        it('keeps a main project breakpoint placeable when a component library is present', async () => {
+            setDebuggerType(true);
+            const [breakpoint] = bpManager.replaceBreakpoints(mainSrcPath, [{ line: 2 }]);
+
+            await bpManager.validateAndWriteBreakpointsForProjects([mainProject, libProject]);
+
+            //the complib's pass must not fail the main project breakpoint
+            expect(breakpoint.reason).to.not.equal('failed');
+
+            const diff = await bpManager.getDiff([mainProject, libProject]);
+            expect(
+                diff.added.map(x => ({ pkgPath: x.pkgPath, line: x.line }))
+            ).to.eql([{
+                pkgPath: 'pkg:/source/main.brs',
+                line: 2
+            }]);
+        });
+
+        it('still fails breakpoints that have no staging location in any project', async () => {
+            setDebuggerType(true);
+            const [breakpoint] = bpManager.replaceBreakpoints(s`${tmpDir}/unrelated/orphan.brs`, [{ line: 2 }]);
+
+            await bpManager.validateAndWriteBreakpointsForProjects([mainProject, libProject]);
+
+            expect(breakpoint.reason).to.equal('failed');
+            expect(breakpoint.verified).to.be.false;
+        });
+
+        it('writes telnet STOP statements into every project in a single call', async () => {
+            setDebuggerType(false);
+            bpManager.replaceBreakpoints(mainSrcPath, [{ line: 2 }]);
+            bpManager.replaceBreakpoints(libSrcPath, [{ line: 2 }]);
+
+            await bpManager.validateAndWriteBreakpointsForProjects([mainProject, libProject]);
+
+            expect(fsExtra.readFileSync(`${mainStagingDir}/source/main.brs`).toString()).to.include('STOP');
+            expect(fsExtra.readFileSync(`${libStagingDir}/components/Task.brs`).toString()).to.include('STOP');
+        });
+    });
+
+    describe('validateAndWriteBreakpointsForProjects', () => {
         let tmpDir = s`${cwd}/.tmp`;
         let rootDir = s`${tmpDir}/rokuProject`;
         let outDir = s`${tmpDir}/out`;
@@ -810,7 +907,7 @@ describe('BreakpointManager', () => {
                 const project = setup();
                 bpManager.launchConfiguration = { enableDebugProtocol: false } as any;
 
-                await bpManager.validateAndWriteBreakpointsForProject(project);
+                await bpManager.validateAndWriteBreakpointsForProjects([project]);
 
                 expect(fsExtra.readFileSync(`${stagingDir}/source/main.brs`).toString())
                     .to.equal(`sub main()\n    print 1\nSTOP\n    print 2\nend sub`);
@@ -820,7 +917,7 @@ describe('BreakpointManager', () => {
                 const project = setup();
                 bpManager.launchConfiguration = { enableDebugProtocol: true } as any;
 
-                await bpManager.validateAndWriteBreakpointsForProject(project);
+                await bpManager.validateAndWriteBreakpointsForProjects([project]);
 
                 //file is untouched — the device sets breakpoints by line number
                 expect(fsExtra.readFileSync(`${stagingDir}/source/main.brs`).toString()).to.equal(code);
@@ -852,7 +949,7 @@ describe('BreakpointManager', () => {
                 fsExtra.outputFileSync(srcPath.replace(s`${rootDir}`, s`${stagingDir}`), code);
                 offManager.launchConfiguration = { enableDebugProtocol: true } as any;
                 const [bp] = offManager.replaceBreakpoints(srcPath, [{ line: line }]);
-                await offManager.validateAndWriteBreakpointsForProject(project());
+                await offManager.validateAndWriteBreakpointsForProjects([project()]);
                 return bp;
             }
 
@@ -913,7 +1010,7 @@ describe('BreakpointManager', () => {
 
                 offManager.launchConfiguration = { enableDebugProtocol: true } as any;
                 const [bp] = offManager.replaceBreakpoints(s`${rootDir}/source/helper.script`, [{ line: 2 }]);
-                await offManager.validateAndWriteBreakpointsForProject(proj);
+                await offManager.validateAndWriteBreakpointsForProjects([proj]);
 
                 expect(bp.reason, 'script-referenced non-.brs file breakpoint should be kept').to.not.equal('failed');
             });
@@ -925,7 +1022,7 @@ describe('BreakpointManager', () => {
 
                 offManager.launchConfiguration = { enableDebugProtocol: false } as any;
                 offManager.replaceBreakpoints(s`${rootDir}/source/main.brs`, [{ line: 3 }]);
-                await offManager.validateAndWriteBreakpointsForProject(project());
+                await offManager.validateAndWriteBreakpointsForProjects([project()]);
 
                 expect(fsExtra.readFileSync(`${stagingDir}/source/main.brs`).toString())
                     .to.equal(`sub main()\n    print 1\nSTOP\n    print 2\nend sub`);

--- a/src/managers/BreakpointManager.ts
+++ b/src/managers/BreakpointManager.ts
@@ -529,29 +529,42 @@ export class BreakpointManager {
     }
 
     /**
-     * Reconcile every breakpoint against the project's staged files, marking any that can't be placed
-     * (unsupported file type, or a file not in the project) as failed. Returns the placeable breakpoints
-     * keyed by staging file path.
+     * Reconcile every breakpoint against the staged files of the given projects, marking any that can't be
+     * placed (unsupported file type, or a file not in any project) as failed. Returns the placeable
+     * breakpoints keyed by staging file path.
+     *
+     * Always pass every project in the session (main project and all component libraries) together: a
+     * breakpoint is only failed when it has no staging location in ANY of the given projects, so validating
+     * one project at a time would incorrectly fail every other project's breakpoints.
      *
      * For telnet there is no on-device breakpoint API, so this also bakes a literal `STOP` into the staged
      * files for each breakpoint and registers them as permanent/verified. DebugProtocol writes nothing
      * (the device breaks by line number). The choice is made here from `launchConfiguration.enableDebugProtocol`.
      */
-    public async validateAndWriteBreakpointsForProject(project: Project) {
+    public async validateAndWriteBreakpointsForProjects(projects: Project[]) {
         //telnet bakes in a literal STOP per breakpoint; DebugProtocol breaks by line number and writes nothing
         const willInjectStop = !this.launchConfiguration?.enableDebugProtocol;
 
-        const breakpointsByStagingFilePath = await this.getBreakpointWork(project, willInjectStop);
+        //compute the breakpoint work for every project up front so the failure check below sees the whole session
+        const workForProjects = await Promise.all(
+            projects.map(project => this.getBreakpointWork(project, willInjectStop))
+        );
 
-        //track which breakpoints were successfully mapped to a staging location
+        //track which breakpoints were successfully mapped to a staging location in at least one project.
+        //staging file paths are unique per project (each project has its own staging dir), so the work
+        //records can be safely merged into one
         const stagedSrcHashes = new Set<string>();
-        for (const stagingFilePath in breakpointsByStagingFilePath) {
-            for (const breakpoint of breakpointsByStagingFilePath[stagingFilePath]) {
-                stagedSrcHashes.add(breakpoint.srcHash);
+        const breakpointsByStagingFilePath: Record<string, BreakpointWorkItem[]> = {};
+        for (const workForProject of workForProjects) {
+            for (const stagingFilePath in workForProject) {
+                for (const breakpoint of workForProject[stagingFilePath]) {
+                    stagedSrcHashes.add(breakpoint.srcHash);
+                }
+                breakpointsByStagingFilePath[stagingFilePath] = workForProject[stagingFilePath];
             }
         }
 
-        //fail any breakpoints that had no staging location
+        //fail any breakpoints that had no staging location in any project
         for (const [, breakpoints] of this.breakpointsByFilePath) {
             for (const bp of breakpoints) {
                 if (!stagedSrcHashes.has(bp.srcHash) && bp.reason !== 'failed') {
@@ -578,7 +591,7 @@ export class BreakpointManager {
     /**
      * Write STOP statements into the project's staging files for each breakpoint location and update the
      * sourcemaps to match. Marks the written breakpoints as verified and registers them as permanent.
-     * Telnet only — `validateAndWriteBreakpointsForProject` calls this when no on-device breakpoint API
+     * Telnet only — `validateAndWriteBreakpointsForProjects` calls this when no on-device breakpoint API
      * is available.
      */
     private async writeBreakpointsForProject(breakpointsByStagingFilePath: Record<string, BreakpointWorkItem[]>) {


### PR DESCRIPTION
Fixes breakpoints in component libraries never reaching the device over the debug protocol.

`validateAndWriteBreakpointsForProject` computed breakpoint work for a single project, then marked every breakpoint without a staging location in that project as failed. The session calls it once per project at `configurationDone`, so with component libraries configured, the main project's pass failed every complib breakpoint (and a complib's pass failed main-project breakpoints). Once failed, `getBreakpointWork` excludes the breakpoint from every future sync, so it was never sent to the device and showed "No executable code at this line" in the editor. Present since #317.

The method is now `validateAndWriteBreakpointsForProjects(projects)`: it computes the work for every project up front and only fails breakpoints that have no staging location in any project. In the session, the breakpoint write phase (`writeBreakpoints`) runs before complib postfixing so telnet STOPs are written to the original file names, and `writeAndPostfixComponentLibraries` shrank to `postfixComponentLibraries`.