### PR TITLE
Security enhancements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1433,9 +1433,9 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.42",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
-            "integrity": "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==",
+            "version": "2.11.20",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
+            "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -1665,9 +1665,9 @@
             "dev": true
         },
         "node_modules/browserslist": {
-            "version": "4.28.5",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.5.tgz",
-            "integrity": "sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==",
+            "version": "4.28.8",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+            "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
             "dev": true,
             "funding": [
                 {
@@ -1685,11 +1685,11 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "baseline-browser-mapping": "^2.10.42",
-                "caniuse-lite": "^1.0.30001800",
-                "electron-to-chromium": "^1.5.387",
-                "node-releases": "^2.0.50",
-                "update-browserslist-db": "^1.2.3"
+                "baseline-browser-mapping": "^2.11.12",
+                "caniuse-lite": "^1.0.30001809",
+                "electron-to-chromium": "^1.5.402",
+                "node-releases": "^2.0.53",
+                "update-browserslist-db": "^1.3.0"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -1790,9 +1790,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001803",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001803.tgz",
-            "integrity": "sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==",
+            "version": "1.0.30001810",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+            "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
             "dev": true,
             "funding": [
                 {
@@ -2146,9 +2146,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.388",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.388.tgz",
-            "integrity": "sha512-Pl/aJaqOOxYxda3vcx1IKSJimwYXHDkEnGn0F+kG2EE68dDtx2uCinaS+Vih8Z91B9t8CSAbiF/HKyWcnXjhzw==",
+            "version": "1.5.420",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.420.tgz",
+            "integrity": "sha512-2yD6XreGusOfNV+dUcvipJEXc3n/n7fgr7996aszTG+YY5E4mqM4tOq/3uhP129cazL9YHbVWSpc79ePotWtPA==",
             "dev": true,
             "license": "ISC"
         },
@@ -3940,9 +3940,9 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.50",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
-            "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+            "version": "2.0.54",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+            "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5658,9 +5658,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-            "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+            "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
             "dev": true,
             "funding": [
                 {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,8 @@
     "overrides": {
         "serialize-javascript": "^7.0.5",
         "qs": "^6.15.3",
-        "uuid": "^11.1.1"
+        "uuid": "^11.1.1",
+        "browserslist": "^4.28.8"
     },
     "dependencies": {
         "@rokucommunity/logger": "^0.4.1",


### PR DESCRIPTION
Clears the two high `browserslist` advisories (GHSA-c83g-rgw3-j3cx, GHSA-73wf-gq98-2v4g) failing the nightly security-audit gate.

`npm audit` is now **0 vulnerabilities**, prod included.

## Ships to consumers
Nothing — `browserslist` is dev-only via `nyc > istanbul-lib-instrument > @babel/core`, cleared with an `overrides` pin to `^4.28.8`.

## Notes for the reviewer
- Tests fail before and after this change on Node 22 (angle-bracket type assertions in `TelnetAdapter.spec.ts` hit type-strip mode) — pre-existing, unrelated; lockfile diff touches only browserslist and its data deps.

## Verification
`npm run build` and `npm run lint` pass; `npm run audit` exits clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)