### PR TITLE
chore: Remove unused eol dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
                 "brighterscript": "^0.73.3",
                 "dateformat": "^4.6.3",
                 "debounce": "^1.2.1",
-                "eol": "^0.9.1",
                 "eventemitter3": "^4.0.7",
                 "fast-glob": "^3.2.11",
                 "find-in-files": "^0.5.0",
@@ -1951,11 +1950,6 @@
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-        },
-        "node_modules/eol": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/eol/-/eol-0.9.1.tgz",
-            "integrity": "sha512-Ds/TEoZjwggRoz/Q2O7SE3i4Jm66mqTDfmdHdq/7DKVk3bro9Q8h6WdXKdPqFLMoqxrDK5SVRzHVPOS6uuGtrg=="
         },
         "node_modules/es6-error": {
             "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,6 @@
         "brighterscript": "^0.73.3",
         "dateformat": "^4.6.3",
         "debounce": "^1.2.1",
-        "eol": "^0.9.1",
         "eventemitter3": "^4.0.7",
         "fast-glob": "^3.2.11",
         "find-in-files": "^0.5.0",


### PR DESCRIPTION
`eol` is declared as a production dependency but has zero imports anywhere in this repo.

### Dependency impact

| Metric | Baseline | This PR |
|---|---|---|
| Direct prod deps | 25 | **24** |
| Total prod modules | 124 | **123** |

`eol` is a zero-dependency leaf package, so it leaves the tree cleanly — the direct and installed counts both drop by exactly 1.

### Notes for the reviewer

- Verified repo-wide, not just `src/` — no `import`/`require` of `eol` in source, scripts, or tests.

### Verification

`npm run preversion` passed: build, lint, 1197 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)