### PR TITLE
Update roku-deploy to 4.0.0-alpha.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
                 "portfinder": "^1.0.32",
                 "replace-in-file": "^6.3.2",
                 "replace-last": "^1.2.6",
-                "roku-deploy": "^4.0.0-alpha.5",
+                "roku-deploy": "^4.0.0-alpha.6",
                 "semver": "^7.5.4",
                 "serialize-error": "^8.1.0",
                 "smart-buffer": "^4.2.0",
@@ -4174,11 +4174,12 @@
             }
         },
         "node_modules/roku-deploy": {
-            "version": "4.0.0-alpha.5",
-            "resolved": "https://registry.npmjs.org/roku-deploy/-/roku-deploy-4.0.0-alpha.5.tgz",
-            "integrity": "sha512-JKyNGpGJbLGkbXmIDUotTuLJGXRhiWMEg/ZB9CDDsSlBSUSw8Kt9Y6F3wL+TxxromNF+A4scTV3UbiIOJfru6w==",
+            "version": "4.0.0-alpha.6",
+            "resolved": "https://registry.npmjs.org/roku-deploy/-/roku-deploy-4.0.0-alpha.6.tgz",
+            "integrity": "sha512-BAZpI/X5HBJuTsyshC2bNnqORLXzFe7NVcXpdcmw7NABzfv3wU+8Ozc18KGsmopjwJphuWXs0P00r9bWgOew+Q==",
+            "license": "MIT",
             "dependencies": {
-                "@rokucommunity/logger": "^0.4.1",
+                "@rokucommunity/logger": "^0.4.2",
                 "chalk": "^2.4.2",
                 "fast-glob": "^3.2.12",
                 "fs-extra": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
         "portfinder": "^1.0.32",
         "replace-in-file": "^6.3.2",
         "replace-last": "^1.2.6",
-        "roku-deploy": "^4.0.0-alpha.5",
+        "roku-deploy": "^4.0.0-alpha.6",
         "semver": "^7.5.4",
         "serialize-error": "^8.1.0",
         "smart-buffer": "^4.2.0",

--- a/src/RendezvousTracker.spec.ts
+++ b/src/RendezvousTracker.spec.ts
@@ -403,11 +403,11 @@ describe('BrightScriptFileUtils ', () => {
         };
 
         it('queries roku-deploy with the bare host when device is not set', async () => {
-            const queryRendezvousStub = sinon.stub(rokuDeploy, 'queryRendezvous').resolves(rendezvousResult);
+            const getRendezvousTrackingStub = sinon.stub(rokuDeploy, 'getRendezvousTracking').resolves(rendezvousResult);
 
             const result = await rendezvousTracker.getEcpRendezvous();
 
-            expect(queryRendezvousStub.getCall(0).args).to.eql([{
+            expect(getRendezvousTrackingStub.getCall(0).args).to.eql([{
                 device: { host: '192.168.1.5' },
                 ecpPort: 8060
             }]);
@@ -417,11 +417,11 @@ describe('BrightScriptFileUtils ', () => {
         it('passes an RCE device config through to roku-deploy', async () => {
             const rceDeviceConfig = { instanceUrl: 'https://device.rce.roku.com/instance/my-instance', rceToken: 'my-rce-token' };
             rendezvousTracker['launchConfiguration'].device = rceDeviceConfig;
-            const queryRendezvousStub = sinon.stub(rokuDeploy, 'queryRendezvous').resolves(rendezvousResult);
+            const getRendezvousTrackingStub = sinon.stub(rokuDeploy, 'getRendezvousTracking').resolves(rendezvousResult);
 
             const result = await rendezvousTracker.getEcpRendezvous();
 
-            expect(queryRendezvousStub.getCall(0).args[0].device).to.equal(rceDeviceConfig);
+            expect(getRendezvousTrackingStub.getCall(0).args[0].device).to.equal(rceDeviceConfig);
             expect(result).to.eql(rendezvousResult);
         });
     });

--- a/src/RendezvousTracker.ts
+++ b/src/RendezvousTracker.ts
@@ -202,7 +202,7 @@ export class RendezvousTracker {
      */
     public async getEcpRendezvous(): Promise<EcpRendezvousData> {
         this.logger.trace('Sending ECP rendezvous request');
-        const rendezvous = await rokuDeploy.queryRendezvous({
+        const rendezvous = await rokuDeploy.getRendezvousTracking({
             device: this.launchConfiguration.device,
             ecpPort: this.launchConfiguration.remotePort
         });

--- a/src/RokuECP.spec.ts
+++ b/src/RokuECP.spec.ts
@@ -70,14 +70,14 @@ describe('RokuECP', () => {
             sections: {}
         };
 
-        it('calls rokuDeploy.queryRegistry with the device option', async () => {
+        it('calls rokuDeploy.getRegistry with the device option', async () => {
             let options = {
                 device: { host: '1.1.1.1' },
                 remotePort: 8080,
                 appId: 'dev'
             };
 
-            let stub = sinon.stub(rokuDeploy, 'queryRegistry').resolves(registryResult);
+            let stub = sinon.stub(rokuDeploy, 'getRegistry').resolves(registryResult);
 
             let result = await rokuECP.getRegistry(options);
             expect(stub.getCall(0).args).to.eql([{
@@ -101,7 +101,7 @@ describe('RokuECP', () => {
                 appId: 'dev'
             };
 
-            let stub = sinon.stub(rokuDeploy, 'queryRegistry').resolves(registryResult);
+            let stub = sinon.stub(rokuDeploy, 'getRegistry').resolves(registryResult);
 
             await rokuECP.getRegistry(options);
             expect(stub.getCall(0).args).to.eql([{
@@ -118,7 +118,7 @@ describe('RokuECP', () => {
                 appId: 'dev'
             };
 
-            let stub = sinon.stub(rokuDeploy, 'queryRegistry').resolves(registryResult);
+            let stub = sinon.stub(rokuDeploy, 'getRegistry').resolves(registryResult);
 
             await rokuECP.getRegistry(options);
             expect(stub.getCall(0).args).to.eql([{
@@ -130,7 +130,7 @@ describe('RokuECP', () => {
         });
 
         it('maps a populated roku-deploy result onto EcpRegistryData', async () => {
-            sinon.stub(rokuDeploy, 'queryRegistry').resolves({
+            sinon.stub(rokuDeploy, 'getRegistry').resolves({
                 devId: '12345',
                 plugins: ['12', '34', 'dev'],
                 spaceAvailable: '28075',
@@ -164,7 +164,7 @@ describe('RokuECP', () => {
         });
 
         it('maps a minimal roku-deploy result onto EcpRegistryData', async () => {
-            sinon.stub(rokuDeploy, 'queryRegistry').resolves({
+            sinon.stub(rokuDeploy, 'getRegistry').resolves({
                 sections: {}
             });
 
@@ -179,7 +179,7 @@ describe('RokuECP', () => {
         });
 
         it('propagates errors from roku-deploy', async () => {
-            sinon.stub(rokuDeploy, 'queryRegistry').rejects(new Error('Could not retrieve registry: Device not keyed'));
+            sinon.stub(rokuDeploy, 'getRegistry').rejects(new Error('Could not retrieve registry: Device not keyed'));
 
             await expectThrowsAsync(() => rokuECP.getRegistry({ device: { host: '1.1.1.1' }, appId: 'dev' }), 'Could not retrieve registry: Device not keyed');
         });
@@ -194,14 +194,14 @@ describe('RokuECP', () => {
             state: 'active'
         };
 
-        it('calls rokuDeploy.queryAppState with the device option', async () => {
+        it('calls rokuDeploy.getAppState with the device option', async () => {
             let options = {
                 device: { host: '1.1.1.1' },
                 remotePort: 8080,
                 appId: 'dev'
             };
 
-            let stub = sinon.stub(rokuDeploy, 'queryAppState').resolves(appStateResult);
+            let stub = sinon.stub(rokuDeploy, 'getAppState').resolves(appStateResult);
 
             let result = await rokuECP.getAppState(options);
             expect(stub.getCall(0).args).to.eql([{
@@ -225,7 +225,7 @@ describe('RokuECP', () => {
                 appId: 'dev'
             };
 
-            let stub = sinon.stub(rokuDeploy, 'queryAppState').resolves(appStateResult);
+            let stub = sinon.stub(rokuDeploy, 'getAppState').resolves(appStateResult);
 
             await rokuECP.getAppState(options);
             expect(stub.getCall(0).args).to.eql([{
@@ -237,7 +237,7 @@ describe('RokuECP', () => {
         });
 
         it('maps an unknown state onto AppState.unknown', async () => {
-            sinon.stub(rokuDeploy, 'queryAppState').resolves({
+            sinon.stub(rokuDeploy, 'getAppState').resolves({
                 ...appStateResult,
                 state: 'unknown'
             });
@@ -254,7 +254,7 @@ describe('RokuECP', () => {
         });
 
         it('propagates errors from roku-deploy', async () => {
-            sinon.stub(rokuDeploy, 'queryAppState').rejects(new Error('Could not retrieve app state: App not found'));
+            sinon.stub(rokuDeploy, 'getAppState').rejects(new Error('Could not retrieve app state: App not found'));
 
             await expectThrowsAsync(() => rokuECP.getAppState({ device: { host: '1.1.1.1' }, appId: 'dev' }), 'Could not retrieve app state: App not found');
         });

--- a/src/RokuECP.ts
+++ b/src/RokuECP.ts
@@ -74,7 +74,7 @@ export class RokuECP {
     }
 
     public async getRegistry(options: BaseOptions & { appId: string }): Promise<EcpRegistryData> {
-        const registry = await rokuDeploy.queryRegistry({
+        const registry = await rokuDeploy.getRegistry({
             device: options.device,
             appId: options.appId,
             ecpPort: options.remotePort
@@ -89,7 +89,7 @@ export class RokuECP {
     }
 
     public async getAppState(options: BaseOptions & { appId: string }): Promise<EcpAppStateData> {
-        const appState = await rokuDeploy.queryAppState({
+        const appState = await rokuDeploy.getAppState({
             device: options.device,
             appId: options.appId,
             ecpPort: options.remotePort

--- a/src/debugSession/BrightScriptDebugSession.spec.ts
+++ b/src/debugSession/BrightScriptDebugSession.spec.ts
@@ -111,7 +111,7 @@ describe('BrightScriptDebugSession', () => {
             createSignedPackage: () => {
                 return Promise.resolve();
             },
-            getFilePaths: () => {
+            resolveFilesArray: () => {
             }
         };
         rokuAdapter = {
@@ -1018,7 +1018,7 @@ describe('BrightScriptDebugSession', () => {
             let filePath = path.resolve(`${folder}/main.brs`);
 
             //prevent actually talking to the file system...just hardcode the list to exactly our main file
-            (session.rokuDeploy as any).getFilePaths = () => {
+            (session.rokuDeploy as any).resolveFilesArray = () => {
                 return [{
                     src: filePath,
                     dest: filePath

--- a/src/debugSession/ecpRegistryUtils.spec.ts
+++ b/src/debugSession/ecpRegistryUtils.spec.ts
@@ -43,7 +43,7 @@ describe('ecpRegistryUtils', () => {
                     childVariables: []
                 };
 
-                sinon.stub(rokuDeploy, 'queryRegistry').resolves({
+                sinon.stub(rokuDeploy, 'getRegistry').resolves({
                     sections: {}
                 });
 
@@ -92,7 +92,7 @@ describe('ecpRegistryUtils', () => {
                     childVariables: []
                 };
 
-                sinon.stub(rokuDeploy, 'queryRegistry').resolves({
+                sinon.stub(rokuDeploy, 'getRegistry').resolves({
                     devId: '12345',
                     plugins: ['12', '34', 'dev'],
                     spaceAvailable: '28075',
@@ -175,7 +175,7 @@ describe('ecpRegistryUtils', () => {
                     childVariables: []
                 };
 
-                sinon.stub(rokuDeploy, 'queryRegistry').resolves({
+                sinon.stub(rokuDeploy, 'getRegistry').resolves({
                     devId: '12345',
                     plugins: ['dev'],
                     spaceAvailable: '32590',
@@ -315,7 +315,7 @@ describe('ecpRegistryUtils', () => {
                     childVariables: []
                 };
 
-                sinon.stub(rokuDeploy, 'queryRegistry').rejects(new Error('Could not retrieve registry: Plugin dev not found'));
+                sinon.stub(rokuDeploy, 'getRegistry').rejects(new Error('Could not retrieve registry: Plugin dev not found'));
 
                 await populateVariableFromRegistryEcp({ device: { host: '' }, appId: '' }, v, session['variables'], refFactory);
                 expect(v.childVariables.length).to.eql(1);
@@ -337,7 +337,7 @@ describe('ecpRegistryUtils', () => {
                     childVariables: []
                 };
 
-                sinon.stub(rokuDeploy, 'queryRegistry').rejects(new Error('Could not retrieve registry: Device not keyed'));
+                sinon.stub(rokuDeploy, 'getRegistry').rejects(new Error('Could not retrieve registry: Device not keyed'));
 
                 await populateVariableFromRegistryEcp({ device: { host: '' }, appId: '' }, v, session['variables'], refFactory);
                 expect(v.childVariables.length).to.eql(1);
@@ -359,7 +359,7 @@ describe('ecpRegistryUtils', () => {
                     childVariables: []
                 };
 
-                sinon.stub(rokuDeploy, 'queryRegistry').rejects(new Error('Could not retrieve registry: Unknown error'));
+                sinon.stub(rokuDeploy, 'getRegistry').rejects(new Error('Could not retrieve registry: Unknown error'));
 
                 await populateVariableFromRegistryEcp({ device: { host: '' }, appId: '' }, v, session['variables'], refFactory);
                 expect(v.childVariables.length).to.eql(1);
@@ -384,7 +384,7 @@ describe('ecpRegistryUtils', () => {
                 //roku-deploy throws an UnparsableDeviceResponseError carrying the device's
                 //plain-text explanation when the response body is not xml (a limited-mode refusal,
                 //for example), so that text still reaches the variables pane
-                sinon.stub(rokuDeploy, 'queryRegistry').rejects(new Error('Could not retrieve registry: ECP command not allowed in Limited mode.'));
+                sinon.stub(rokuDeploy, 'getRegistry').rejects(new Error('Could not retrieve registry: ECP command not allowed in Limited mode.'));
 
                 await populateVariableFromRegistryEcp({ device: { host: '' }, appId: '' }, v, session['variables'], refFactory);
                 expect(v.childVariables.length).to.eql(1);

--- a/src/managers/LocationManager.ts
+++ b/src/managers/LocationManager.ts
@@ -196,7 +196,7 @@ export interface GetSourceLocationOptions {
      */
     sourceDirs?: string[];
     /**
-     * The result of rokuDeploy.getFilePaths(). This is passed in so it can be cached on the outside in order to improve performance
+     * The result of rokuDeploy.resolveFilesArray(). This is passed in so it can be cached on the outside in order to improve performance
      */
     fileMappings: { src: string; dest: string }[];
     /**

--- a/src/managers/ProjectManager.spec.ts
+++ b/src/managers/ProjectManager.spec.ts
@@ -2200,7 +2200,7 @@ describe('ComponentLibraryProject', () => {
             let project = new ComponentLibraryProject(params);
 
             //roku-deploy returns staging-relative dest paths; getFileMappings makes them absolute
-            sinon.stub(rokuDeploy, 'getFilePaths').returns(Promise.resolve([
+            sinon.stub(rokuDeploy, 'resolveFilesArray').returns(Promise.resolve([
                 { src: s`${rootDir}/manifest`, dest: 'manifest' },
                 { src: s`${rootDir}/source/main.brs`, dest: s`source/main.brs` }
             ]));

--- a/src/managers/ProjectManager.ts
+++ b/src/managers/ProjectManager.ts
@@ -1076,7 +1076,7 @@ export class Project {
      * (`dest` paths are relative in later versions of roku-deploy)
      */
     protected async getFileMappings() {
-        let fileMappings = await rokuDeploy.getFilePaths({ files: this.files, rootDir: this.rootDir });
+        let fileMappings = await rokuDeploy.resolveFilesArray({ files: this.files, rootDir: this.rootDir });
         for (let fileMapping of fileMappings) {
             fileMapping.dest = s`${this.stagingDir}/${fileMapping.dest}`;
         }


### PR DESCRIPTION
Updates roku-deploy to `4.0.0-alpha.6` and adopts its renamed methods (pure identifier swaps, options and return shapes unchanged):

- `queryRegistry` -> `getRegistry` and `queryAppState` -> `getAppState` in RokuECP
- `queryRendezvous` -> `getRendezvousTracking` in RendezvousTracker
- `getFilePaths` -> `resolveFilesArray` in ProjectManager
- Spec stubs and a LocationManager doc comment updated to match

alpha.6 also carries the renamed Roku Cloud Emulator instance routes (`/api/v0/input` key input and the `/api/v0/ports/8060/http` ECP proxy), which RCE devices need now that Roku is removing the old `/ecp1` paths.