### PR TITLE
chore: Security enhancements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -540,9 +540,9 @@
             }
         },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-            "version": "3.15.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
-            "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+            "version": "3.15.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+            "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3000,9 +3000,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+            "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
             "dev": true,
             "funding": [
                 {

--- a/package.json
+++ b/package.json
@@ -98,6 +98,8 @@
     },
     "overrides": {
         "serialize-javascript": "^7.0.5",
+        "js-yaml@^3": "^3.15.2",
+        "js-yaml@^4": "^4.3.2",
         "qs": "^6.16.0",
         "uuid": "^11.1.1",
         "browserslist": "^4.28.8"


### PR DESCRIPTION
Clears GHSA-2883-xcg3-v3hh (js-yaml, high), the only advisory failing the audit gate.

`npm audit --omit=dev`: **0 vulnerabilities**. Full `npm audit` is also at 0 after this change.

## Ships to consumers
Nothing. Both overrides are dev-scoped.

## Lockfile only (dev deps)
| Override | Version | Reached via |
|---|---|---|
| `js-yaml@^3` | `^3.15.2` (new) | `nyc > @istanbuljs/load-nyc-config` |
| `js-yaml@^4` | `^4.3.2` (new) | `eslint`, `mocha` |

## Notes for the reviewer
- This repo had no js-yaml override yet, and both major lines resolved into the advisory range (`3.0.0 - 3.15.1 || 4.0.0 - 4.3.1`), so each gets a version-scoped pin at the first patched release rather than one blanket override.

## Verification
`npm run preversion` (build + lint + test) passes, and `npm run audit` reports 0 vulnerabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)